### PR TITLE
Fix clippy lints for tls-2pc-core

### DIFF
--- a/tls-2pc-core/build.rs
+++ b/tls-2pc-core/build.rs
@@ -4,7 +4,9 @@ use rayon::prelude::*;
 use std::{env, fs, io, path::Path};
 use tls_circuits::{c1, c2, c3, c4, c5, c6, c7};
 
-static CIRCUITS: &[(&str, fn() -> Circuit)] = &[
+type CircuitBuilderMap = [(&'static str, fn() -> Circuit)];
+
+static CIRCUITS: &CircuitBuilderMap = &[
     ("c1", c1),
     ("c2", c2),
     ("c3", c3),

--- a/tls-2pc-core/src/lib.rs
+++ b/tls-2pc-core/src/lib.rs
@@ -10,19 +10,19 @@ use once_cell::sync::Lazy;
 use std::sync::Arc;
 
 #[cfg(feature = "c1")]
-pub static CIRCUIT_1_BYTES: &'static [u8] = std::include_bytes!("../circuits/bin/c1.bin");
+pub static CIRCUIT_1_BYTES: &[u8] = std::include_bytes!("../circuits/bin/c1.bin");
 #[cfg(feature = "c2")]
-pub static CIRCUIT_2_BYTES: &'static [u8] = std::include_bytes!("../circuits/bin/c2.bin");
+pub static CIRCUIT_2_BYTES: &[u8] = std::include_bytes!("../circuits/bin/c2.bin");
 #[cfg(feature = "c3")]
-pub static CIRCUIT_3_BYTES: &'static [u8] = std::include_bytes!("../circuits/bin/c3.bin");
+pub static CIRCUIT_3_BYTES: &[u8] = std::include_bytes!("../circuits/bin/c3.bin");
 #[cfg(feature = "c4")]
-pub static CIRCUIT_4_BYTES: &'static [u8] = std::include_bytes!("../circuits/bin/c4.bin");
+pub static CIRCUIT_4_BYTES: &[u8] = std::include_bytes!("../circuits/bin/c4.bin");
 #[cfg(feature = "c5")]
-pub static CIRCUIT_5_BYTES: &'static [u8] = std::include_bytes!("../circuits/bin/c5.bin");
+pub static CIRCUIT_5_BYTES: &[u8] = std::include_bytes!("../circuits/bin/c5.bin");
 #[cfg(feature = "c6")]
-pub static CIRCUIT_6_BYTES: &'static [u8] = std::include_bytes!("../circuits/bin/c6.bin");
+pub static CIRCUIT_6_BYTES: &[u8] = std::include_bytes!("../circuits/bin/c6.bin");
 #[cfg(feature = "c7")]
-pub static CIRCUIT_7_BYTES: &'static [u8] = std::include_bytes!("../circuits/bin/c7.bin");
+pub static CIRCUIT_7_BYTES: &[u8] = std::include_bytes!("../circuits/bin/c7.bin");
 
 #[cfg(feature = "c1")]
 pub static CIRCUIT_1: Lazy<Arc<Circuit>> =

--- a/tls-2pc-core/src/prf/follower.rs
+++ b/tls-2pc-core/src/prf/follower.rs
@@ -95,6 +95,12 @@ impl PRFFollower<Ms1> {
     }
 }
 
+impl Default for PRFFollower<Ms1> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PRFFollower<Ms2> {
     /// Computes a2
     /// ```text

--- a/tls-2pc-core/src/prf/leader.rs
+++ b/tls-2pc-core/src/prf/leader.rs
@@ -136,6 +136,12 @@ impl PRFLeader<Ms1> {
     }
 }
 
+impl Default for PRFLeader<Ms1> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PRFLeader<Ms2> {
     /// Computes p1 and a2 inner hashes
     /// ```text

--- a/tls-2pc-core/src/prf/mod.rs
+++ b/tls-2pc-core/src/prf/mod.rs
@@ -107,7 +107,7 @@ mod tests {
         let (follower_msg, follower) = follower.next(outer_hash_state, leader_msg);
 
         // H((pms xor opad) || H((pms xor ipad) || seed))
-        let a1 = follower_msg.a1.clone();
+        let a1 = follower_msg.a1;
         assert_eq!(
             &a1,
             &hmac_sha256(&pms, &seed_ms(&client_random, &server_random))
@@ -117,7 +117,7 @@ mod tests {
         let (follower_msg, follower) = follower.next(leader_msg);
 
         // H((pms xor opad) || H((pms xor ipad) || a1))
-        let a2 = follower_msg.a2.clone();
+        let a2 = follower_msg.a2;
         assert_eq!(&a2, &hmac_sha256(&pms, &a1));
 
         let (leader_msg, leader) = leader.next(follower_msg);
@@ -160,7 +160,7 @@ mod tests {
         let (follower_msg, follower) = follower.next(outer_hash_state).next(leader_msg);
 
         // H((ms xor opad) || H((ms xor ipad) || seed))
-        let a1 = follower_msg.a1.clone();
+        let a1 = follower_msg.a1;
         assert_eq!(
             &a1,
             &hmac_sha256(&ms, &seed_ke(&client_random, &server_random))
@@ -170,7 +170,7 @@ mod tests {
         let (follower_msg, follower) = follower.next(leader_msg);
 
         // H((ms xor opad) || H((ms xor ipad) || a1))
-        let a2 = follower_msg.a2.clone();
+        let a2 = follower_msg.a2;
         assert_eq!(&a2, &hmac_sha256(&ms, &a1));
 
         let leader = leader.next(follower_msg);
@@ -189,14 +189,14 @@ mod tests {
         let (follower_msg, follower) = follower.next(leader_msg);
 
         // H((ms xor opad) || H((ms xor ipad) || seed))
-        let a1 = follower_msg.a1.clone();
+        let a1 = follower_msg.a1;
         assert_eq!(&a1, &hmac_sha256(&ms, &seed_cf(&handshake_blob)));
 
         let (leader_msg, leader) = leader.next(follower_msg);
         let (follower_msg, follower) = follower.next(leader_msg);
 
         // H((ms xor opad) || H((ms xor ipad) || a1 || seed))
-        let vd = follower_msg.verify_data.clone();
+        let vd = follower_msg.verify_data;
         // a1 || seed
         let mut a1_seed = [0u8; 79];
         a1_seed[..32].copy_from_slice(&a1);
@@ -209,7 +209,7 @@ mod tests {
         let (follower_msg, follower) = follower.next(leader_msg);
 
         // H((ms xor opad) || H((ms xor ipad) || seed))
-        let a1 = follower_msg.a1.clone();
+        let a1 = follower_msg.a1;
         assert_eq!(&a1, &hmac_sha256(&ms, &seed_sf(&handshake_blob)));
 
         let (leader_msg, leader) = leader.next(follower_msg);
@@ -241,8 +241,8 @@ mod tests {
             "ede91cf0898c0ac272f1035fe20a8d24d90a6d3bf8be815b4a144cb270e3b8c8e00f2af71471ced8";
         let reference_cfvd = "dc9906a43d25742bc6a479c2";
         let reference_sfvd = "d9f56d1223dea4832a7d8295";
-        assert_eq!(hex::encode(&ek), reference_ek);
-        assert_eq!(hex::encode(&cfvd), reference_cfvd);
-        assert_eq!(hex::encode(&sfvd), reference_sfvd);
+        assert_eq!(hex::encode(ek), reference_ek);
+        assert_eq!(hex::encode(cfvd), reference_cfvd);
+        assert_eq!(hex::encode(sfvd), reference_sfvd);
     }
 }

--- a/tls-2pc-core/src/prf/utils.rs
+++ b/tls-2pc-core/src/prf/utils.rs
@@ -21,10 +21,10 @@ pub fn generate_hmac_pads(input: &[u8]) -> ([u8; 64], [u8; 64]) {
     let mut opad = [0x5c_u8; 64];
 
     for (ipad, input) in ipad.iter_mut().zip(input.iter()) {
-        *ipad = *ipad ^ *input;
+        *ipad ^= *input;
     }
     for (opad, input) in opad.iter_mut().zip(input.iter()) {
-        *opad = *opad ^ *input;
+        *opad ^= *input;
     }
     (ipad, opad)
 }


### PR DESCRIPTION
This PR fixes all clippy lints in the `tls-2pc-core` subcrate **except** those in the `ghash` module, because this will be replaced by #111 soon.