### PR TITLE
Garble Config

### DIFF
--- a/mpc-aio/src/protocol/garble/backend/mod.rs
+++ b/mpc-aio/src/protocol/garble/backend/mod.rs
@@ -21,14 +21,14 @@ mod mock {
             &mut self,
             circ: Arc<Circuit>,
             delta: Delta,
-            input_labels: &[FullInputLabels],
+            input_labels: Vec<FullInputLabels>,
         ) -> Result<GarbledCircuit<gc_state::Full>, GCError> {
             let cipher = Aes128::new_from_slice(&[0u8; 16]).unwrap();
             Ok(GarbledCircuit::generate(
                 &cipher,
                 circ,
                 delta,
-                input_labels,
+                &input_labels,
             )?)
         }
     }
@@ -38,10 +38,10 @@ mod mock {
         async fn evaluate(
             &mut self,
             circ: GarbledCircuit<gc_state::Partial>,
-            input_labels: &[ActiveInputLabels],
+            input_labels: Vec<ActiveInputLabels>,
         ) -> Result<GarbledCircuit<gc_state::Evaluated>, GCError> {
             let cipher = Aes128::new_from_slice(&[0u8; 16]).unwrap();
-            Ok(circ.evaluate(&cipher, input_labels)?)
+            Ok(circ.evaluate(&cipher, &input_labels)?)
         }
     }
 }

