### PR TITLE
2PC Block Cipher

### DIFF
--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["stream-cipher", "cipher-circuits"]
+members = ["stream-cipher", "block-cipher", "cipher-circuits"]
 
 [workspace.dependencies]
 # tlsn

--- a/cipher/block-cipher/Cargo.toml
+++ b/cipher/block-cipher/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "block-cipher"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["mock"]
+mock = []
+
+[dependencies]
+tlsn-cipher-circuits = { path = "../cipher-circuits" }
+tlsn-mpc-circuits.workspace = true
+tlsn-mpc-core.workspace = true
+tlsn-mpc-aio.workspace = true
+tlsn-utils.workspace = true
+tlsn-utils-aio.workspace = true
+
+async-trait.workspace = true
+tokio = { workspace = true, default-features = false, features = ["sync"] }
+futures.workspace = true
+rand.workspace = true
+thiserror.workspace = true
+derive_builder.workspace = true
+
+[dev-dependencies]
+aes.workspace = true
+ctr.workspace = true
+cipher.workspace = true
+rand_chacha.workspace = true
+tokio = { workspace = true, features = [
+    "macros",
+    "io-util",
+    "rt",
+    "rt-multi-thread",
+] }
+rstest = { workspace = true, features = ["async-timeout"] }
+criterion = { workspace = true, features = ["async_tokio"] }

