### PR TITLE
Tlsn verifier crate

### DIFF
--- a/tlsn/Cargo.toml
+++ b/tlsn/Cargo.toml
@@ -31,6 +31,7 @@ mpz-garble = { git = "https://github.com/privacy-scaling-explorations/mpz", rev 
 mpz-ot = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "a98fd8a" }
 mpz-share-conversion = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "a98fd8a" }
 
+spansy = {git = "https://github.com/sinui0/spansy", rev = "23a6b0a"}
 
 futures = "0.3"
 tokio-util = "0.7"

--- a/tlsn/tlsn-verifier/Cargo.toml
+++ b/tlsn/tlsn-verifier/Cargo.toml
@@ -17,6 +17,8 @@ tlsn-utils.workspace = true
 
 mpz-core.workspace = true
 
+spansy.workspace = true
+
 webpki-roots.workspace = true
 p256.workspace = true
 thiserror.workspace = true

--- a/tlsn/tlsn-verifier/src/assert.rs
+++ b/tlsn/tlsn-verifier/src/assert.rs
@@ -1,0 +1,3 @@
+pub struct VerifiedTranscript {
+    pub(crate) data: Vec<u8>,
+}


### PR DESCRIPTION
This PR turns the `simple_verifier` example code into a library crate, which simplifies dealing with verification and allows to be compiled to wasm.