--- a/mpc-core/src/garble/config.rs
+++ b/mpc-core/src/garble/config.rs
@@ -1,0 +1,151 @@
+use std::sync::Arc;
+
+use derive_builder::Builder;
+
+use mpc_circuits::{Circuit, InputValue, WireGroup};
+use rand::{CryptoRng, Rng};
+use utils::iter::DuplicateCheck;
+
+use super::{ActiveInputLabels, Delta, FullInputLabels};
+
+#[derive(Debug, Clone, Builder)]
+#[builder(build_fn(validate = "Self::validate"))]
+pub struct GarbleConfig {
+    pub circ: Arc<Circuit>,
+    #[builder(default = "None", setter(strip_option))]
+    pub generator_config: Option<GeneratorConfig>,
+    #[builder(default = "None", setter(strip_option))]
+    pub evaluator_config: Option<EvaluatorConfig>,
+}
+
+impl GarbleConfigBuilder {
+    /// Generates a config using the provided rng and circuit
+    pub fn default_dual_with_rng<R: Rng + CryptoRng>(rng: &mut R, circ: Arc<Circuit>) -> Self {
+        let generator_config = GeneratorConfigBuilder::default()
+            .with_rng(rng, &circ)
+            .build()
+            .expect("Default generator config should be valid");
+
+        let evaluator_config = EvaluatorConfigBuilder::default()
+            .build()
+            .expect("Default evaluator config should be valid");
+
+        let mut config = Self::default();
+        config.circ = Some(circ);
+        config.generator_config = Some(Some(generator_config));
+        config.evaluator_config = Some(Some(evaluator_config));
+
+        config
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        let Some(ref circ) = self.circ else {
+            return Err("Must provide circuit".to_string())
+        };
+
+        if let Some(Some(generator_config)) = self.generator_config.as_ref() {
+            validate_inputs(circ, &generator_config.input_labels)?;
+        }
+
+        if let Some(Some(evaluator_config)) = self.evaluator_config.as_ref() {
+            validate_inputs(circ, &evaluator_config.input_labels)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Builder)]
+pub struct GeneratorConfig {
+    pub input_labels: Vec<FullInputLabels>,
+    pub delta: Delta,
+}
+
+impl GeneratorConfigBuilder {
+    /// Generates a config using the provided rng and circuit
+    pub fn with_rng<R: Rng + CryptoRng>(&mut self, rng: &mut R, circ: &Circuit) -> &mut Self {
+        let (input_labels, delta) = FullInputLabels::generate_set(rng, circ, None);
+        self.input_labels = Some(input_labels);
+        self.delta = Some(delta);
+        self
+    }
+}
+
+impl GeneratorConfig {
+    /// Returns Generator's input labels
+    ///
+    /// * `generator_inputs` - Generator's inputs to the circuit
+    pub fn generator_labels(&self, generator_inputs: &[impl WireGroup]) -> Vec<FullInputLabels> {
+        let gen_input_ids = generator_inputs
+            .iter()
+            .map(|input| input.id())
+            .collect::<Vec<usize>>();
+
+        self.input_labels
+            .iter()
+            .filter(|input| gen_input_ids.contains(&input.id()))
+            .cloned()
+            .collect()
+    }
+
+    /// Returns Evaluator's input labels by excluding Generator's inputs from the set
+    ///
+    /// * `generator_inputs` - Generator's inputs to the circuit
+    pub fn evaluator_labels(&self, generator_inputs: &[impl WireGroup]) -> Vec<FullInputLabels> {
+        let gen_input_ids = generator_inputs
+            .iter()
+            .map(|input| input.id())
+            .collect::<Vec<usize>>();
+
+        self.input_labels
+            .iter()
+            .filter(|input| !gen_input_ids.contains(&input.id()))
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Debug, Default, Clone, Builder)]
+pub struct EvaluatorConfig {
+    #[builder(default = "vec![]")]
+    pub input_labels: Vec<ActiveInputLabels>,
+}
+
+impl EvaluatorConfig {
+    /// Returns only the inputs which the Evaluator still needs to retrieve via OT
+    ///
+    /// * `inputs` - All of Evaluator's input values
+    pub fn filter_cached_inputs(&self, inputs: &[InputValue]) -> Vec<InputValue> {
+        let cached_input_ids = self
+            .input_labels
+            .iter()
+            .map(|labels| labels.id())
+            .collect::<Vec<usize>>();
+
+        inputs
+            .iter()
+            .filter(|input| !cached_input_ids.contains(&input.id()))
+            .cloned()
+            .collect::<Vec<InputValue>>()
+    }
+}
+
+fn validate_inputs(circ: &Circuit, inputs: &[impl WireGroup]) -> Result<(), String> {
+    if inputs
+        .iter()
+        .map(|input| input.id())
+        .collect::<Vec<usize>>()
+        .iter()
+        .contains_dups()
+    {
+        return Err("Duplicate inputs".to_string());
+    } else if !inputs
+        .iter()
+        .map(|input| input.id())
+        .all(|id| circ.is_input_id(id))
+    {
+        return Err("Invalid input id".to_string());
+    }
+
+    Ok(())
+}

--- a/mpc-core/src/garble/error.rs
+++ b/mpc-core/src/garble/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     ValidationError(String),
     #[error("Invalid opening")]
     InvalidOpening,
+    #[error("Configuration error: {0:?}")]
+    ConfigError(String),
     #[error("Circuit error: {0:?}")]
     CircuitError(#[from] mpc_circuits::CircuitError),
     #[error("Value error: {0:?}")]

--- a/mpc-core/src/garble/exec/deap/mod.rs
+++ b/mpc-core/src/garble/exec/deap/mod.rs
@@ -6,7 +6,9 @@ pub use leader::{state as leader_state, DEAPLeader};
 
 #[cfg(test)]
 mod tests {
-    use crate::garble::{commitment::CommitmentOpening, Delta, Error, FullInputLabels};
+    use crate::garble::{
+        commitment::CommitmentOpening, config::GarbleConfigBuilder, Delta, Error, FullInputLabels,
+    };
 
     use super::*;
     use mpc_circuits::{Circuit, OutputValue, WireGroup, ADDER_64};
@@ -22,8 +24,13 @@ mod tests {
         let mut rng = ChaCha12Rng::seed_from_u64(0);
         let circ = Arc::new(Circuit::load_bytes(ADDER_64).unwrap());
 
-        let leader = DEAPLeader::new(circ.clone());
-        let follower = DEAPFollower::new(circ.clone());
+        let config = GarbleConfigBuilder::default()
+            .circ(circ.clone())
+            .build()
+            .unwrap();
+
+        let leader = DEAPLeader::new(config.clone());
+        let follower = DEAPFollower::new(config);
 
         let leader_input = circ.input(0).unwrap().to_value(0u64).unwrap();
         let follower_input = circ.input(1).unwrap().to_value(0u64).unwrap();

--- a/mpc-core/src/garble/exec/dual/mod.rs
+++ b/mpc-core/src/garble/exec/dual/mod.rs
@@ -14,7 +14,10 @@ pub use leader::{state as leader_state, DualExLeader};
 
 #[cfg(test)]
 mod tests {
-    use crate::garble::{commitment::CommitmentOpening, Error, FullInputLabels, LabelsDigest};
+    use crate::garble::{
+        commitment::CommitmentOpening, config::GarbleConfigBuilder, Error, FullInputLabels,
+        LabelsDigest,
+    };
 
     use super::*;
     use mpc_circuits::{Circuit, WireGroup, ADDER_64};
@@ -28,8 +31,13 @@ mod tests {
         let mut rng = thread_rng();
         let circ = Arc::new(Circuit::load_bytes(ADDER_64).unwrap());
 
-        let leader = DualExLeader::new(circ.clone());
-        let follower = DualExFollower::new(circ.clone());
+        let config = GarbleConfigBuilder::default()
+            .circ(circ.clone())
+            .build()
+            .unwrap();
+
+        let leader = DualExLeader::new(config.clone());
+        let follower = DualExFollower::new(config);
 
         let leader_input = circ.input(0).unwrap().to_value(0u64).unwrap();
         let follower_input = circ.input(1).unwrap().to_value(0u64).unwrap();

--- a/mpc-core/src/garble/mod.rs
+++ b/mpc-core/src/garble/mod.rs
@@ -6,6 +6,7 @@
 
 pub(crate) mod circuit;
 pub(crate) mod commitment;
+pub mod config;
 mod error;
 mod evaluator;
 pub mod exec;


### PR DESCRIPTION
This PR depends on #144. It encapsulates common configuration for garbled circuits into `GarbleConfig`. I expect that these configurations will expand as we require more features, but I'm keeping this PR relatively simple for now.

Additionally it simplifies the `Execute` trait, but looking forward I don't think that trait will be used very much (in our protocol at least).