### PR TITLE
Return error for missing circuit io

### DIFF
--- a/mpc-circuits/src/circuit.rs
+++ b/mpc-circuits/src/circuit.rs
@@ -811,8 +811,11 @@ impl Circuit {
     }
 
     /// Returns group corresponding to input id
-    pub fn input(&self, id: usize) -> Option<Input> {
-        self.inputs.get(id).cloned()
+    pub fn input(&self, id: usize) -> Result<Input, CircuitError> {
+        self.inputs
+            .get(id)
+            .cloned()
+            .ok_or(CircuitError::InputError(id, self.name.clone()))
     }
 
     /// Returns reference to all circuit inputs
@@ -831,8 +834,11 @@ impl Circuit {
     }
 
     /// Returns group corresponding to output id
-    pub fn output(&self, id: usize) -> Option<Output> {
-        self.outputs.get(id).cloned()
+    pub fn output(&self, id: usize) -> Result<Output, CircuitError> {
+        self.outputs
+            .get(id)
+            .cloned()
+            .ok_or(CircuitError::OutputError(id, self.name.clone()))
     }
 
     /// Returns reference to all circuit outputs

--- a/mpc-circuits/src/error.rs
+++ b/mpc-circuits/src/error.rs
@@ -14,6 +14,10 @@ pub enum CircuitError {
     ValueError(#[from] ValueError),
     #[error("encountered error while constructing a circuit: {0}")]
     InvalidCircuit(String),
+    #[error("Input {0} does not exist in {1:?} circuit")]
+    InputError(usize, String),
+    #[error("Output {0} does not exist in {1:?} circuit")]
+    OutputError(usize, String),
     #[error("encountered io error while loading circuit")]
     IoError(#[from] std::io::Error),
     #[error("encountered prost DecodeError while loading circuit")]

--- a/mpc-core/src/garble/label.rs
+++ b/mpc-core/src/garble/label.rs
@@ -228,10 +228,10 @@ impl InputLabels<WireLabelPair> {
         let mut input_ids = input_ids.to_vec();
         input_ids.sort();
         input_ids.dedup();
+
+        // Check input ids are valid
         for id in input_ids.iter() {
-            if circ.input(*id).is_none() {
-                return Err(Error::InvalidInput(InputError::InvalidId(*id)));
-            }
+            _ = circ.input(*id)?
         }
 
         let (labels, delta) = Self::generate(rng, circ, delta);

--- a/mpc-core/src/msgs/garble.rs
+++ b/mpc-core/src/msgs/garble.rs
@@ -70,9 +70,7 @@ impl garble::InputLabels<garble::WireLabel> {
         circ: &Circuit,
         input_labels: InputLabels,
     ) -> Result<Self, crate::garble::Error> {
-        let input = circ
-            .input(input_labels.id)
-            .ok_or(crate::garble::Error::InvalidInputLabels)?;
+        let input = circ.input(input_labels.id)?;
         if input.as_ref().len() != input_labels.labels.len() {
             return Err(crate::garble::Error::InvalidInputLabels);
         }
@@ -114,9 +112,7 @@ impl garble::label::OutputLabelsEncoding {
         circ: &Circuit,
         encoding: OutputEncoding,
     ) -> Result<Self, crate::garble::Error> {
-        let output = circ
-            .output(encoding.id)
-            .ok_or(crate::garble::Error::InvalidLabelEncoding)?;
+        let output = circ.output(encoding.id)?;
 
         Self::new(output, encoding.encoding)
     }


### PR DESCRIPTION
This PR modifies the circuit model slightly to return an error when getting an input or output which doesn't exist. This will make error handling more ergonomic.