### PR TITLE
Mock OT typecasting

### DIFF
--- a/mpc/garble/mpc-garble/src/protocol/deap/mock.rs
+++ b/mpc/garble/mpc-garble/src/protocol/deap/mock.rs
@@ -1,6 +1,5 @@
 //! Mocked DEAP VMs for testing
 
-use mpc_core::Block;
 use mpc_ot::mock::{mock_ot_pair, MockOTReceiver, MockOTSender};
 use utils_aio::mux::{mock::MockMuxChannelFactory, MuxChannelControl};
 
@@ -9,20 +8,20 @@ use crate::config::Role;
 use super::{vm::DEAPVm, DEAPThread};
 
 /// Mock DEAP Leader VM.
-pub type MockLeader = DEAPVm<MockOTSender<Block>, MockOTReceiver<Block>>;
+pub type MockLeader = DEAPVm<MockOTSender, MockOTReceiver>;
 /// Mock DEAP Leader thread.
-pub type MockLeaderThread = DEAPThread<MockOTSender<Block>, MockOTReceiver<Block>>;
+pub type MockLeaderThread = DEAPThread<MockOTSender, MockOTReceiver>;
 /// Mock DEAP Follower VM.
-pub type MockFollower = DEAPVm<MockOTSender<Block>, MockOTReceiver<Block>>;
+pub type MockFollower = DEAPVm<MockOTSender, MockOTReceiver>;
 /// Mock DEAP Follower thread.
-pub type MockFollowerThread = DEAPThread<MockOTSender<Block>, MockOTReceiver<Block>>;
+pub type MockFollowerThread = DEAPThread<MockOTSender, MockOTReceiver>;
 
 /// Create a pair of mocked DEAP VMs
 pub async fn create_mock_deap_vm(
     id: &str,
 ) -> (
-    DEAPVm<MockOTSender<Block>, MockOTReceiver<Block>>,
-    DEAPVm<MockOTSender<Block>, MockOTReceiver<Block>>,
+    DEAPVm<MockOTSender, MockOTReceiver>,
+    DEAPVm<MockOTSender, MockOTReceiver>,
 ) {
     let mut mux_factory = MockMuxChannelFactory::new();
     let (leader_ot_send, follower_ot_recv) = mock_ot_pair();

--- a/mpc/share-conversion/mpc-share-conversion/src/mock.rs
+++ b/mpc/share-conversion/mpc-share-conversion/src/mock.rs
@@ -1,17 +1,14 @@
 //! Mocks for testing the share conversion protocol.
 
 use super::{ConverterReceiver, ConverterSender, ReceiverConfig, SenderConfig};
-use mpc_core::BlockSerialize;
 use mpc_ot::mock::{mock_ot_pair, MockOTReceiver, MockOTSender};
 use mpc_share_conversion_core::fields::Field;
 use utils_aio::duplex::DuplexChannel;
 
 /// A mock converter sender
-pub type MockConverterSender<F> =
-    ConverterSender<F, MockOTSender<<F as BlockSerialize>::Serialized>>;
+pub type MockConverterSender<F> = ConverterSender<F, MockOTSender>;
 /// A mock converter receiver
-pub type MockConverterReceiver<F> =
-    ConverterReceiver<F, MockOTReceiver<<F as BlockSerialize>::Serialized>>;
+pub type MockConverterReceiver<F> = ConverterReceiver<F, MockOTReceiver>;
 
 /// Creates a mock sender and receiver for testing the share conversion protocol.
 #[allow(clippy::type_complexity)]
@@ -19,8 +16,8 @@ pub fn mock_converter_pair<F: Field>(
     sender_config: SenderConfig,
     receiver_config: ReceiverConfig,
 ) -> (
-    ConverterSender<F, MockOTSender<<F as BlockSerialize>::Serialized>>,
-    ConverterReceiver<F, MockOTReceiver<<F as BlockSerialize>::Serialized>>,
+    ConverterSender<F, MockOTSender>,
+    ConverterReceiver<F, MockOTReceiver>,
 ) {
     let (c1, c2) = DuplexChannel::new();
 


### PR DESCRIPTION
This PR removes the generic from our Mock OT and uses downcasting of `dyn Any` so that a mock pair can support transferring any value type.