### PR TITLE
Disable workflow for draft PRS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build:
+    if: ! github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
If we decide to turn off github workflows for draft PRs, this should do the trick.