### PR TITLE
Moar Bitvec Utils

### DIFF
--- a/mpc/mpc-core/benches/ot.rs
+++ b/mpc/mpc-core/benches/ot.rs
@@ -5,7 +5,7 @@ use mpc_core::{
 };
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha12Rng;
-use utils::bits::BytesToBits;
+use utils::bits::IterToBits;
 
 fn base_ot(c: &mut Criterion) {
     let mut group = c.benchmark_group("base_ot");

--- a/mpc/mpc-core/src/ot/base/mod.rs
+++ b/mpc/mpc-core/src/ot/base/mod.rs
@@ -33,7 +33,7 @@ pub mod tests {
     use rstest::*;
 
     pub mod fixtures {
-        use utils::bits::BytesToBits;
+        use utils::bits::IterToBits;
 
         use super::*;
 
@@ -49,7 +49,7 @@ pub mod tests {
         pub fn choice() -> Vec<bool> {
             let mut choice = vec![0u8; 16];
             thread_rng().fill_bytes(&mut choice);
-            choice.into_iter().into_msb0()
+            choice.into_msb0()
         }
 
         #[fixture]

--- a/mpc/mpc-core/src/ot/extension/kos15/receiver/mod.rs
+++ b/mpc/mpc-core/src/ot/extension/kos15/receiver/mod.rs
@@ -20,7 +20,7 @@ use error::{CommittedOTError, ExtReceiverCoreError};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha12Rng;
 use rand_core::RngCore;
-use utils::{bits::BitsToBytes, iter::xor};
+use utils::{bits::FromBits, iter::xor};
 
 pub struct Kos15Receiver<S = state::Initialized>(S)
 where
@@ -367,7 +367,7 @@ fn extension_setup_from(
     // Extend choice bits
     let mut r_bool = choices.to_vec();
     r_bool.extend(&padding_values);
-    let r = r_bool.iter().copied().msb0_into_bytes();
+    let r: Vec<u8> = Vec::from_msb0(r_bool.iter().copied());
     let ncols = r_bool.len();
 
     let row_length = ncols / 8;

--- a/mpc/mpc-core/src/ot/extension/kos15/utils.rs
+++ b/mpc/mpc-core/src/ot/extension/kos15/utils.rs
@@ -7,7 +7,7 @@ use matrix_transpose::LANE_COUNT;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha12Rng;
 use std::convert::TryInto;
-use utils::bits::BitsToBytes;
+use utils::bits::{FromBits, IterFromBits};
 
 /// Row length of the transposed KOS15 matrix
 const ROW_LENGTH_TR: usize = BASE_COUNT / 8;
@@ -116,7 +116,7 @@ pub fn kos15_check_sender(
     }
 
     let mut delta = [0u8; ROW_LENGTH_TR];
-    let choice_bytes = base_choices.into_iter().copied().msb0_into_bytes();
+    let choice_bytes: Vec<u8> = Vec::from_msb0(base_choices.into_iter().copied());
     delta.copy_from_slice(&choice_bytes);
     let delta = Clmul::new(&delta);
 
@@ -157,9 +157,10 @@ pub fn encrypt_values<C: BlockCipher<BlockSize = U16> + BlockEncrypt>(
     let base_choice: [u8; 16] = choices
         .into_iter()
         .copied()
-        .msb0_into_bytes()
+        .iter_from_msb0()
+        .collect::<Vec<u8>>()
         .try_into()
-        .unwrap();
+        .expect("choices should be 16 bytes long");
     let delta = Block::from(base_choice);
     // If Receiver used *random* choice bits during OT extension setup, he will now
     // instruct us to de-randomize, so that the value corresponding to his *actual*

--- a/utils/utils/src/bits.rs
+++ b/utils/utils/src/bits.rs
@@ -1,4 +1,9 @@
-use std::marker::PhantomData;
+use std::{iter::Peekable, marker::PhantomData};
+
+/// Zero-sized type used to represent LSB0 bit order.
+pub struct Lsb0;
+/// Zero-sized type used to represent MSB0 bit order.
+pub struct Msb0;
 
 pub struct BitStringIterator<'a> {
     string: &'a str,
@@ -27,26 +32,26 @@ impl<'a> Iterator for BitStringIterator<'a> {
     }
 }
 
-/// Helper trait for converting bit strings to bool iterators.
-pub trait BitStringToBoolVec<'a> {
-    /// Converts a bit string to an iterator of bools.
+/// Trait for converting from bit strings to bit iterators.
+pub trait StrToBits<'a> {
+    /// Converts a bit string to an iterator of bits.
     ///
     /// Panics if the string contains characters other than '0' or '1'.
-    fn to_bool_iter(&'a self) -> BitStringIterator<'a>;
+    fn to_bit_iter(&'a self) -> BitStringIterator<'a>;
 
-    /// Converts a bit string to a bool vec.
+    /// Converts a bit string to a bit vec.
     ///
     /// Panics if the string contains characters other than '0' or '1'.
-    fn to_bool_vec(&'a self) -> Vec<bool> {
-        self.to_bool_iter().collect()
+    fn to_bit_vec(&'a self) -> Vec<bool> {
+        self.to_bit_iter().collect()
     }
 }
 
-impl<'a, T> BitStringToBoolVec<'a> for T
+impl<'a, T> StrToBits<'a> for T
 where
     T: AsRef<str>,
 {
-    fn to_bool_iter(&'a self) -> BitStringIterator<'a> {
+    fn to_bit_iter(&'a self) -> BitStringIterator<'a> {
         BitStringIterator {
             string: self.as_ref(),
             pos: 0,
@@ -54,206 +59,370 @@ where
     }
 }
 
-pub struct Lsb0;
-pub struct Msb0;
+/// Trait used for parsing a value from an iterator of bits.
+pub trait FromBits {
+    /// Parses a value from an iterator of bits in LSB0 order.
+    ///
+    /// Panics if the iterator yields fewer than `Self::BITS` bits.
+    fn from_lsb0(iter: impl IntoIterator<Item = bool>) -> Self;
 
-pub struct ByteIterator<I, Ord>
+    /// Parses a value from an iterator of bits in MSB0 order.
+    ///
+    /// Panics if the iterator yields fewer than `Self::BITS` bits.
+    fn from_msb0(iter: impl IntoIterator<Item = bool>) -> Self;
+}
+
+macro_rules! impl_from_bits {
+    ($typ:ty) => {
+        impl FromBits for $typ {
+            fn from_lsb0(iter: impl IntoIterator<Item = bool>) -> Self {
+                let mut iter = iter.into_iter();
+
+                let mut value = <$typ>::default();
+
+                for i in 0..<$typ>::BITS {
+                    let Some(bit) = iter.next() else {
+                        panic!("Bit iterator yielded fewer bits than expected, got {}, expected {}", i, <$typ>::BITS);
+                    };
+
+                    value |= (bit as $typ) << i;
+                }
+
+                value
+            }
+
+            fn from_msb0(iter: impl IntoIterator<Item = bool>) -> Self {
+                let mut iter = iter.into_iter();
+
+                let mut value = <$typ>::default();
+
+                for i in 0..<$typ>::BITS {
+                    let Some(bit) = iter.next() else {
+                        panic!("Bit iterator yielded fewer bits than expected, got {}, expected {}", i, <$typ>::BITS);
+                    };
+
+                    value |= (bit as $typ) << ((<$typ>::BITS - 1) - i);
+                }
+
+                value
+            }
+        }
+    };
+}
+
+impl_from_bits!(u8);
+impl_from_bits!(u16);
+impl_from_bits!(u32);
+impl_from_bits!(u64);
+impl_from_bits!(u128);
+
+pub struct UintIterator<T, Ord> {
+    bit_order: PhantomData<Ord>,
+    value: T,
+    pos: usize,
+}
+
+macro_rules! impl_uint_iter {
+    ($typ:ty) => {
+        impl Iterator for UintIterator<$typ, Lsb0> {
+            type Item = bool;
+
+            fn next(&mut self) -> Option<bool> {
+                if self.pos == <$typ>::BITS as usize {
+                    return None;
+                }
+
+                let bit = (self.value & (1 << self.pos)) != 0;
+
+                self.pos += 1;
+
+                Some(bit)
+            }
+        }
+
+        impl Iterator for UintIterator<$typ, Msb0> {
+            type Item = bool;
+
+            fn next(&mut self) -> Option<bool> {
+                if self.pos == <$typ>::BITS as usize {
+                    return None;
+                }
+
+                let bit = (self.value & (1 << (<$typ>::BITS as usize - self.pos - 1))) != 0;
+
+                self.pos += 1;
+
+                Some(bit)
+            }
+        }
+    };
+}
+
+impl_uint_iter!(u8);
+impl_uint_iter!(u16);
+impl_uint_iter!(u32);
+impl_uint_iter!(u64);
+impl_uint_iter!(u128);
+
+pub struct BitParser<I, V, Ord>
 where
-    I: Iterator<Item = bool> + ?Sized,
+    I: Iterator<Item = bool>,
+    V: FromBits,
 {
     bit_order: PhantomData<Ord>,
-    bit_iter: I,
+    value: PhantomData<V>,
+    iter: Peekable<I>,
 }
 
-impl<I> Iterator for ByteIterator<I, Lsb0>
+impl<I, V> Iterator for BitParser<I, V, Lsb0>
 where
     I: Iterator<Item = bool>,
+    V: FromBits,
 {
-    type Item = u8;
+    type Item = V;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut byte = 0u8;
-        for idx in 0u8..8 {
-            let Some(bit) = self.bit_iter.next() else {
-                if idx == 0 {
-                    // We've reached the end of the bit iterator
-                    return None;
-                } else {
-                    panic!("bit iterator yielded less than a byte")
-                }
-            };
-            byte |= (bit as u8) << idx;
+    fn next(&mut self) -> Option<V> {
+        // Check if there are any bits left in the iterator,
+        // otherwise return None.
+        if let Some(_) = self.iter.peek() {
+            Some(V::from_lsb0(&mut self.iter))
+        } else {
+            None
         }
-
-        Some(byte)
     }
 }
 
-impl<I> Iterator for ByteIterator<I, Msb0>
+impl<I, V> Iterator for BitParser<I, V, Msb0>
 where
     I: Iterator<Item = bool>,
+    V: FromBits,
 {
-    type Item = u8;
+    type Item = V;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut byte = 0u8;
-        for idx in 0u8..8 {
-            let Some(bit) = self.bit_iter.next() else {
-                if idx == 0 {
-                    // We've reached the end of the bit iterator
-                    return None;
-                } else {
-                    panic!("bit iterator yielded less than a byte")
-                }
-            };
-            byte |= (bit as u8) << (7 - idx);
+    fn next(&mut self) -> Option<V> {
+        // Check if there are any bits left in the iterator,
+        // otherwise return None.
+        if let Some(_) = self.iter.peek() {
+            Some(V::from_msb0(&mut self.iter))
+        } else {
+            None
         }
-
-        Some(byte)
     }
 }
 
-/// Helper trait used for converting bool iterators into byte iterators.
-pub trait BitsToBytes
+/// Trait used for parsing an iterator of values from an iterator of bits.
+pub trait IterFromBits<V>
 where
     Self: IntoIterator<Item = bool>,
+    V: FromBits,
 {
-    /// Converts an iterator of LSB0 bits into an iterator of bytes.
+    /// Parses an iterator of values from an iterator of bits in LSB0 order.
     ///
-    /// Panics if number of bits is not a multiple of 8.
-    fn lsb0_into_bytes_iter(self) -> ByteIterator<<Self as IntoIterator>::IntoIter, Lsb0>;
+    /// Panics if the iterator does not yield a multiple of `V::BITS` bits.
+    fn iter_from_lsb0(self) -> BitParser<<Self as IntoIterator>::IntoIter, V, Lsb0>;
 
-    /// Converts an iterator of LSB0 bits into a byte vector.
+    /// Parses an iterator of values from an iterator of bits in MSB0 order.
     ///
-    /// Panics if number of bits is not a multiple of 8.
-    fn lsb0_into_bytes(self) -> Vec<u8>;
-
-    /// Converts an iterator of MSB0 bits into an iterator of bytes.
-    ///
-    /// Panics if number of bits is not a multiple of 8.
-    fn msb0_into_bytes_iter(self) -> ByteIterator<<Self as IntoIterator>::IntoIter, Msb0>;
-
-    /// Converts an iterator of MSB0 bits into a byte vector.
-    ///
-    /// Panics if number of bits is not a multiple of 8.
-    fn msb0_into_bytes(self) -> Vec<u8>;
+    /// Panics if the iterator does not yield a multiple of `V::BITS` bits.
+    fn iter_from_msb0(self) -> BitParser<<Self as IntoIterator>::IntoIter, V, Msb0>;
 }
 
-impl<I> BitsToBytes for I
+impl<I, V> IterFromBits<V> for I
 where
     I: IntoIterator<Item = bool>,
+    V: FromBits,
 {
-    fn lsb0_into_bytes_iter(self) -> ByteIterator<<Self as IntoIterator>::IntoIter, Lsb0> {
-        ByteIterator {
+    fn iter_from_lsb0(self) -> BitParser<<Self as IntoIterator>::IntoIter, V, Lsb0> {
+        BitParser {
             bit_order: PhantomData::<Lsb0>,
-            bit_iter: self.into_iter(),
+            value: PhantomData::<V>,
+            iter: self.into_iter().peekable(),
         }
     }
 
-    fn lsb0_into_bytes(self) -> Vec<u8> {
-        self.lsb0_into_bytes_iter().collect()
-    }
-
-    fn msb0_into_bytes_iter(self) -> ByteIterator<<Self as IntoIterator>::IntoIter, Msb0> {
-        ByteIterator {
+    fn iter_from_msb0(self) -> BitParser<<Self as IntoIterator>::IntoIter, V, Msb0> {
+        BitParser {
             bit_order: PhantomData::<Msb0>,
-            bit_iter: self.into_iter(),
+            value: PhantomData::<V>,
+            iter: self.into_iter().peekable(),
         }
-    }
-
-    fn msb0_into_bytes(self) -> Vec<u8> {
-        self.msb0_into_bytes_iter().collect()
     }
 }
 
-pub struct BitIterator<I, Ord>
+impl<V> FromBits for Vec<V>
 where
-    I: Iterator<Item = u8> + ?Sized,
+    V: FromBits,
 {
-    bit_order: PhantomData<Ord>,
-    bit_idx: usize,
-    byte: Option<u8>,
-    byte_iter: I,
-}
+    fn from_lsb0(iter: impl IntoIterator<Item = bool>) -> Self {
+        iter.into_iter().iter_from_lsb0().collect()
+    }
 
-impl<I> Iterator for BitIterator<I, Lsb0>
-where
-    I: Iterator<Item = u8>,
-{
-    type Item = bool;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.bit_idx == 0 {
-            self.byte = self.byte_iter.next();
-        }
-
-        let byte = self.byte?;
-
-        let bit = (byte >> self.bit_idx) & 1 == 1;
-
-        self.bit_idx += 1;
-
-        if self.bit_idx == 8 {
-            self.bit_idx = 0;
-        }
-
-        Some(bit)
+    fn from_msb0(iter: impl IntoIterator<Item = bool>) -> Self {
+        iter.into_iter().iter_from_msb0().collect()
     }
 }
 
-impl<I> Iterator for BitIterator<I, Msb0>
-where
-    I: Iterator<Item = u8>,
-{
-    type Item = bool;
+/// Trait for converting types to bit iterators.
+pub trait ToBits {
+    type Lsb0Iter: Iterator<Item = bool>;
+    type Msb0Iter: Iterator<Item = bool>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.bit_idx == 0 {
-            self.byte = self.byte_iter.next();
-        }
+    /// Converts into an iterator of LSB0 bits.
+    fn into_lsb0_iter(self) -> Self::Lsb0Iter;
 
-        let byte = self.byte?;
-
-        let bit = (byte >> (7 - self.bit_idx)) & 1 == 1;
-
-        self.bit_idx += 1;
-
-        if self.bit_idx == 8 {
-            self.bit_idx = 0;
-        }
-
-        Some(bit)
-    }
-}
-
-/// Helper trait for converting an iterator of bytes to an iterator of bits
-pub trait BytesToBits
-where
-    Self: IntoIterator<Item = u8>,
-{
-    /// Converts an iterator of bytes into an iterator of LSB0 bits.
-    fn into_lsb0_iter(self) -> BitIterator<<Self as IntoIterator>::IntoIter, Lsb0>;
-
-    /// Converts an iterator of bytes into an LSB0 bit vector.
+    /// Converts into an LSB0 bit vector.
     fn into_lsb0(self) -> Vec<bool>;
 
-    /// Converts an iterator of bytes into an iterator of MSB0 bits.
-    fn into_msb0_iter(self) -> BitIterator<<Self as IntoIterator>::IntoIter, Msb0>;
+    /// Converts into an iterator of MSB0 bits.
+    fn into_msb0_iter(self) -> Self::Msb0Iter;
 
-    /// Converts an iterator of bytes into an MSB0 bit vector.
+    /// Converts into an MSB0 bit vector.
     fn into_msb0(self) -> Vec<bool>;
 }
 
-impl<T> BytesToBits for T
+macro_rules! impl_uint_to_bits {
+    ($typ:ty) => {
+        impl ToBits for $typ {
+            type Lsb0Iter = UintIterator<$typ, Lsb0>;
+            type Msb0Iter = UintIterator<$typ, Msb0>;
+
+            fn into_lsb0_iter(self) -> UintIterator<$typ, Lsb0> {
+                UintIterator {
+                    bit_order: PhantomData::<Lsb0>,
+                    value: self,
+                    pos: 0,
+                }
+            }
+
+            fn into_lsb0(self) -> Vec<bool> {
+                self.into_lsb0_iter().collect()
+            }
+
+            fn into_msb0_iter(self) -> UintIterator<$typ, Msb0> {
+                UintIterator {
+                    bit_order: PhantomData::<Msb0>,
+                    value: self,
+                    pos: 0,
+                }
+            }
+
+            fn into_msb0(self) -> Vec<bool> {
+                self.into_msb0_iter().collect()
+            }
+        }
+    };
+}
+
+impl_uint_to_bits!(u8);
+impl_uint_to_bits!(u16);
+impl_uint_to_bits!(u32);
+impl_uint_to_bits!(u64);
+impl_uint_to_bits!(u128);
+
+pub struct BitIterator<I, V, Ord> {
+    bit_order: PhantomData<Ord>,
+    inner_iter: Option<V>,
+    outer_iter: I,
+}
+
+impl<I, V> Iterator for BitIterator<I, <V as ToBits>::Lsb0Iter, Lsb0>
 where
-    T: IntoIterator<Item = u8>,
+    I: Iterator<Item = V>,
+    V: ToBits,
 {
-    fn into_lsb0_iter(self) -> BitIterator<<Self as IntoIterator>::IntoIter, Lsb0> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        // If inner_iter is set, pull from it.
+        let Some(inner_iter) = self.inner_iter.as_mut() else {
+            // If inner_iter is not set, pull from outer_iter.
+            // If outer_iter is empty, return None.
+            let Some(value) = self.outer_iter.next() else {
+                return None;
+            };
+
+            // Set inner_iter to the next value.
+            self.inner_iter = Some(value.into_lsb0_iter());
+
+            return self.next();
+        };
+
+        let Some(bit) = inner_iter.next() else {
+            // If inner_iter is empty, set it to None.
+            self.inner_iter = None;
+
+            return self.next();
+        };
+
+        Some(bit)
+    }
+}
+
+impl<I, V> Iterator for BitIterator<I, <V as ToBits>::Msb0Iter, Msb0>
+where
+    I: Iterator<Item = V>,
+    V: ToBits,
+{
+    type Item = bool;
+
+    fn next(&mut self) -> Option<bool> {
+        // If inner_iter is set, pull from it.
+        let Some(inner_iter) = self.inner_iter.as_mut() else {
+            // If inner_iter is not set, pull from outer_iter.
+            // If outer_iter is empty, return None.
+            let Some(value) = self.outer_iter.next() else {
+                return None;
+            };
+
+            // Set inner_iter to the next value.
+            self.inner_iter = Some(value.into_msb0_iter());
+
+            return self.next();
+        };
+
+        let Some(bit) = inner_iter.next() else {
+            // If inner_iter is empty, set it to None.
+            self.inner_iter = None;
+
+            return self.next();
+        };
+
+        Some(bit)
+    }
+}
+
+/// Trait for converting an iterator of values to an iterator of bits.
+pub trait IterToBits
+where
+    Self: IntoIterator,
+{
+    type Item: ToBits;
+    type Lsb0Iter: Iterator<Item = bool>;
+    type Msb0Iter: Iterator<Item = bool>;
+
+    fn into_lsb0_iter(self) -> Self::Lsb0Iter;
+
+    fn into_lsb0(self) -> Vec<bool>;
+
+    fn into_msb0_iter(self) -> Self::Msb0Iter;
+
+    fn into_msb0(self) -> Vec<bool>;
+}
+
+impl<I, V> IterToBits for I
+where
+    I: IntoIterator<Item = V>,
+    V: ToBits,
+{
+    type Item = V;
+    type Lsb0Iter = BitIterator<<I as IntoIterator>::IntoIter, <V as ToBits>::Lsb0Iter, Lsb0>;
+    type Msb0Iter = BitIterator<<I as IntoIterator>::IntoIter, <V as ToBits>::Msb0Iter, Msb0>;
+
+    fn into_lsb0_iter(self) -> Self::Lsb0Iter {
         BitIterator {
             bit_order: PhantomData::<Lsb0>,
-            bit_idx: 0,
-            byte: None,
-            byte_iter: self.into_iter(),
+            inner_iter: None,
+            outer_iter: self.into_iter(),
         }
     }
 
@@ -261,235 +430,16 @@ where
         self.into_lsb0_iter().collect()
     }
 
-    fn into_msb0_iter(self) -> BitIterator<<Self as IntoIterator>::IntoIter, Msb0> {
+    fn into_msb0_iter(self) -> Self::Msb0Iter {
         BitIterator {
             bit_order: PhantomData::<Msb0>,
-            bit_idx: 0,
-            byte: None,
-            byte_iter: self.into_iter(),
+            inner_iter: None,
+            outer_iter: self.into_iter(),
         }
     }
 
     fn into_msb0(self) -> Vec<bool> {
         self.into_msb0_iter().collect()
-    }
-}
-
-/// Helper trait for converting an iterator of bits to an unsigned integer.
-pub trait BitsToUint {
-    /// Converts an iterator of LSB0 bits into a u8.
-    ///
-    /// Panics if number of bits is not 8.
-    fn lsb0_into_u8(self) -> u8;
-
-    /// Converts an iterator of LSB0 bits into a u16.
-    ///
-    /// Panics if number of bits is not 16.
-    fn lsb0_into_u16(self) -> u16;
-
-    /// Converts an iterator of LSB0 bits into a u32.
-    ///
-    /// Panics if number of bits is not 32.
-    fn lsb0_into_u32(self) -> u32;
-
-    /// Converts an iterator of LSB0 bits into a u64.
-    ///
-    /// Panics if number of bits is not 64.
-    fn lsb0_into_u64(self) -> u64;
-
-    /// Converts an iterator of LSB0 bits into a u128.
-    ///
-    /// Panics if number of bits is not 128.
-    fn lsb0_into_u128(self) -> u128;
-
-    /// Converts an iterator of MSB0 bits into a u8.
-    ///
-    /// Panics if number of bits is not 8.
-    fn msb0_into_u8(self) -> u8;
-
-    /// Converts an iterator of MSB0 bits into a u16.
-    ///
-    /// Panics if number of bits is not 16.
-    fn msb0_into_u16(self) -> u16;
-
-    /// Converts an iterator of MSB0 bits into a u32.
-    ///
-    /// Panics if number of bits is not 32.
-    fn msb0_into_u32(self) -> u32;
-
-    /// Converts an iterator of MSB0 bits into a u64.
-    ///
-    /// Panics if number of bits is not 64.
-    fn msb0_into_u64(self) -> u64;
-
-    /// Converts an iterator of MSB0 bits into a u128.
-    ///
-    /// Panics if number of bits is not 128.
-    fn msb0_into_u128(self) -> u128;
-}
-
-impl<T> BitsToUint for T
-where
-    T: IntoIterator<Item = bool>,
-{
-    fn lsb0_into_u8(self) -> u8 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u8;
-
-        for i in 0..8 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u8");
-            };
-
-            value |= (bit as u8) << i;
-        }
-
-        value
-    }
-
-    fn lsb0_into_u16(self) -> u16 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u16;
-
-        for i in 0..16 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u16");
-            };
-
-            value |= (bit as u16) << i;
-        }
-
-        value
-    }
-
-    fn lsb0_into_u32(self) -> u32 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u32;
-
-        for i in 0..32 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u32");
-            };
-
-            value |= (bit as u32) << i;
-        }
-
-        value
-    }
-
-    fn lsb0_into_u64(self) -> u64 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u64;
-
-        for i in 0..64 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u64");
-            };
-
-            value |= (bit as u64) << i;
-        }
-
-        value
-    }
-
-    fn lsb0_into_u128(self) -> u128 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u128;
-
-        for i in 0..128 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u128");
-            };
-
-            value |= (bit as u128) << i;
-        }
-
-        value
-    }
-
-    fn msb0_into_u8(self) -> u8 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u8;
-
-        for i in 0..8 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u8");
-            };
-
-            value |= (bit as u8) << (7 - i);
-        }
-
-        value
-    }
-
-    fn msb0_into_u16(self) -> u16 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u16;
-
-        for i in 0..16 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u16");
-            };
-
-            value |= (bit as u16) << (15 - i);
-        }
-
-        value
-    }
-
-    fn msb0_into_u32(self) -> u32 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u32;
-
-        for i in 0..32 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u32");
-            };
-
-            value |= (bit as u32) << (31 - i);
-        }
-
-        value
-    }
-
-    fn msb0_into_u64(self) -> u64 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u64;
-
-        for i in 0..64 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u64");
-            };
-
-            value |= (bit as u64) << (63 - i);
-        }
-
-        value
-    }
-
-    fn msb0_into_u128(self) -> u128 {
-        let mut iter = self.into_iter();
-
-        let mut value = 0u128;
-
-        for i in 0..128 {
-            let Some(bit) = iter.next() else {
-                panic!("Not enough bits to convert to u128");
-            };
-
-            value |= (bit as u128) << (127 - i);
-        }
-
-        value
     }
 }
 
