### PR TITLE
Clean up builders

### DIFF
--- a/actors/actor-ot/src/config.rs
+++ b/actors/actor-ot/src/config.rs
@@ -4,12 +4,20 @@ use derive_builder::Builder;
 #[derive(Debug, Default, Builder)]
 pub struct OTActorSenderConfig {
     /// The ID of the sender
+    #[builder(setter(into))]
     pub(crate) id: String,
     /// The number of OTs to set up
     pub(crate) initial_count: usize,
     /// Whether the sender should commit to the OTs
     #[builder(default = "false", setter(custom))]
     pub(crate) committed: bool,
+}
+
+impl OTActorSenderConfig {
+    /// Creates a new builder for the OT sender actor configuration
+    pub fn builder() -> OTActorSenderConfigBuilder {
+        OTActorSenderConfigBuilder::default()
+    }
 }
 
 impl OTActorSenderConfigBuilder {
@@ -24,12 +32,20 @@ impl OTActorSenderConfigBuilder {
 #[derive(Debug, Default, Builder)]
 pub struct OTActorReceiverConfig {
     /// The ID of the receiver
+    #[builder(setter(into))]
     pub(crate) id: String,
     /// The number of OTs to setup
     pub(crate) initial_count: usize,
     /// Whether the receiver should expect the sender to commit to the OTs
     #[builder(default = "false", setter(custom))]
     pub(crate) committed: bool,
+}
+
+impl OTActorReceiverConfig {
+    /// Creates a new builder for the OT receiver actor configuration
+    pub fn builder() -> OTActorReceiverConfigBuilder {
+        OTActorReceiverConfigBuilder::default()
+    }
 }
 
 impl OTActorReceiverConfigBuilder {

--- a/actors/actor-ot/src/lib.rs
+++ b/actors/actor-ot/src/lib.rs
@@ -79,13 +79,13 @@ mod test {
 
     #[tokio::test]
     async fn test_ot_actor() {
-        let sender_config = OTActorSenderConfigBuilder::default()
-            .id("test".to_string())
+        let sender_config = OTActorSenderConfig::builder()
+            .id("test")
             .initial_count(10)
             .build()
             .unwrap();
-        let receiver_config = OTActorReceiverConfigBuilder::default()
-            .id("test".to_string())
+        let receiver_config = OTActorReceiverConfig::builder()
+            .id("test")
             .initial_count(10)
             .build()
             .unwrap();
@@ -115,13 +115,13 @@ mod test {
 
     #[tokio::test]
     async fn test_ot_actor_many_splits() {
-        let sender_config = OTActorSenderConfigBuilder::default()
-            .id("test".to_string())
+        let sender_config = OTActorSenderConfig::builder()
+            .id("test")
             .initial_count(100)
             .build()
             .unwrap();
-        let receiver_config = OTActorReceiverConfigBuilder::default()
-            .id("test".to_string())
+        let receiver_config = OTActorReceiverConfig::builder()
+            .id("test")
             .initial_count(100)
             .build()
             .unwrap();
@@ -154,14 +154,14 @@ mod test {
 
     #[tokio::test]
     async fn test_ot_actor_committed_ot() {
-        let sender_config = OTActorSenderConfigBuilder::default()
-            .id("test".to_string())
+        let sender_config = OTActorSenderConfig::builder()
+            .id("test")
             .initial_count(100)
             .committed()
             .build()
             .unwrap();
-        let receiver_config = OTActorReceiverConfigBuilder::default()
-            .id("test".to_string())
+        let receiver_config = OTActorReceiverConfig::builder()
+            .id("test")
             .initial_count(100)
             .committed()
             .build()

--- a/aead/src/aes_gcm/config.rs
+++ b/aead/src/aes_gcm/config.rs
@@ -12,12 +12,18 @@ pub enum Role {
 #[derive(Debug, Clone, Builder)]
 pub struct AesGcmConfig {
     /// The id of this instance
+    #[builder(setter(into))]
     id: String,
     /// The protocol role
     role: Role,
 }
 
 impl AesGcmConfig {
+    /// Creates a new builder for the AES-GCM configuration
+    pub fn builder() -> AesGcmConfigBuilder {
+        AesGcmConfigBuilder::default()
+    }
+
     /// Returns the id of this instance
     pub fn id(&self) -> &str {
         &self.id

--- a/aead/src/aes_gcm/mock.rs
+++ b/aead/src/aes_gcm/mock.rs
@@ -1,9 +1,9 @@
 //! Mock implementation of AES-GCM for testing purposes.
 
-use block_cipher::{BlockCipherConfigBuilder, MpcBlockCipher};
+use block_cipher::{BlockCipherConfig, MpcBlockCipher};
 use mpc_garble::{Decode, DecodePrivate, Execute, Memory, Prove, Verify, Vm};
 use mpc_share_conversion::conversion::recorder::Void;
-use tlsn_stream_cipher::{MpcStreamCipher, StreamCipherConfigBuilder};
+use tlsn_stream_cipher::{MpcStreamCipher, StreamCipherConfig};
 use tlsn_universal_hash::ghash::mock_ghash_pair;
 use utils_aio::duplex::DuplexChannel;
 
@@ -31,14 +31,14 @@ where
 {
     let block_cipher_id = format!("{}/block_cipher", id);
     let leader_block_cipher = MpcBlockCipher::new(
-        BlockCipherConfigBuilder::default()
+        BlockCipherConfig::builder()
             .id(block_cipher_id.clone())
             .build()
             .unwrap(),
         leader_vm.new_thread(&block_cipher_id).await.unwrap(),
     );
     let follower_block_cipher = MpcBlockCipher::new(
-        BlockCipherConfigBuilder::default()
+        BlockCipherConfig::builder()
             .id(block_cipher_id.clone())
             .build()
             .unwrap(),
@@ -47,7 +47,7 @@ where
 
     let stream_cipher_id = format!("{}/stream_cipher", id);
     let leader_stream_cipher = MpcStreamCipher::new(
-        StreamCipherConfigBuilder::default()
+        StreamCipherConfig::builder()
             .id(stream_cipher_id.clone())
             .build()
             .unwrap(),
@@ -57,7 +57,7 @@ where
             .unwrap(),
     );
     let follower_stream_cipher = MpcStreamCipher::new(
-        StreamCipherConfigBuilder::default()
+        StreamCipherConfig::builder()
             .id(stream_cipher_id.clone())
             .build()
             .unwrap(),

--- a/cipher/block-cipher/src/config.rs
+++ b/cipher/block-cipher/src/config.rs
@@ -4,5 +4,13 @@ use derive_builder::Builder;
 #[derive(Debug, Clone, Builder)]
 pub struct BlockCipherConfig {
     /// The ID of the block cipher
+    #[builder(setter(into))]
     pub(crate) id: String,
+}
+
+impl BlockCipherConfig {
+    /// Creates a new builder for the block cipher configuration
+    pub fn builder() -> BlockCipherConfigBuilder {
+        BlockCipherConfigBuilder::default()
+    }
 }

--- a/cipher/block-cipher/src/lib.rs
+++ b/cipher/block-cipher/src/lib.rs
@@ -86,15 +86,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_cipher_blind() {
-        let leader_config = BlockCipherConfigBuilder::default()
-            .id("test".to_string())
-            .build()
-            .unwrap();
-
-        let follower_config = BlockCipherConfigBuilder::default()
-            .id("test".to_string())
-            .build()
-            .unwrap();
+        let leader_config = BlockCipherConfig::builder().id("test").build().unwrap();
+        let follower_config = BlockCipherConfig::builder().id("test").build().unwrap();
 
         let key = [0u8; 16];
 
@@ -128,15 +121,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_cipher_share() {
-        let leader_config = BlockCipherConfigBuilder::default()
-            .id("test".to_string())
-            .build()
-            .unwrap();
-
-        let follower_config = BlockCipherConfigBuilder::default()
-            .id("test".to_string())
-            .build()
-            .unwrap();
+        let leader_config = BlockCipherConfig::builder().id("test").build().unwrap();
+        let follower_config = BlockCipherConfig::builder().id("test").build().unwrap();
 
         let key = [0u8; 16];
 

--- a/cipher/stream-cipher/src/config.rs
+++ b/cipher/stream-cipher/src/config.rs
@@ -9,14 +9,22 @@ use crate::CtrCircuit;
 #[derive(Debug, Clone, Builder)]
 pub struct StreamCipherConfig {
     /// The ID of the stream cipher.
+    #[builder(setter(into))]
     pub(crate) id: String,
     /// The start block counter value.
     #[builder(default = "2")]
     pub(crate) start_ctr: usize,
     /// Transcript ID used to determine the unique identifiers
     /// for the plaintext bytes during encryption and decryption.
-    #[builder(default = "\"transcript\".to_string()")]
+    #[builder(setter(into), default = "\"transcript\".to_string()")]
     pub(crate) transcript_id: String,
+}
+
+impl StreamCipherConfig {
+    /// Creates a new builder for the stream cipher configuration.
+    pub fn builder() -> StreamCipherConfigBuilder {
+        StreamCipherConfigBuilder::default()
+    }
 }
 
 pub(crate) struct KeyBlockConfig<C: CtrCircuit> {

--- a/cipher/stream-cipher/src/lib.rs
+++ b/cipher/stream-cipher/src/lib.rs
@@ -224,14 +224,14 @@ mod tests {
             .await
             .unwrap();
 
-        let leader_config = StreamCipherConfigBuilder::default()
-            .id("test".to_string())
+        let leader_config = StreamCipherConfig::builder()
+            .id("test")
             .start_ctr(start_ctr)
             .build()
             .unwrap();
 
-        let follower_config = StreamCipherConfigBuilder::default()
-            .id("test".to_string())
+        let follower_config = StreamCipherConfig::builder()
+            .id("test")
             .start_ctr(start_ctr)
             .build()
             .unwrap();

--- a/key-exchange/src/config.rs
+++ b/key-exchange/src/config.rs
@@ -14,12 +14,18 @@ pub enum Role {
 #[derive(Debug, Clone, Builder)]
 pub struct KeyExchangeConfig {
     /// The id of this instance
+    #[builder(setter(into))]
     id: String,
     /// Protocol role
     role: Role,
 }
 
 impl KeyExchangeConfig {
+    /// Creates a new builder for the key exchange configuration
+    pub fn builder() -> KeyExchangeConfigBuilder {
+        KeyExchangeConfigBuilder::default()
+    }
+
     /// Get the id of this instance
     pub fn id(&self) -> &str {
         &self.id

--- a/key-exchange/src/exchange.rs
+++ b/key-exchange/src/exchange.rs
@@ -273,6 +273,7 @@ mod tests {
         let (mut leader_vm, mut follower_vm) = create_mock_deap_vm("test").await;
         (
             create_mock_key_exchange_pair(
+                "test",
                 leader_vm.new_thread("ke").await.unwrap(),
                 follower_vm.new_thread("ke").await.unwrap(),
             ),

--- a/key-exchange/src/mock.rs
+++ b/key-exchange/src/mock.rs
@@ -1,7 +1,7 @@
 //! This module provides mock types for key exchange leader and follower and a function to create
 //! such a pair
 
-use crate::{config::KeyExchangeConfigBuilder, KeyExchangeCore, KeyExchangeMessage, Role};
+use crate::{KeyExchangeConfig, KeyExchangeCore, KeyExchangeMessage, Role};
 
 use mpc_garble::{Decode, Execute, Memory};
 use point_addition::mock::{
@@ -15,6 +15,7 @@ pub type MockKeyExchange<E> =
 
 /// Create a mock pair of key exchange leader and follower
 pub fn create_mock_key_exchange_pair<E: Memory + Execute + Decode + Send>(
+    id: &str,
     leader_executor: E,
     follower_executor: E,
 ) -> (MockKeyExchange<E>, MockKeyExchange<E>) {
@@ -23,14 +24,14 @@ pub fn create_mock_key_exchange_pair<E: Memory + Execute + Decode + Send>(
 
     let (leader_channel, follower_channel) = DuplexChannel::<KeyExchangeMessage>::new();
 
-    let key_exchange_config_leader = KeyExchangeConfigBuilder::default()
-        .id(String::from(""))
+    let key_exchange_config_leader = KeyExchangeConfig::builder()
+        .id(id)
         .role(Role::Leader)
         .build()
         .unwrap();
 
-    let key_exchange_config_follower = KeyExchangeConfigBuilder::default()
-        .id(String::from(""))
+    let key_exchange_config_follower = KeyExchangeConfig::builder()
+        .id(id)
         .role(Role::Follower)
         .build()
         .unwrap();

--- a/mpc/garble/mpc-garble/src/evaluator/config.rs
+++ b/mpc/garble/mpc-garble/src/evaluator/config.rs
@@ -17,6 +17,13 @@ pub struct EvaluatorConfig {
     pub(crate) batch_size: usize,
 }
 
+impl EvaluatorConfig {
+    /// Creates a new builder for the evaluator configuration.
+    pub fn builder() -> EvaluatorConfigBuilder {
+        EvaluatorConfigBuilder::default()
+    }
+}
+
 impl EvaluatorConfigBuilder {
     /// Enable encoding commitments.
     pub fn encoding_commitments(&mut self) -> &mut Self {

--- a/mpc/garble/mpc-garble/src/generator/config.rs
+++ b/mpc/garble/mpc-garble/src/generator/config.rs
@@ -11,6 +11,13 @@ pub struct GeneratorConfig {
     pub(crate) batch_size: usize,
 }
 
+impl GeneratorConfig {
+    /// Creates a new builder for the generator configuration.
+    pub fn builder() -> GeneratorConfigBuilder {
+        GeneratorConfigBuilder::default()
+    }
+}
+
 impl GeneratorConfigBuilder {
     /// Enable encoding commitments.
     pub fn encoding_commitments(&mut self) -> &mut Self {

--- a/mpc/ot/mpc-ot-core/src/config.rs
+++ b/mpc/ot/mpc-ot-core/src/config.rs
@@ -5,7 +5,21 @@ pub struct OTSenderConfig {
     pub count: usize,
 }
 
+impl OTSenderConfig {
+    /// Creates a new builder for the OT sender configuration
+    pub fn builder() -> OTSenderConfigBuilder {
+        OTSenderConfigBuilder::default()
+    }
+}
+
 #[derive(Debug, Clone, Builder)]
 pub struct OTReceiverConfig {
     pub count: usize,
+}
+
+impl OTReceiverConfig {
+    /// Creates a new builder for the OT receiver configuration
+    pub fn builder() -> OTReceiverConfigBuilder {
+        OTReceiverConfigBuilder::default()
+    }
 }

--- a/universal-hash/src/ghash/ghash/config.rs
+++ b/universal-hash/src/ghash/ghash/config.rs
@@ -9,3 +9,10 @@ pub struct GhashConfig {
     #[builder(default = "1024")]
     pub max_block_count: usize,
 }
+
+impl GhashConfig {
+    /// Creates a new builder for the ghash configuration
+    pub fn builder() -> GhashConfigBuilder {
+        GhashConfigBuilder::default()
+    }
+}


### PR DESCRIPTION
This PR just does some tidying on config builders.

# Changes
- Use `builder(setter(into))` for string fields
- Add `XConfig::builder()` method for convience.