### PR TITLE
Convenience function for circuit input values

### DIFF
--- a/mpc-circuits/src/circuit.rs
+++ b/mpc-circuits/src/circuit.rs
@@ -818,6 +818,15 @@ impl Circuit {
             .ok_or(CircuitError::InputError(id, self.name.clone()))
     }
 
+    /// Returns input value from id and value
+    pub fn input_value(
+        &self,
+        id: usize,
+        value: impl Into<Value>,
+    ) -> Result<InputValue, CircuitError> {
+        self.input(id)?.to_value(value)
+    }
+
     /// Returns reference to all circuit inputs
     pub fn inputs(&self) -> &[Input] {
         &self.inputs


### PR DESCRIPTION
This PR adds a convenience function for constructing `InputValue` from an input id and value