### PR TITLE
Ci/cache build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,4 +30,4 @@ jobs:
         run: cargo build --verbose
 
       - name: Run tests
-        run: cargo test --all-targets --workspace --exclude tlsn-tls-circuits
+        run: cargo test --lib --bins --tests --examples --workspace --exclude tlsn-tls-circuits


### PR DESCRIPTION
This PR updates our CI workflow.

1. Adds actions-rs toolchain for installing the toolchain
2. Adds Swatinem rust-cache to cache build dependencies which should speed up CI quite a bit
3. Removes bench tests from CI, they're too heavy.