### PR TITLE
Ot wrong ciphertext count

### DIFF
--- a/mpc/mpc-core/src/ot/extension/kos15/mod.rs
+++ b/mpc/mpc-core/src/ot/extension/kos15/mod.rs
@@ -251,7 +251,7 @@ pub mod tests {
         let receiver = receiver
             .receive(add_ciphers)
             .expect_err("Sending more OTs should be state error");
-        assert_eq!(receiver, ExtReceiverCoreError::NotDerandomized);
+        assert_eq!(receiver, ExtReceiverCoreError::CiphertextCountWrong);
 
         let expected: Vec<Block> = inputs
             .iter()

--- a/mpc/mpc-core/src/ot/extension/kos15/receiver/error.rs
+++ b/mpc/mpc-core/src/ot/extension/kos15/receiver/error.rs
@@ -8,9 +8,9 @@ pub enum ExtReceiverCoreError {
     /// Error originating from Base OT
     #[error("OT failed due to error in Base OT")]
     BaseError(#[from] crate::ot::base::SenderCoreError),
-    /// Choice bits not derandomized
-    #[error("Payload contains more encrypted values than derandomized choice bits")]
-    NotDerandomized,
+    /// Sender sent an incorrect count of encrypted OT messages
+    #[error("The count of encrypted values and choice bits must match")]
+    CiphertextCountWrong,
     #[error("Tried to derandomize more OTs than setup")]
     InvalidChoiceLength,
     #[error("Received payload of unexpected size")]

--- a/mpc/mpc-core/src/ot/extension/kos15/receiver/state.rs
+++ b/mpc/mpc-core/src/ot/extension/kos15/receiver/state.rs
@@ -44,7 +44,10 @@ impl ReceiverState for Setup {}
 pub struct RandSetup {
     pub(crate) rng: ChaCha12Rng,
     pub(crate) table: KosMatrix,
-    pub(crate) choices: Vec<bool>,
+    /// Random choice bits are the result of the Random OT setup
+    pub(crate) rand_choices: Vec<bool>,
+    /// A buffer of choice bits for which derandomization request has already been sent to the OT
+    /// Sender but the corresponding encrypted OT messages have not yet been received
     pub(crate) derandomized: Vec<bool>,
     // Records the received, encrypted blocks, sent by the sender for later use in committed OT
     pub(crate) sender_output_tape: Vec<[Block; 2]>,


### PR DESCRIPTION
This PR:
- makes it an error if the count of OT Sender's ciphertexts doesn't match the count of derandomized choice bits
- consistently names receiver's choice bits as `choices` and the random bits from Random OT setup as `rand_choices`