@@ -506,7 +456,7 @@ mod test {
     #[should_panic]
     #[case::non_binary_char("a", vec![])]
     fn test_string_to_boolvec(#[case] bits: &str, #[case] expected: Vec<bool>) {
-        let bits: Vec<bool> = bits.to_bool_vec();
+        let bits: Vec<bool> = bits.to_bit_vec();
 
         assert_eq!(bits, expected);
     }
@@ -521,7 +471,7 @@ mod test {
     #[should_panic]
     #[case::extra_bit("000000000", vec![0u8])]
     fn test_lsb0_to_bytes(#[case] bits: &str, #[case] expected: Vec<u8>) {
-        let bytes: Vec<u8> = bits.to_bool_iter().lsb0_into_bytes();
+        let bytes: Vec<u8> = Vec::from_lsb0(bits.to_bit_iter());
 
         assert_eq!(bytes, expected);
     }
@@ -536,7 +486,7 @@ mod test {
     #[should_panic]
     #[case::extra_bit("000000000", vec![0u8])]
     fn test_msb0_to_bytes(#[case] bits: &str, #[case] expected: Vec<u8>) {
-        let bytes: Vec<u8> = bits.to_bool_iter().msb0_into_bytes();
+        let bytes: Vec<u8> = Vec::from_msb0(bits.to_bit_iter());
 
         assert_eq!(bytes, expected);
     }
@@ -548,7 +498,7 @@ mod test {
     #[case::multi_byte(vec![0u8, 1u8], "0000000010000000")]
     #[case::empty(vec![], "")]
     fn test_bytes_to_lsb0(#[case] bytes: Vec<u8>, #[case] expected: &str) {
-        let expected = expected.to_bool_vec();
+        let expected = expected.to_bit_vec();
 
         let bits: Vec<bool> = bytes.into_lsb0();
 
@@ -562,7 +512,7 @@ mod test {
     #[case::multi_byte(vec![0u8, 1u8], "0000000000000001")]
     #[case::empty(vec![], "")]
     fn test_bytes_to_msb0(#[case] bytes: Vec<u8>, #[case] expected: &str) {
-        let expected = expected.to_bool_vec();
+        let expected = expected.to_bit_vec();
 
         let bits: Vec<bool> = bytes.into_msb0();
 
@@ -573,69 +523,106 @@ mod test {
     #[case(format!("{:08b}", 0u8), 0u8)]
     #[case(format!("{:08b}", 1u8), 1u8)]
     #[case(format!("{:08b}", u8::MAX), u8::MAX)]
-    fn test_lsb0_to_u8(#[case] bits: impl AsRef<str>, #[case] expected: u8) {
-        let msb_value = bits.to_bool_iter().msb0_into_u8();
-
-        let lsb_bits = bits.as_ref().chars().rev().collect::<String>();
-        let lsb_value = lsb_bits.to_bool_iter().lsb0_into_u8();
-
-        assert_eq!(msb_value, expected);
-        assert_eq!(lsb_value, expected);
-    }
-
-    #[rstest]
     #[case(format!("{:016b}", 0u16), 0u16)]
     #[case(format!("{:016b}", 1u16), 1u16)]
     #[case(format!("{:016b}", u16::MAX), u16::MAX)]
-    fn test_lsb0_to_u16(#[case] bits: impl AsRef<str>, #[case] expected: u16) {
-        let msb_value = bits.to_bool_iter().msb0_into_u16();
-
-        let lsb_bits = bits.as_ref().chars().rev().collect::<String>();
-        let lsb_value = lsb_bits.to_bool_iter().lsb0_into_u16();
-
-        assert_eq!(msb_value, expected);
-        assert_eq!(lsb_value, expected);
-    }
-
-    #[rstest]
     #[case(format!("{:032b}", 0u32), 0u32)]
     #[case(format!("{:032b}", 1u32), 1u32)]
     #[case(format!("{:032b}", u32::MAX), u32::MAX)]
-    fn test_lsb0_to_u32(#[case] bits: impl AsRef<str>, #[case] expected: u32) {
-        let msb_value = bits.to_bool_iter().msb0_into_u32();
-
-        let lsb_bits = bits.as_ref().chars().rev().collect::<String>();
-        let lsb_value = lsb_bits.to_bool_iter().lsb0_into_u32();
-
-        assert_eq!(msb_value, expected);
-        assert_eq!(lsb_value, expected);
-    }
-
-    #[rstest]
     #[case(format!("{:064b}", 0u64), 0u64)]
     #[case(format!("{:064b}", 1u64), 1u64)]
     #[case(format!("{:064b}", u64::MAX), u64::MAX)]
-    fn test_lsb0_to_u64(#[case] bits: impl AsRef<str>, #[case] expected: u64) {
-        let msb_value = bits.to_bool_iter().msb0_into_u64();
+    #[case(format!("{:0128b}", 0u128), 0u128)]
+    #[case(format!("{:0128b}", 1u128), 1u128)]
+    #[case(format!("{:0128b}", u128::MAX), u128::MAX)]
+    fn test_from_bits<T: FromBits + PartialEq + std::fmt::Debug>(
+        #[case] bits: impl AsRef<str>,
+        #[case] expected: T,
+    ) {
+        let msb_value = T::from_msb0(bits.to_bit_iter());
 
         let lsb_bits = bits.as_ref().chars().rev().collect::<String>();
-        let lsb_value = lsb_bits.to_bool_iter().lsb0_into_u64();
+        let lsb_value = T::from_lsb0(lsb_bits.to_bit_iter());
 
         assert_eq!(msb_value, expected);
         assert_eq!(lsb_value, expected);
     }
 
     #[rstest]
-    #[case(format!("{:0128b}", 0u128), 0u128)]
-    #[case(format!("{:0128b}", 1u128), 1u128)]
-    #[case(format!("{:0128b}", u128::MAX), u128::MAX)]
-    fn test_lsb0_to_u128(#[case] bits: impl AsRef<str>, #[case] expected: u128) {
-        let msb_value = bits.to_bool_iter().msb0_into_u128();
-
-        let lsb_bits = bits.as_ref().chars().rev().collect::<String>();
-        let lsb_value = lsb_bits.to_bool_iter().lsb0_into_u128();
+    #[case::u8(format!("{:08b}{:08b}", 1u8, 2u8), vec![1u8, 2u8])]
+    #[case::u16(format!("{:016b}{:016b}", 1u16, 2u16), vec![1u16, 2u16])]
+    #[case::u32(format!("{:032b}{:032b}", 1u32, 2u32), vec![1u32, 2u32])]
+    #[case::u64(format!("{:064b}{:064b}", 1u64, 2u64), vec![1u64, 2u64])]
+    #[case::u128(format!("{:0128b}{:0128b}", 1u128, 2u128), vec![1u128, 2u128])]
+    #[should_panic]
+    #[case::missing_bit(format!("{:08b}{:07b}", 1u8, 2u8), vec![1u8, 2u8])]
+    fn test_iter_from_bits<T: FromBits + PartialEq + std::fmt::Debug>(
+        #[case] bits: impl AsRef<str>,
+        #[case] mut expected: Vec<T>,
+    ) {
+        let msb_value = Vec::<T>::from_msb0(bits.to_bit_iter());
 
         assert_eq!(msb_value, expected);
+
+        let lsb_bits = bits.as_ref().chars().rev().collect::<String>();
+        let lsb_value = Vec::<T>::from_lsb0(lsb_bits.to_bit_iter());
+
+        expected.reverse();
+
         assert_eq!(lsb_value, expected);
+    }
+
+    #[rstest]
+    #[case(0u8, format!("{:08b}", 0u8))]
+    #[case(1u8, format!("{:08b}", 1u8))]
+    #[case(u8::MAX, format!("{:08b}", u8::MAX))]
+    #[case(0u16, format!("{:016b}", 0u16))]
+    #[case(1u16, format!("{:016b}", 1u16))]
+    #[case(u16::MAX, format!("{:016b}", u16::MAX))]
+    #[case(0u32, format!("{:032b}", 0u32))]
+    #[case(1u32, format!("{:032b}", 1u32))]
+    #[case(u32::MAX, format!("{:032b}", u32::MAX))]
+    #[case(0u64, format!("{:064b}", 0u64))]
+    #[case(1u64, format!("{:064b}", 1u64))]
+    #[case(u64::MAX, format!("{:064b}", u64::MAX))]
+    #[case(0u128, format!("{:0128b}", 0u128))]
+    #[case(1u128, format!("{:0128b}", 1u128))]
+    #[case(u128::MAX, format!("{:0128b}", u128::MAX))]
+    fn test_to_bits(#[case] value: impl ToBits + Copy, #[case] expected: impl AsRef<str>) {
+        let lsb0_bits = value.into_lsb0();
+        let msb0_bits = value.into_msb0();
+
+        let mut expected = expected.as_ref().to_bit_vec();
+
+        assert_eq!(msb0_bits, expected);
+
+        expected.reverse();
+
+        assert_eq!(lsb0_bits, expected);
+    }
+
+    #[rstest]
+    #[case(vec![1u8, 2u8], format!("{:08b}{:08b}", 1u8, 2u8))]
+    #[case(vec![1u16, 2u16], format!("{:016b}{:016b}", 1u16, 2u16))]
+    #[case(vec![1u32, 2u32], format!("{:032b}{:032b}", 1u32, 2u32))]
+    #[case(vec![1u64, 2u64], format!("{:064b}{:064b}", 1u64, 2u64))]
+    #[case(vec![1u128, 2u128], format!("{:0128b}{:0128b}", 1u128, 2u128))]
+    fn test_iter_to_bits<V: ToBits + Clone>(
+        #[case] mut values: Vec<V>,
+        #[case] expected: impl AsRef<str>,
+    ) {
+        let msb0_bits = values.clone().into_msb0();
+        let mut expected = expected.as_ref().to_bit_vec();
+
+        assert_eq!(msb0_bits, expected);
+
+        // Reverse order of values
+        values.reverse();
+        // Reverse order of bits, this also reverses the order of the values
+        expected.reverse();
+
+        let lsb0_bits = values.into_lsb0();
+
+        assert_eq!(lsb0_bits, expected);
     }
 }


### PR DESCRIPTION
Sorry, I somehow ended up bikeshedding this.

This PR improves our bitvec utils to be more generic, and include implementations for native uint types. I also introduced some macro impl blocks to reduce duplication. Now any iterator of any size uint can be converted into a bit iterator and vice versa.

With these utilities implemented, it gives me some ideas for improving the mpc-circuits API quite a bit. For another day..