### PR TITLE
Improvements for padding in KOS15

### DIFF
--- a/mpc-core/src/ot/extension/kos15/sender.rs
+++ b/mpc-core/src/ot/extension/kos15/sender.rs
@@ -306,7 +306,7 @@ where
             return Err(ExtSenderCoreError::ConsistencyCheckFailed);
         }
 
-        // Remove the last 256 rows which were sacrificed due to the KOS check
+        // Remove additional rows introduced by padding
         qs.drain(qs.len() - expected_padding * BASE_COUNT / 8..);
         self.table = Some(qs);
         self.state = State::Setup;

--- a/mpc-core/src/ot/extension/kos15/sender.rs
+++ b/mpc-core/src/ot/extension/kos15/sender.rs
@@ -224,7 +224,7 @@ where
         //   setup
         let rem = ncols_unpadded % 256;
         let pad1 = if rem == 0 { 0 } else { 256 - rem };
-        let expected_padding = if pad1 == 0 { 256 + 0 } else { 256 + pad1 };
+        let expected_padding = 256 + pad1;
         let ncols = receiver_setup.table.len() / BASE_COUNT * 8;
 
         if ncols != ncols_unpadded + expected_padding {
@@ -307,7 +307,7 @@ where
         }
 
         // Remove the last 256 rows which were sacrificed due to the KOS check
-        qs.drain(qs.len() - 256 * BASE_COUNT / 8..);
+        qs.drain(qs.len() - expected_padding * BASE_COUNT / 8..);
         self.table = Some(qs);
         self.state = State::Setup;
         Ok(())


### PR DESCRIPTION
- Remove `self.padding` of KOS15Receiver
- Remove the entire padding after transposition for both sender and
  receiver