### PR TITLE
fix deadlock, removing tokio codec

### DIFF
--- a/uid-mux/Cargo.toml
+++ b/uid-mux/Cargo.toml
@@ -6,14 +6,13 @@ edition = "2021"
 [dependencies]
 tlsn-utils-aio = { path = "../utils/utils-aio" }
 
-bytes = "1.4"
 async-trait = "0.1"
 futures = "0.3"
 tokio = { version = "1.23", features = ["time"] }
-tokio-util = { version = "0.7", features = ["compat"] }
 yamux = "0.11"
 
 [dev-dependencies]
+tokio-util = { version = "0.7", features = ["compat"] }
 tokio = { version = "1.23", features = [
     "macros",
     "io-util",


### PR DESCRIPTION
This PR fixes a deadlock issue in `uid-mux`.

The current implementation uses `LengthDelimitedCodec` for transmitting the unique `stream_id` to the mux peer. The issue is that `LengthDelimitedCodec` performs internal buffering which is dropped when the stream is pulled back out of the codec before returning it to the caller. This data loss causes a deadlock.

I've replaced the codec with a simple manual impl of length delimited framing for the `stream_id`.