--- a/cipher/block-cipher/src/cipher.rs
+++ b/cipher/block-cipher/src/cipher.rs
@@ -1,0 +1,377 @@
+use std::{marker::PhantomData, sync::Arc};
+
+use async_trait::async_trait;
+use futures::lock::Mutex;
+
+use mpc_aio::protocol::garble::{exec::dual::DEExecute, factory::GCFactoryError};
+use mpc_circuits::{Value, WireGroup};
+use mpc_core::garble::{
+    exec::dual::{DualExConfig, DualExConfigBuilder},
+    ActiveEncodedInput, ChaChaEncoder, Encoder, FullEncodedInput, FullInputSet,
+};
+use utils_aio::factory::AsyncFactory;
+
+use crate::{
+    config::Role, BlockCipher, BlockCipherCircuit, BlockCipherCircuitSuite, BlockCipherConfig,
+    BlockCipherError, BlockCipherLabels, BlockCipherShareCircuit,
+};
+
+pub struct State {
+    execution_id: usize,
+    encoder: Option<Arc<Mutex<ChaChaEncoder>>>,
+    labels: Option<BlockCipherLabels>,
+}
+
+pub struct DEBlockCipher<C, DEF, DE>
+where
+    C: BlockCipherCircuitSuite,
+    DEF: AsyncFactory<DE, Config = DualExConfig, Error = GCFactoryError>,
+    DE: DEExecute,
+{
+    config: BlockCipherConfig,
+    state: State,
+
+    de_factory: DEF,
+
+    _cipher: PhantomData<C>,
+    _de: PhantomData<DE>,
+}
+
+impl<C, DEF, DE> DEBlockCipher<C, DEF, DE>
+where
+    C: BlockCipherCircuitSuite,
+    DEF: AsyncFactory<DE, Config = DualExConfig, Error = GCFactoryError> + Send,
+    DE: DEExecute + Send,
+{
+    pub fn new(config: BlockCipherConfig, de_factory: DEF) -> Self {
+        Self {
+            config,
+            state: State {
+                execution_id: 0,
+                encoder: None,
+                labels: None,
+            },
+            de_factory,
+            _cipher: PhantomData,
+            _de: PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<C, DEF, DE> BlockCipher<C> for DEBlockCipher<C, DEF, DE>
+where
+    C: BlockCipherCircuitSuite,
+    DEF: AsyncFactory<DE, Config = DualExConfig, Error = GCFactoryError> + Send,
+    DE: DEExecute + Send,
+{
+    /// Sets the key input labels for the block cipher.
+    ///
+    /// * `labels`: The labels to use for the key input.
+    fn set_keys(&mut self, labels: BlockCipherLabels) {
+        self.state.labels = Some(labels);
+    }
+
+    /// Sets the encoder used to generate the input labels
+    /// used during 2PC.
+    fn set_encoder(&mut self, encoder: Arc<Mutex<ChaChaEncoder>>) {
+        self.state.encoder = Some(encoder);
+    }
+
+    /// Encrypts the given plaintext.
+    ///
+    /// Returns the ciphertext
+    ///
+    /// * `plaintext` - The plaintext to encrypt
+    async fn encrypt_private(&mut self, plaintext: Vec<u8>) -> Result<Vec<u8>, BlockCipherError> {
+        let labels = self
+            .state
+            .labels
+            .clone()
+            .ok_or(BlockCipherError::KeysNotSet)?;
+
+        let encoder = self
+            .state
+            .encoder
+            .clone()
+            .ok_or(BlockCipherError::EncoderNotSet)?;
+
+        // Compute instance id
+        let id = format!("{}/{}", self.config.id, self.state.execution_id);
+
+        self.state.execution_id += 1;
+
+        let cipher = C::BlockCipherCircuit::default();
+
+        if plaintext.len() != C::BLOCK_SIZE {
+            return Err(BlockCipherError::InvalidInputLength(
+                C::BLOCK_SIZE,
+                plaintext.len(),
+            ));
+        }
+
+        let de_config = DualExConfigBuilder::default()
+            .id(id.clone())
+            .circ(cipher.circuit())
+            .build()
+            .expect("DualExConfig should be valid");
+        let de = self.de_factory.create(id, de_config).await?;
+
+        let key_input = cipher.key();
+        let text_input = cipher
+            .text()
+            .to_value(plaintext)
+            .expect("plaintext is valid length");
+
+        let mut encoder = encoder.lock().await;
+        let text_labels = FullEncodedInput::from_labels(
+            text_input.group().clone(),
+            encoder.encode(self.config.encoder_default_stream_id, text_input.group()),
+        )
+        .expect("Text labels should be valid");
+        drop(encoder);
+
+        let key_full_labels = FullEncodedInput::from_labels(key_input.clone(), labels.key_full)
+            .expect("Key labels should be valid");
+        let key_active_labels = ActiveEncodedInput::from_labels(key_input, labels.key_active)
+            .expect("Key labels should be valid");
+
+        let gen_labels = FullInputSet::new(vec![key_full_labels, text_labels])
+            .expect("Circuit input should only be key and text");
+        let gen_inputs = vec![text_input.clone()];
+        let ot_send_inputs = vec![];
+        let ot_receive_inputs = vec![text_input];
+        let cached_labels = vec![key_active_labels];
+
+        let output = de
+            .execute(
+                gen_labels,
+                gen_inputs,
+                ot_send_inputs,
+                ot_receive_inputs,
+                cached_labels,
+            )
+            .await?;
+
+        let Value::Bytes(ciphertext) = output[cipher.ciphertext().index()].value().clone() else {
+            panic!("Ciphertext should be bytes");
+        };
+
+        Ok(ciphertext)
+    }
+
+    /// Encrypts a plaintext provided by the other party
+    ///
+    /// Returns the ciphertext
+    async fn encrypt_blind(&mut self) -> Result<Vec<u8>, BlockCipherError> {
+        let labels = self
+            .state
+            .labels
+            .clone()
+            .ok_or(BlockCipherError::KeysNotSet)?;
+
+        let encoder = self
+            .state
+            .encoder
+            .clone()
+            .ok_or(BlockCipherError::EncoderNotSet)?;
+
+        // Instance ID / Execution ID
+        let id = format!("{}/{}", self.config.id, self.state.execution_id);
+        self.state.execution_id += 1;
+
+        let cipher = C::BlockCipherCircuit::default();
+
+        let de_config = DualExConfigBuilder::default()
+            .id(id.clone())
+            .circ(cipher.circuit())
+            .build()
+            .expect("DualExConfig should be valid");
+        let de = self.de_factory.create(id, de_config).await?;
+
+        let key_input = cipher.key();
+        let text_input = cipher.text();
+
+        let mut encoder = encoder.lock().await;
+        let text_labels = FullEncodedInput::from_labels(
+            text_input.clone(),
+            encoder.encode(self.config.encoder_default_stream_id, &text_input),
+        )
+        .expect("Text labels should be valid");
+        drop(encoder);
+
+        let key_full_labels = FullEncodedInput::from_labels(key_input.clone(), labels.key_full)
+            .expect("Key labels should be valid");
+        let key_active_labels = ActiveEncodedInput::from_labels(key_input, labels.key_active)
+            .expect("Key labels should be valid");
+
+        let gen_labels = FullInputSet::new(vec![key_full_labels, text_labels])
+            .expect("Circuit input should only be key and text");
+        let gen_inputs = vec![];
+        let ot_send_inputs = vec![text_input];
+        let ot_receive_inputs = vec![];
+        let cached_labels = vec![key_active_labels];
+
+        let output = de
+            .execute(
+                gen_labels,
+                gen_inputs,
+                ot_send_inputs,
+                ot_receive_inputs,
+                cached_labels,
+            )
+            .await?;
+
+        let Value::Bytes(ciphertext) = output[cipher.ciphertext().index()].value().clone() else {
+            panic!("Ciphertext should be bytes");
+        };
+
+        Ok(ciphertext)
+    }
+
+    /// Encrypts a plaintext provided by both parties. Fails if the
+    /// plaintext provided by both parties does not match.
+    ///
+    /// Returns the additive share of the ciphertext
+    ///
+    /// * `plaintext` - The plaintext to encrypt
+    /// * `mask` - The additive share of the mask to use
+    async fn encrypt_share(
+        &mut self,
+        plaintext: Vec<u8>,
+        mask: Vec<u8>,
+    ) -> Result<Vec<u8>, BlockCipherError> {
+        let labels = self
+            .state
+            .labels
+            .clone()
+            .ok_or(BlockCipherError::KeysNotSet)?;
+
+        let encoder = self
+            .state
+            .encoder
+            .clone()
+            .ok_or(BlockCipherError::EncoderNotSet)?;
+
+        // Instance ID / Execution ID
+        let id = format!("{}/{}", self.config.id, self.state.execution_id);
+        self.state.execution_id += 1;
+
+        let cipher = C::ShareCircuit::default();
+
+        if plaintext.len() != C::BLOCK_SIZE {
+            return Err(BlockCipherError::InvalidInputLength(
+                C::BLOCK_SIZE,
+                plaintext.len(),
+            ));
+        }
+
+        if mask.len() != C::BLOCK_SIZE {
+            return Err(BlockCipherError::InvalidInputLength(
+                C::BLOCK_SIZE,
+                plaintext.len(),
+            ));
+        }
+
+        let de_config = DualExConfigBuilder::default()
+            .id(id.clone())
+            .circ(cipher.circuit())
+            .build()
+            .expect("DualExConfig should be valid");
+        let de = self.de_factory.create(id, de_config).await?;
+
+        let key_input = cipher.key();
+        let text_input = cipher
+            .text()
+            .to_value(plaintext)
+            .expect("plaintext is valid length");
+        let mask_leader_input = cipher.mask_0();
+        let mask_follower_input = cipher.mask_1();
+
+        let mut encoder = encoder.lock().await;
+        let text_labels = FullEncodedInput::from_labels(
+            text_input.group().clone(),
+            encoder.encode(self.config.encoder_default_stream_id, text_input.group()),
+        )
+        .expect("Text labels should be valid");
+        let mask_leader_labels = FullEncodedInput::from_labels(
+            mask_leader_input.clone(),
+            encoder.encode(self.config.encoder_default_stream_id, &mask_leader_input),
+        )
+        .expect("Mask leader labels should be valid");
+        let mask_follower_labels = FullEncodedInput::from_labels(
+            mask_follower_input.clone(),
+            encoder.encode(self.config.encoder_default_stream_id, &mask_follower_input),
+        )
+        .expect("Mask follower labels should be valid");
+        drop(encoder);
+
+        let key_full_labels = FullEncodedInput::from_labels(key_input.clone(), labels.key_full)
+            .expect("Key labels should be valid");
+        let key_active_labels = ActiveEncodedInput::from_labels(key_input, labels.key_active)
+            .expect("Key labels should be valid");
+
+        let gen_labels = FullInputSet::new(vec![
+            key_full_labels,
+            text_labels,
+            mask_leader_labels,
+            mask_follower_labels,
+        ])
+        .expect("Circuit inputs should be complete");
+
+        let (gen_inputs, ot_send_inputs, ot_receive_inputs) = match self.config.role {
+            Role::Leader => {
+                let mask_leader_input = mask_leader_input
+                    .to_value(mask.clone())
+                    .expect("mask is valid length");
+
+                (
+                    vec![text_input.clone(), mask_leader_input.clone()],
+                    vec![mask_follower_input],
+                    vec![mask_leader_input],
+                )
+            }
+            Role::Follower => {
+                let mask_follower_input = mask_follower_input
+                    .to_value(mask.clone())
+                    .expect("mask is valid length");
+
+                (
+                    vec![text_input.clone(), mask_follower_input.clone()],
+                    vec![mask_leader_input],
+                    vec![mask_follower_input],
+                )
+            }
+        };
+
+        let cached_labels = vec![key_active_labels];
+
+        let mut output = de
+            .execute(
+                gen_labels,
+                gen_inputs,
+                ot_send_inputs,
+                ot_receive_inputs,
+                cached_labels,
+            )
+            .await?;
+
+        let Value::Bytes(masked_ciphertext) = output.remove(cipher.masked_ciphertext().index()).value().clone() else {
+            panic!("Masked ciphertext should be bytes");
+        };
+
+        // Masked ciphertext C_MASKED = C + MASK_LEADER + MASK_FOLLOWER
+        // Leader share = C_MASKED - MASK_LEADER
+        // Follower share = MASK_FOLLOWER
+        let share = match self.config.role {
+            Role::Leader => masked_ciphertext
+                .into_iter()
+                .zip(mask.into_iter())
+                .map(|(a, b)| a ^ b)
+                .collect::<Vec<_>>(),
+            Role::Follower => mask,
+        };
+
+        Ok(share)
+    }
+}

--- a/cipher/block-cipher/src/config.rs
+++ b/cipher/block-cipher/src/config.rs
@@ -1,0 +1,15 @@
+use derive_builder::Builder;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Role {
+    Leader,
+    Follower,
+}
+
+#[derive(Debug, Clone, Builder)]
+pub struct BlockCipherConfig {
+    pub(crate) id: String,
+    pub(crate) role: Role,
+    #[builder(default = "0")]
+    pub(crate) encoder_default_stream_id: u32,
+}

--- a/cipher/block-cipher/src/lib.rs
+++ b/cipher/block-cipher/src/lib.rs
@@ -1,0 +1,296 @@
+//! This crate provides a 2PC block cipher implementation.
+//!
+//! Both parties work together to encrypt or share an encrypted block using a shared key.
+
+mod cipher;
+mod config;
+mod suite;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::lock::Mutex;
+
+use mpc_aio::protocol::garble::GCError;
+use mpc_core::garble::{ActiveLabels, ChaChaEncoder, FullLabels};
+
+pub use crate::{
+    cipher::DEBlockCipher,
+    suite::{
+        Aes128, Aes128Circuit, Aes128ShareCircuit, BlockCipherCircuit, BlockCipherCircuitSuite,
+        BlockCipherShareCircuit,
+    },
+};
+pub use config::{BlockCipherConfig, BlockCipherConfigBuilder, BlockCipherConfigBuilderError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum BlockCipherError {
+    #[error("MuxerError: {0}")]
+    MuxerError(#[from] utils_aio::mux::MuxerError),
+    #[error("GCFactoryError: {0}")]
+    GCFactoryError(#[from] mpc_aio::protocol::garble::factory::GCFactoryError),
+    #[error("GCError: {0}")]
+    GCError(#[from] GCError),
+    #[error("Cipher key labels not set")]
+    KeysNotSet,
+    #[error("Encoder not set")]
+    EncoderNotSet,
+    #[error("Input does not match block length: expected {0}, got {1}")]
+    InvalidInputLength(usize, usize),
+}
+
+#[derive(Clone)]
+pub struct BlockCipherLabels {
+    key_full: FullLabels,
+    key_active: ActiveLabels,
+}
+
+#[async_trait]
+pub trait BlockCipher<Cipher>
+where
+    Cipher: BlockCipherCircuitSuite,
+    Self: Sized + Send,
+{
+    /// Sets the key input labels for the block cipher.
+    ///
+    /// * `labels`: The labels to use for the key input.
+    fn set_keys(&mut self, labels: BlockCipherLabels);
+
+    /// Sets the encoder used to generate the input labels
+    /// used during 2PC.
+    ///
+    /// * `encoder`: The encoder to use
+    fn set_encoder(&mut self, encoder: Arc<Mutex<ChaChaEncoder>>);
+
+    /// Encrypts the given plaintext.
+    ///
+    /// Returns the ciphertext
+    ///
+    /// * `plaintext` - The plaintext to encrypt
+    async fn encrypt_private(&mut self, plaintext: Vec<u8>) -> Result<Vec<u8>, BlockCipherError>;
+
+    /// Encrypts a plaintext provided by the other party
+    ///
+    /// Returns the ciphertext
+    async fn encrypt_blind(&mut self) -> Result<Vec<u8>, BlockCipherError>;
+
+    /// Encrypts a plaintext provided by both parties. Fails if the
+    /// plaintext provided by both parties does not match.
+    ///
+    /// Returns the additive share of the ciphertext
+    ///
+    /// * `plaintext` - The plaintext to encrypt
+    /// * `mask` - The additive share of the mask to use
+    async fn encrypt_share(
+        &mut self,
+        plaintext: Vec<u8>,
+        mask: Vec<u8>,
+    ) -> Result<Vec<u8>, BlockCipherError>;
+}
+
+#[cfg(feature = "mock")]
+pub mod mock {
+    use mpc_aio::protocol::garble::{
+        exec::dual::mock::{MockDualExFollower, MockDualExLeader},
+        factory::dual::mock::{create_mock_dualex_factory, MockDualExFactory},
+    };
+    use mpc_circuits::{BitOrder, Value};
+    use mpc_core::garble::Encoder;
+
+    use super::*;
+
+    pub type MockDEBlockCipherLeader<C> = DEBlockCipher<C, MockDualExFactory, MockDualExLeader>;
+    pub type MockDEBlockCipherFollower<C> = DEBlockCipher<C, MockDualExFactory, MockDualExFollower>;
+
+    pub fn create_labels<C: BlockCipherCircuitSuite>(
+        key: Vec<u8>,
+        leader_encoder: &mut ChaChaEncoder,
+        follower_encoder: &mut ChaChaEncoder,
+    ) -> (BlockCipherLabels, BlockCipherLabels) {
+        let cipher = C::BlockCipherCircuit::default();
+
+        let leader_key_full = leader_encoder.encode(0, &cipher.key());
+        let follower_key_full = follower_encoder.encode(0, &cipher.key());
+
+        let leader_key_active = follower_key_full
+            .select(&Value::Bytes(key.clone()), BitOrder::Msb0)
+            .unwrap();
+        let follower_key_active = leader_key_full
+            .select(&Value::Bytes(key), BitOrder::Msb0)
+            .unwrap();
+
+        let leader_labels = BlockCipherLabels {
+            key_full: leader_key_full,
+            key_active: leader_key_active,
+        };
+
+        let follower_labels = BlockCipherLabels {
+            key_full: follower_key_full,
+            key_active: follower_key_active,
+        };
+
+        (leader_labels, follower_labels)
+    }
+
+    pub fn create_mock_block_cipher_pair<C: BlockCipherCircuitSuite>(
+        leader_config: BlockCipherConfig,
+        follower_config: BlockCipherConfig,
+    ) -> (MockDEBlockCipherLeader<C>, MockDEBlockCipherFollower<C>) {
+        let de_factory = create_mock_dualex_factory();
+
+        let leader = DEBlockCipher::new(leader_config, de_factory.clone());
+
+        let follower = DEBlockCipher::new(follower_config, de_factory);
+
+        (leader, follower)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mock::*;
+    use mpc_circuits::BitOrder;
+
+    use crate::{config::Role, suite::Aes128};
+
+    use ::aes::Aes128 as TestAes128;
+    use ::cipher::{BlockEncrypt, KeyInit};
+
+    fn setup_pair<C: BlockCipherCircuitSuite>(
+        key: Vec<u8>,
+        leader_config: BlockCipherConfig,
+        follower_config: BlockCipherConfig,
+    ) -> (MockDEBlockCipherLeader<C>, MockDEBlockCipherFollower<C>) {
+        let (mut leader, mut follower) =
+            create_mock_block_cipher_pair::<C>(leader_config, follower_config);
+
+        let mut leader_encoder = ChaChaEncoder::new([0u8; 32], BitOrder::Msb0);
+        let mut follower_encoder = ChaChaEncoder::new([1u8; 32], BitOrder::Msb0);
+
+        let (leader_labels, follower_labels) =
+            create_labels::<Aes128>(key, &mut leader_encoder, &mut follower_encoder);
+
+        leader.set_encoder(Arc::new(Mutex::new(leader_encoder)));
+        leader.set_keys(leader_labels);
+        follower.set_encoder(Arc::new(Mutex::new(follower_encoder)));
+        follower.set_keys(follower_labels);
+
+        (leader, follower)
+    }
+
+    #[tokio::test]
+    async fn test_block_cipher_blind() {
+        let leader_config = BlockCipherConfigBuilder::default()
+            .id("test".to_string())
+            .role(Role::Leader)
+            .build()
+            .unwrap();
+
+        let follower_config = BlockCipherConfigBuilder::default()
+            .id("test".to_string())
+            .role(Role::Follower)
+            .build()
+            .unwrap();
+
+        let key = [0u8; 16];
+
+        let (mut leader, mut follower) =
+            setup_pair::<Aes128>(key.to_vec(), leader_config, follower_config);
+
+        let plaintext = [0u8; 16];
+
+        let (leader_result, follower_result) = tokio::join!(
+            leader.encrypt_private(plaintext.to_vec()),
+            follower.encrypt_blind()
+        );
+
+        let leader_ciphertext = leader_result.unwrap();
+        let follower_ciphertext = follower_result.unwrap();
+
+        let mut reference_ciphertext = plaintext.into();
+        let cipher = TestAes128::new(&key.into());
+        cipher.encrypt_block(&mut reference_ciphertext);
+
+        assert_eq!(leader_ciphertext, reference_ciphertext.to_vec());
+        assert_eq!(leader_ciphertext, follower_ciphertext);
+    }
+
+    #[tokio::test]
+    async fn test_block_cipher_share() {
+        let leader_config = BlockCipherConfigBuilder::default()
+            .id("test".to_string())
+            .role(Role::Leader)
+            .build()
+            .unwrap();
+
+        let follower_config = BlockCipherConfigBuilder::default()
+            .id("test".to_string())
+            .role(Role::Follower)
+            .build()
+            .unwrap();
+
+        let key = [0u8; 16];
+
+        let (mut leader, mut follower) =
+            setup_pair::<Aes128>(key.to_vec(), leader_config, follower_config);
+
+        let plaintext = [0u8; 16];
+        let leader_mask = vec![1u8; 16];
+        let follower_mask = vec![2u8; 16];
+
+        let (leader_result, follower_result) = tokio::join!(
+            leader.encrypt_share(plaintext.to_vec(), leader_mask.clone()),
+            follower.encrypt_share(plaintext.to_vec(), follower_mask.clone())
+        );
+
+        let leader_share = leader_result.unwrap();
+        let follower_share = follower_result.unwrap();
+
+        let mut reference_ciphertext = plaintext.into();
+        let cipher = TestAes128::new(&key.into());
+        cipher.encrypt_block(&mut reference_ciphertext);
+
+        let ciphertext = leader_share
+            .iter()
+            .zip(follower_share.iter())
+            .map(|(a, b)| a ^ b)
+            .collect::<Vec<_>>();
+
+        assert_eq!(ciphertext, reference_ciphertext.to_vec());
+    }
+
+    #[tokio::test]
+    async fn test_block_cipher_share_unequal_plaintext() {
+        let leader_config = BlockCipherConfigBuilder::default()
+            .id("test".to_string())
+            .role(Role::Leader)
+            .build()
+            .unwrap();
+
+        let follower_config = BlockCipherConfigBuilder::default()
+            .id("test".to_string())
+            .role(Role::Follower)
+            .build()
+            .unwrap();
+
+        let key = [0u8; 16];
+
+        let (mut leader, mut follower) =
+            setup_pair::<Aes128>(key.to_vec(), leader_config, follower_config);
+
+        let plaintext = [0u8; 16];
+        let plaintext_1 = [1u8; 16];
+        let leader_mask = vec![1u8; 16];
+        let follower_mask = vec![2u8; 16];
+
+        let (leader_result, follower_result) = tokio::join!(
+            leader.encrypt_share(plaintext.to_vec(), leader_mask.clone()),
+            follower.encrypt_share(plaintext_1.to_vec(), follower_mask.clone())
+        );
+
+        assert!(leader_result.is_err());
+        assert!(follower_result.is_err());
+    }
+}

--- a/cipher/block-cipher/src/suite.rs
+++ b/cipher/block-cipher/src/suite.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use cipher_circuits::AES_MASKED;
+use mpc_circuits::{Circuit, Input, Output, AES_128};
+
+pub trait BlockCipherCircuitSuite: Default + Clone + Send + Sync {
+    type BlockCipherCircuit: BlockCipherCircuit;
+    type ShareCircuit: BlockCipherShareCircuit;
+
+    const KEY_SIZE: usize;
+    const BLOCK_SIZE: usize;
+}
+
+pub trait BlockCipherCircuit: Default + Clone + Send + Sync {
+    const KEY_SIZE: usize;
+    const BLOCK_SIZE: usize;
+
+    /// Returns circuit
+    fn circuit(&self) -> Arc<Circuit>;
+    /// Returns input corresponding to key
+    fn key(&self) -> Input;
+    /// Returns input corresponding to text
+    fn text(&self) -> Input;
+    /// Returns output correpsonding to ciphertext
+    fn ciphertext(&self) -> Output;
+}
+
+pub trait BlockCipherShareCircuit: Default + Clone + Send + Sync {
+    const KEY_SIZE: usize;
+    const BLOCK_SIZE: usize;
+
+    /// Returns circuit
+    fn circuit(&self) -> Arc<Circuit>;
+    /// Returns input corresponding to key
+    fn key(&self) -> Input;
+    /// Returns input corresponding to text
+    fn text(&self) -> Input;
+    /// Returns input corresponding to mask 0
+    fn mask_0(&self) -> Input;
+    /// Returns input corresponding to mask 1
+    fn mask_1(&self) -> Input;
+    /// Returns output correpsonding to masked ciphertext
+    fn masked_ciphertext(&self) -> Output;
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Aes128;
+
+impl BlockCipherCircuitSuite for Aes128 {
+    type BlockCipherCircuit = Aes128Circuit;
+    type ShareCircuit = Aes128ShareCircuit;
+
+    const KEY_SIZE: usize = 16;
+    const BLOCK_SIZE: usize = 16;
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Aes128Circuit;
+
+#[derive(Default, Debug, Clone)]
+pub struct Aes128ShareCircuit;
+
+impl BlockCipherCircuit for Aes128Circuit {
+    const KEY_SIZE: usize = 16;
+    const BLOCK_SIZE: usize = 16;
+
+    fn circuit(&self) -> Arc<Circuit> {
+        AES_128.clone()
+    }
+
+    fn key(&self) -> Input {
+        AES_128.input(0).expect("AES input 0 should be key")
+    }
+
+    fn text(&self) -> Input {
+        AES_128.input(1).expect("AES input 1 should be text")
+    }
+
+    fn ciphertext(&self) -> Output {
+        AES_128
+            .output(0)
+            .expect("AES output 0 should be ciphertext")
+    }
+}
+
+impl BlockCipherShareCircuit for Aes128ShareCircuit {
+    const KEY_SIZE: usize = 16;
+    const BLOCK_SIZE: usize = 16;
+
+    fn circuit(&self) -> Arc<Circuit> {
+        AES_MASKED.clone()
+    }
+
+    fn key(&self) -> Input {
+        AES_MASKED.input(0).expect("AES input 0 should be key")
+    }
+
+    fn text(&self) -> Input {
+        AES_MASKED.input(1).expect("AES input 1 should be text")
+    }
+
+    fn mask_0(&self) -> Input {
+        AES_MASKED.input(2).expect("AES input 2 should be mask 0")
+    }
+
+    fn mask_1(&self) -> Input {
+        AES_MASKED.input(3).expect("AES input 3 should be mask 1")
+    }
+
+    fn masked_ciphertext(&self) -> Output {
+        AES_MASKED
+            .output(0)
+            .expect("AES output 0 should be masked ciphertext")
+    }
+}


### PR DESCRIPTION
This PR builds on #169 and provides a 2PC block cipher generic over the cipher.

**Features**
1. Encrypt a message provided by one of the parties
2. Compute additive shares of a ciphertext (we'll use this to compute shares of the hash key in AEAD)