### PR TITLE
fix: enable tlsn-prover logs in examples, and reduce log noise

### DIFF
--- a/components/aead/src/aes_gcm/mod.rs
+++ b/components/aead/src/aes_gcm/mod.rs
@@ -101,7 +101,7 @@ impl MpcAesGcm {
         Ok(AesGcmTagShare(tag_share))
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "debug", err, ret))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", err, ret))]
     async fn compute_tag(
         &mut self,
         explicit_nonce: Vec<u8>,
@@ -184,7 +184,7 @@ impl Aead for MpcAesGcm {
         self.aes_ctr.set_transcript_id(id)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "info", err, ret))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", err, ret))]
     async fn encrypt_public(
         &mut self,
         explicit_nonce: Vec<u8>,
@@ -206,7 +206,7 @@ impl Aead for MpcAesGcm {
         Ok(payload)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "info", err, ret))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", err, ret))]
     async fn encrypt_private(
         &mut self,
         explicit_nonce: Vec<u8>,
@@ -228,7 +228,7 @@ impl Aead for MpcAesGcm {
         Ok(payload)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "info", err, ret))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", err, ret))]
     async fn encrypt_blind(
         &mut self,
         explicit_nonce: Vec<u8>,
@@ -250,7 +250,7 @@ impl Aead for MpcAesGcm {
         Ok(payload)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "info", err, ret))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", err, ret))]
     async fn decrypt_public(
         &mut self,
         explicit_nonce: Vec<u8>,
@@ -274,7 +274,7 @@ impl Aead for MpcAesGcm {
             .await
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "info", err, ret))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", err, ret))]
     async fn decrypt_private(
         &mut self,
         explicit_nonce: Vec<u8>,
@@ -298,7 +298,7 @@ impl Aead for MpcAesGcm {
             .await
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "info", err, ret))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", err, ret))]
     async fn decrypt_blind(
         &mut self,
         explicit_nonce: Vec<u8>,

--- a/components/tls/tls-mpc/src/setup.rs
+++ b/components/tls/tls-mpc/src/setup.rs
@@ -18,7 +18,7 @@ use crate::{config::MpcTlsCommonConfig, MpcTlsError, TlsRole};
 #[allow(clippy::type_complexity)]
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(level = "info", skip(mux, vm, p256_send, p256_recv, gf), err)
+    tracing::instrument(level = "info", skip_all, err)
 )]
 pub async fn setup_components<
     M: MuxChannel<ke::KeyExchangeMessage> + MuxChannel<aead::AeadMessage> + Clone,

--- a/components/universal-hash/src/ghash/ghash_core/core.rs
+++ b/components/universal-hash/src/ghash/ghash_core/core.rs
@@ -104,7 +104,7 @@ impl GhashCore<Finalized> {
     /// Generate the GHASH output
     ///
     /// Computes the 2PC additive share of the GHASH output
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "debug", err, ret))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", err, ret))]
     pub(crate) fn finalize(&self, message: &[Block]) -> Result<Block, GhashError> {
         if message.len() > self.max_block_count {
             return Err(GhashError::InvalidMessageLength);

--- a/components/universal-hash/src/ghash/ghash_inner/mod.rs
+++ b/components/universal-hash/src/ghash/ghash_inner/mod.rs
@@ -107,7 +107,7 @@ where
 
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(level = "info", skip(input), err)
+        tracing::instrument(level = "info", skip_all, err)
     )]
     async fn finalize(&mut self, mut input: Vec<u8>) -> Result<Vec<u8>, UniversalHashError> {
         // Divide by block length and round up

--- a/tlsn/examples/Cargo.toml
+++ b/tlsn/examples/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 publish = false
 
 [dev-dependencies]
-tlsn-prover.workspace = true
+tlsn-prover = { workspace = true, features = ["tracing"] }
 tlsn-notary.workspace = true
 tlsn-core.workspace = true
 tlsn-tls-core.workspace = true
 tlsn-tls-client.workspace = true
-notary-server = {version = "0.1.0", git = "https://github.com/tlsnotary/notary-server" }
+notary-server = { version = "0.1.0", git = "https://github.com/tlsnotary/notary-server" }
 mpz-core.workspace = true
 
 futures.workspace = true
@@ -30,7 +30,7 @@ tracing-subscriber.workspace = true
 hyper = { version = "0.14", features = ["client", "http1"] }
 
 p256 = { workspace = true, features = ["ecdsa"] }
-elliptic-curve = { version = "0.13.5", features = ["pkcs8"]}
+elliptic-curve = { version = "0.13.5", features = ["pkcs8"] }
 webpki-roots.workspace = true
 
 async-tls = { version = "0.12", default-features = false, features = [

--- a/tlsn/tlsn-prover/src/lib.rs
+++ b/tlsn/tlsn-prover/src/lib.rs
@@ -60,7 +60,7 @@ use tracing::{debug, debug_span, instrument, Instrument};
 #[allow(clippy::type_complexity)]
 #[cfg_attr(
     feature = "tracing",
-    instrument(level = "info", skip(client_socket, notary_socket), err)
+    instrument(level = "info", skip(config, client_socket, notary_socket), err)
 )]
 pub async fn bind_prover<
     S: AsyncWrite + AsyncRead + Send + Unpin + 'static,
@@ -381,7 +381,7 @@ where
     }
 }
 
-#[cfg_attr(feature = "tracing", instrument(level = "debug", skip(mux), err))]
+#[cfg_attr(feature = "tracing", instrument(level = "debug", skip_all, err))]
 #[allow(clippy::type_complexity)]
 async fn setup_mpc_backend<M: MuxChannelSerde + Clone + Send + 'static>(
     config: &ProverConfig,


### PR DESCRIPTION
This PR enables prover logs when running examples, and I also reduced the noise of logging in various components.