### PR TITLE
Recursively enable tracing

### DIFF
--- a/components/aead/Cargo.toml
+++ b/components/aead/Cargo.toml
@@ -14,7 +14,7 @@ name = "aead"
 [features]
 default = ["mock"]
 mock = []
-tracing = ["dep:tracing"]
+tracing = ["dep:tracing", "tlsn-block-cipher/tracing", "tlsn-stream-cipher/tracing", "tlsn-universal-hash/tracing"]
 
 [dependencies]
 tlsn-block-cipher = { path = "../cipher/block-cipher" }

--- a/components/key-exchange/Cargo.toml
+++ b/components/key-exchange/Cargo.toml
@@ -13,7 +13,7 @@ name = "key_exchange"
 
 [features]
 default = ["mock"]
-tracing = ["dep:tracing"]
+tracing = ["dep:tracing", "tlsn-point-addition/tracing"]
 mock = []
 
 [dependencies]

--- a/components/prf/hmac-sha256/Cargo.toml
+++ b/components/prf/hmac-sha256/Cargo.toml
@@ -13,7 +13,7 @@ name = "hmac_sha256"
 
 [features]
 default = ["mock"]
-tracing = ["dep:tracing"]
+tracing = ["dep:tracing", "tlsn-hmac-sha256-circuits/tracing"]
 mock = []
 
 [dependencies]

--- a/components/tls/tls-mpc/Cargo.toml
+++ b/components/tls/tls-mpc/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 name = "tls_mpc"
 
 [features]
-tracing = ["dep:tracing"]
+tracing = ["dep:tracing", "tlsn-block-cipher/tracing", "tlsn-stream-cipher/tracing", "tlsn-universal-hash/tracing", "tlsn-aead/tracing", "tlsn-key-exchange/tracing", "tlsn-point-addition/tracing", "tlsn-hmac-sha256/tracing", "tlsn-tls-client-async/tracing", "uid-mux/tracing"]
 
 [dependencies]
 tlsn-tls-core = { path = "../tls-core", features = ["serde"] }

--- a/tlsn/tlsn-notary/Cargo.toml
+++ b/tlsn/tlsn-notary/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-tracing = ["dep:tracing"]
+tracing = ["dep:tracing", "tlsn-tls-mpc/tracing"]
 
 [dependencies]
 tlsn-core.workspace = true

--- a/tlsn/tlsn-prover/Cargo.toml
+++ b/tlsn/tlsn-prover/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-tracing = ["dep:tracing"]
+tracing = ["dep:tracing", "tlsn-tls-client-async/tracing", "tlsn-core/tracing", "tlsn-tls-mpc/tracing", "uid-mux/tracing"]
 
 [dependencies]
 tlsn-tls-core.workspace = true


### PR DESCRIPTION
This PR recursively enables tracing, i.e. if someone enables tracing in e.g. the `tlsn-prover` library, this also enables tracing for all other tlsn dependencies on which `tlsn-prover` depends. This PR closes #259.