### PR TITLE
OT reveal trigger

### DIFF
--- a/actors/actor-ot/src/lib.rs
+++ b/actors/actor-ot/src/lib.rs
@@ -29,7 +29,7 @@ pub use config::{
 };
 pub use mpc_ot_core::msgs::OTMessage;
 pub(crate) use msg::{
-    GetReceiver, GetSender, MarkForReveal, Reveal, SendBackReceiver, SendBackSender, Setup, Verify,
+    GetReceiver, GetSender, Reveal, SendBackReceiver, SendBackSender, Setup, Verify,
 };
 pub use receiver::{KOSReceiverActor, ReceiverActorControl};
 pub use sender::{KOSSenderActor, SenderActorControl};
@@ -178,10 +178,7 @@ mod test {
 
         let receive = async { receiver_control.receive("", choices).await.map(|_| ()) };
 
-        let reveal = async {
-            sender_control.mark_for_reveal("").await.unwrap();
-            sender_control.reveal().await
-        };
+        let reveal = sender_control.reveal();
 
         let verify = async { receiver_control.verify("", data.clone()).await.map(|_| ()) };
 

--- a/actors/actor-ot/src/msg.rs
+++ b/actors/actor-ot/src/msg.rs
@@ -17,8 +17,6 @@ pub(crate) struct GetReceiver {
     pub(crate) count: usize,
 }
 
-pub(crate) struct MarkForReveal(pub(crate) String);
-
 pub(crate) struct Reveal;
 
 pub(crate) struct SendBackSender {

--- a/mpc/ot/mpc-ot/src/lib.rs
+++ b/mpc/ot/mpc-ot/src/lib.rs
@@ -50,7 +50,6 @@ pub trait ObliviousSend<T> {
 #[async_trait]
 pub trait ObliviousReveal {
     async fn reveal(&self) -> Result<(), OTError>;
-    async fn mark_for_reveal(&self, id: &str) -> Result<(), OTError>;
 }
 
 #[async_trait]

--- a/mpc/ot/mpc-ot/src/mock/borrowed.rs
+++ b/mpc/ot/mpc-ot/src/mock/borrowed.rs
@@ -52,10 +52,6 @@ impl<T: Send> ObliviousReveal for MockOTSender<T> {
     async fn reveal(&self) -> Result<(), OTError> {
         Ok(())
     }
-
-    async fn mark_for_reveal(&self, _id: &str) -> Result<(), OTError> {
-        Ok(())
-    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This PR modifies our OT Sender actor to trigger the reveal of every OT at once, removing the "MarkForReveal" functionality.

Synchronization can be managed in the outer context, rather than putting the responsibility on dependent protocols to indicate when they are ready. With this approach the caller of `sender.reveal()` must know when its time to reveal everything.