### PR TITLE
Canonical serialize trait

### DIFF
--- a/mpc/mpc-core/src/lib.rs
+++ b/mpc/mpc-core/src/lib.rs
@@ -5,6 +5,7 @@
 mod block;
 pub mod commit;
 pub mod hash;
+pub mod serialize;
 pub mod utils;
 pub mod value;
 

--- a/mpc/mpc-core/src/serialize.rs
+++ b/mpc/mpc-core/src/serialize.rs
@@ -1,0 +1,14 @@
+//! Traits for canonical serialization of serde serializable types.
+
+/// A trait for canonical serialization of serde serializable types.
+///
+/// This trait provides a default implementation which uses
+/// [Binary Canonical Serialization (BCS)](https://docs.rs/bcs/latest/bcs/).
+pub trait CanonicalSerialize: serde::Serialize {
+    /// Serializes self into a byte vector
+    fn to_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(self).expect("serialization should not fail")
+    }
+}
+
+impl<T> CanonicalSerialize for T where T: serde::Serialize {}


### PR DESCRIPTION
This PR adds the `CanonicalSerialize` trait to `mpc-core`, this is more of a refactor than a new feature as we already use this for hashing. This just provides more flexibility to use with other things, eg signatures.