### PR TITLE
simplified a2m

### DIFF
--- a/mpc/share-conversion-core/src/a2m.rs
+++ b/mpc/share-conversion-core/src/a2m.rs
@@ -26,6 +26,8 @@ impl<T: Field> AddShare<T> {
                 break r;
             }
         };
+
+        // generate random masks
         let mut masks: Vec<T> = vec![T::zero(); T::BIT_SIZE as usize];
         masks.iter_mut().for_each(|m| *m = T::rand(rng));
 
@@ -35,34 +37,43 @@ impl<T: Field> AddShare<T> {
             .take(T::BIT_SIZE as usize - 1)
             .fold(T::zero(), |acc, i| acc + *i);
 
+        // split up our additive share `x` into random summands
+        let mut x_summands: Vec<T> = vec![T::zero(); T::BIT_SIZE as usize];
+        x_summands.iter_mut().for_each(|s| *s = T::rand(rng));
+
+        // set the last summand such that the sum of all [T::BIT_SIZE] summands equals `x`
+        x_summands[T::BIT_SIZE as usize - 1] = self.inner()
+            + -x_summands
+                .iter()
+                .take(T::BIT_SIZE as usize - 1)
+                .fold(T::zero(), |acc, i| acc + *i);
+
         // the inverse of the random share will be the multiplicative share for the sender
         let mul_share = MulShare::new(random.inverse());
 
         // Each choice bit of the peer's share `y` represents a summand of `y`, e.g.
-        // if `y` is 10110 (in binary), then the choice bits (0,1,1,0,1) represent the summands
-        // (0, 10, 100, 0000, 10000).
-        // For each peer's summand, we send back `summand * random` with a mask to hide the product.
+        // if `y` is 10110 (in binary), then the choice bits in lsb0 order (0,1,1,0,1) represent the
+        // summands (0, 10, 100, 0000, 10000).
+        // For each peer's summand (called `y_summand`), we send back `(x_summand + y_summand) * random
+        // + mask`. The purpose of the mask is to hide the product.
 
         let values: Vec<[T; 2]> = (0..T::BIT_SIZE)
             .map(|k| {
-                // when summand is zero, we just send the mask
-                let mut v0 = masks[k as usize];
+                // when y_summand is zero, we send `x_summand * random + mask`
+                let v0 = x_summands[k as usize] * random + masks[k as usize];
 
-                // otherwise we send `summand * random + mask`
+                // otherwise we send `(x_summand + y_summand) * random + mask`
                 let mut bits = vec![false; T::BIT_SIZE as usize];
                 bits[(T::BIT_SIZE - 1 - k) as usize] = true;
-                let summand = T::from_bits_msb0(&bits);
-                let mut v1 = (summand * random) + masks[k as usize];
+                let y_summand = T::from_bits_msb0(&bits);
+                let v1 = (x_summands[k as usize] + y_summand) * random + masks[k as usize];
 
-                // add `x * random` to the last value, so that when the peer sums up all values,
-                // he will get `(y + x) * random`, which will be his multiplicative share
-                if k == T::BIT_SIZE - 1 {
-                    v0 = v0 + self.inner() * random;
-                    v1 = v1 + self.inner() * random;
-                }
                 [v0, v1]
             })
             .collect();
+
+        // when the peer adds up all the received values, the masks will cancel one another out and
+        // the remaining `(x + y) * random` will be the peer's multiplicative share
 
         let (v0, v1): (Vec<T>, Vec<T>) = values.into_iter().map(|[v0, v1]| (v0, v1)).unzip();
 


### PR DESCRIPTION
This PR simplifies a2m
It is easier to reason about the protocol if we break it down in 2 steps: (sender's additive share is x, receiver's is y)
1. the sender sends to peer `y * random`
2. the sender mixes in `x * random` into the last OT.