### PR TITLE
DualEx option to skip equality check

### DIFF
--- a/mpc/mpc-aio/src/protocol/garble/exec/dual.rs
+++ b/mpc/mpc-aio/src/protocol/garble/exec/dual.rs
@@ -213,7 +213,7 @@ where
     /// Execute dual execution protocol without the equality check
     ///
     /// This can be used when chaining multiple circuits together. Neither party
-    /// reveals the output label decoding.
+    /// reveals the output label decoding information.
     ///
     /// ** Warning **
     ///
@@ -430,7 +430,7 @@ where
     /// Execute dual execution protocol without the equality check
     ///
     /// This can be used when chaining multiple circuits together. Neither party
-    /// reveals the output label decoding.
+    /// reveals the output label decoding information.
     ///
     /// ** Warning **
     ///


### PR DESCRIPTION
This PR adds the option to skip (defer) the equality check protocol in dual execution. This will be used in the PRF to output the symmetric key labels for the AEAD.

I hardcoded this to have both parties send output labels commitments for good measure. I don't think it is necessary but it can't hurt.