### PR TITLE
fix: bump GHASH default max block length to 1026

### DIFF
--- a/components/universal-hash/src/ghash/ghash_inner/config.rs
+++ b/components/universal-hash/src/ghash/ghash_inner/config.rs
@@ -7,10 +7,10 @@ pub struct GhashConfig {
     #[builder(setter(into))]
     pub id: String,
     /// Initial number of block shares to provision
-    #[builder(default = "1024")]
+    #[builder(default = "1026")]
     pub initial_block_count: usize,
     /// Maximum number of blocks supported
-    #[builder(default = "1024")]
+    #[builder(default = "1026")]
     pub max_block_count: usize,
 }
 


### PR DESCRIPTION
See #312 