### PR TITLE
OT: Add sender input for the number of OTs to generate

### DIFF
--- a/gf2-128/tests/ot_integration.rs
+++ b/gf2-128/tests/ot_integration.rs
@@ -30,7 +30,7 @@ async fn test_m2a_ot() {
         Kos15IOReceiver::new(Box::new(channel_2)),
     );
     let send = tokio::spawn(async {
-        let mut sender = sender.rand_setup().await.unwrap();
+        let mut sender = sender.rand_setup(128).await.unwrap();
         sender.send(blocks).await.unwrap();
     });
     let receive = tokio::spawn(async move {
@@ -73,7 +73,7 @@ async fn test_a2m_ot() {
         Kos15IOReceiver::new(Box::new(channel_2)),
     );
     let send = tokio::spawn(async {
-        let mut sender = sender.rand_setup().await.unwrap();
+        let mut sender = sender.rand_setup(128).await.unwrap();
         sender.send(blocks).await.unwrap();
     });
     let receive = tokio::spawn(async move {

--- a/mpc-aio/src/protocol/ot/kos/mod.rs
+++ b/mpc-aio/src/protocol/ot/kos/mod.rs
@@ -30,7 +30,7 @@ mod tests {
             Kos15IOReceiver::new(Box::new(channel_2)),
         );
         let send = tokio::spawn(async {
-            let mut sender = sender.rand_setup().await.unwrap();
+            let mut sender = sender.rand_setup(ITERATIONS).await.unwrap();
             sender.send(blocks).await.unwrap();
         });
         let receive = tokio::spawn(async move {
@@ -63,7 +63,7 @@ mod tests {
         );
         let send = tokio::spawn(async {
             sender.commit().await.unwrap();
-            let mut sender = sender.rand_setup().await.unwrap();
+            let mut sender = sender.rand_setup(ITERATIONS).await.unwrap();
             sender.send(blocks_clone).await.unwrap();
             sender.reveal().await.unwrap();
         });

--- a/mpc-aio/src/protocol/ot/kos/receiver.rs
+++ b/mpc-aio/src/protocol/ot/kos/receiver.rs
@@ -25,7 +25,7 @@ impl Kos15IOReceiver<r_state::Initialized> {
         }
     }
 
-    /// Setup the receiver for random OT
+    /// Set up the receiver for random OT
     ///
     /// * `count` - The number of OTs the receiver should prepare
     pub async fn rand_setup(

--- a/mpc-aio/src/protocol/ot/kos/receiver.rs
+++ b/mpc-aio/src/protocol/ot/kos/receiver.rs
@@ -25,9 +25,12 @@ impl Kos15IOReceiver<r_state::Initialized> {
         }
     }
 
+    /// Setup the receiver for random OT
+    ///
+    /// * `count` - The number of OTs the receiver should prepare
     pub async fn rand_setup(
         mut self,
-        choice_len: usize,
+        count: usize,
     ) -> Result<Kos15IOReceiver<r_state::RandSetup>, OTError> {
         let (kos_receiver, message) = self.inner.base_setup()?;
         self.channel
@@ -44,7 +47,7 @@ impl Kos15IOReceiver<r_state::Initialized> {
             .send(OTMessage::BaseSenderPayloadWrapper(message))
             .await?;
 
-        let (kos_receiver, message) = kos_receiver.rand_extension_setup(choice_len)?;
+        let (kos_receiver, message) = kos_receiver.rand_extension_setup(count)?;
 
         self.channel
             .send(OTMessage::ExtReceiverSetup(message))

--- a/mpc-aio/src/protocol/ot/kos/sender.rs
+++ b/mpc-aio/src/protocol/ot/kos/sender.rs
@@ -28,7 +28,7 @@ impl Kos15IOSender<s_state::Initialized> {
         }
     }
 
-    /// Setup the sender for random OT
+    /// Set up the sender for random OT
     ///
     /// * `count` - The number of OTs the sender should prepare
     pub async fn rand_setup(

--- a/mpc-aio/src/protocol/ot/kos/sender.rs
+++ b/mpc-aio/src/protocol/ot/kos/sender.rs
@@ -28,7 +28,13 @@ impl Kos15IOSender<s_state::Initialized> {
         }
     }
 
-    pub async fn rand_setup(mut self) -> Result<Kos15IOSender<s_state::RandSetup>, OTError> {
+    /// Setup the sender for random OT
+    ///
+    /// * `count` - The number of OTs the sender should prepare
+    pub async fn rand_setup(
+        mut self,
+        count: usize,
+    ) -> Result<Kos15IOSender<s_state::RandSetup>, OTError> {
         let message = expect_msg_or_err!(
             self.channel.next().await,
             OTMessage::BaseSenderSetupWrapper,
@@ -54,7 +60,7 @@ impl Kos15IOSender<s_state::Initialized> {
             OTError::Unexpected
         )?;
 
-        let kos_sender = kos_sender.rand_extension_setup(message)?;
+        let kos_sender = kos_sender.rand_extension_setup(count, message)?;
         let kos_io_sender = Kos15IOSender {
             inner: kos_sender,
             channel: self.channel,

--- a/mpc-core/benches/ot.rs
+++ b/mpc-core/benches/ot.rs
@@ -49,7 +49,9 @@ fn ext_ot(c: &mut Criterion) {
                 let (receiver, send_seeds) = receiver.base_send(base_receiver_setup).unwrap();
                 let sender = sender.base_receive(send_seeds).unwrap();
                 let (mut receiver, receiver_setup) = receiver.extension_setup(&choice).unwrap();
-                let mut sender = sender.extension_setup(receiver_setup).unwrap();
+                let mut sender = sender
+                    .extension_setup(choice.len(), receiver_setup)
+                    .unwrap();
 
                 let send = sender.send(&msgs).unwrap();
                 let _received = receiver.receive(send).unwrap();

--- a/mpc-core/examples/ote.rs
+++ b/mpc-core/examples/ote.rs
@@ -46,7 +46,9 @@ pub fn main() {
     let (mut receiver, receiver_setup) = receiver.extension_setup(&choice).unwrap();
 
     // Sender takes receiver's setup and runs its own extension setup
-    let mut sender = sender.extension_setup(receiver_setup).unwrap();
+    let mut sender = sender
+        .extension_setup(choice.len(), receiver_setup)
+        .unwrap();
 
     // Finally, sender encrypts their inputs and sends them to receiver
     let payload = sender.send(&inputs).unwrap();

--- a/mpc-core/examples/ote_random.rs
+++ b/mpc-core/examples/ote_random.rs
@@ -42,7 +42,7 @@ pub fn main() {
     let (mut receiver, receiver_setup) = receiver.rand_extension_setup(256).unwrap();
 
     // Sender takes receiver's setup and runs its own extension setup
-    let mut sender = sender.rand_extension_setup(receiver_setup).unwrap();
+    let mut sender = sender.rand_extension_setup(256, receiver_setup).unwrap();
 
     let mut received: Vec<Block> = Vec::new();
 

--- a/mpc-core/src/msgs/ot.rs
+++ b/mpc-core/src/msgs/ot.rs
@@ -84,7 +84,8 @@ pub struct ExtDerandomize {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExtReceiverSetup {
-    pub ncols: usize,
+    /// The unpadded number of OTs the receiver has prepared
+    pub count: usize,
     pub table: Vec<u8>,
     // x, t0, t1 are used for the KOS15 check
     pub x: [u8; 16],

--- a/mpc-core/src/ot/extension/kos15/receiver/mod.rs
+++ b/mpc-core/src/ot/extension/kos15/receiver/mod.rs
@@ -106,7 +106,7 @@ impl Kos15Receiver<state::BaseSetup> {
 }
 
 impl Kos15Receiver<state::BaseSend> {
-    /// Setup receiver for OT extension
+    /// Set up receiver for OT extension
     ///
     /// * `choices` - The receiver's choices for the extended OT
     pub fn extension_setup(
@@ -123,7 +123,7 @@ impl Kos15Receiver<state::BaseSend> {
         Ok((receiver, message))
     }
 
-    /// Setup receiver for random OT extension
+    /// Set up receiver for random OT extension
     ///
     /// * `count` - The number of OTs which the receiver prepares. Needs to agree with the
     ///             sender

--- a/mpc-core/src/ot/extension/kos15/sender/error.rs
+++ b/mpc-core/src/ot/extension/kos15/sender/error.rs
@@ -14,6 +14,8 @@ pub enum ExtSenderCoreError {
     CommitmentCheckFailed,
     #[error("KOS15 consistency check failed")]
     ConsistencyCheckFailed,
+    #[error("Sender and receiver disagree on the number of OTs to generate)")]
+    OTNumberDisagree,
     #[error("Matrix Error: {0}")]
     MatrixError(#[from] MatrixError),
 }

--- a/mpc-core/src/ot/extension/kos15/sender/error.rs
+++ b/mpc-core/src/ot/extension/kos15/sender/error.rs
@@ -14,7 +14,7 @@ pub enum ExtSenderCoreError {
     CommitmentCheckFailed,
     #[error("KOS15 consistency check failed")]
     ConsistencyCheckFailed,
-    #[error("Sender and receiver disagree on the number of OTs to generate)")]
+    #[error("Sender and receiver disagree on the number of OTs to generate")]
     OTNumberDisagree,
     #[error("Matrix Error: {0}")]
     MatrixError(#[from] MatrixError),

--- a/mpc-core/src/ot/extension/kos15/sender/mod.rs
+++ b/mpc-core/src/ot/extension/kos15/sender/mod.rs
@@ -122,11 +122,18 @@ impl Kos15Sender<state::BaseSetup> {
 }
 
 impl Kos15Sender<state::BaseReceive> {
+    /// Setup sender for OT extension
+    ///
+    /// * `count`     - The number of OTs which the sender prepares. Needs to agree with the
+    ///                 receiver's value in `setup_msg`
+    /// * `setup_msg` - Message from the receiver, containing information required for setup
     pub fn extension_setup(
         mut self,
+        count: usize,
         setup_msg: ExtReceiverSetup,
     ) -> Result<Kos15Sender<state::Setup>, ExtSenderCoreError> {
         let (table, ncols_unpadded) = extension_setup_from(
+            count,
             &mut self.0.rngs,
             &self.0.base_choices,
             setup_msg,
@@ -140,11 +147,18 @@ impl Kos15Sender<state::BaseReceive> {
         }))
     }
 
+    /// Setup sender for random OT extension
+    ///
+    /// * `count`     - The number of OTs which the sender prepares. Needs to agree with the
+    ///                 receiver's value in `setup_msg`
+    /// * `setup_msg` - Message from the receiver containing information required for setup
     pub fn rand_extension_setup(
         mut self,
+        count: usize,
         setup_msg: ExtReceiverSetup,
     ) -> Result<Kos15Sender<state::RandSetup>, ExtSenderCoreError> {
         let (table, ncols_unpadded) = extension_setup_from(
+            count,
             &mut self.0.rngs,
             &self.0.base_choices,
             setup_msg,
@@ -291,17 +305,17 @@ fn send_from(
 }
 
 fn extension_setup_from(
+    count: usize,
     rngs: &mut [ChaCha12Rng],
     base_choices: &[bool],
     setup_msg: ExtReceiverSetup,
     cointoss_random: &[u8; 32],
 ) -> Result<(KosMatrix, usize), ExtSenderCoreError> {
-    let ncols_unpadded = setup_msg.ncols;
-
-    // Prevent possible DOS attacks
-    if ncols_unpadded > 1_000_000 {
-        return Err(ExtSenderCoreError::InvalidInputLength);
+    if count != setup_msg.count {
+        return Err(ExtSenderCoreError::OTNumberDisagree);
     }
+
+    let ncols_unpadded = setup_msg.count;
 
     let expected_padding = calc_padding(ncols_unpadded);
     let ncols = setup_msg.table.len() / BASE_COUNT * 8;

--- a/mpc-core/src/ot/extension/kos15/sender/mod.rs
+++ b/mpc-core/src/ot/extension/kos15/sender/mod.rs
@@ -122,7 +122,7 @@ impl Kos15Sender<state::BaseSetup> {
 }
 
 impl Kos15Sender<state::BaseReceive> {
-    /// Setup sender for OT extension
+    /// Set up sender for OT extension
     ///
     /// * `count`     - The number of OTs which the sender prepares. Needs to agree with the
     ///                 receiver's value in `setup_msg`
@@ -147,7 +147,7 @@ impl Kos15Sender<state::BaseReceive> {
         }))
     }
 
-    /// Setup sender for random OT extension
+    /// Set up sender for random OT extension
     ///
     /// * `count`     - The number of OTs which the sender prepares. Needs to agree with the
     ///                 receiver's value in `setup_msg`


### PR DESCRIPTION
This PR adds the feature that for KOS OT, the sender now needs to input the number of OTs, he wants to generate. If this does not meet the receiver's value in the setup message, an error is returned.