### PR TITLE
refactor: factor out generic from prover and notary

### DIFF
--- a/tlsn/Cargo.toml
+++ b/tlsn/Cargo.toml
@@ -49,6 +49,7 @@ thiserror = "1"
 serde = "1"
 bincode = "1"
 hex = "0.4"
+opaque-debug = "0.3"
 
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/tlsn/tlsn-prover/Cargo.toml
+++ b/tlsn/tlsn-prover/Cargo.toml
@@ -37,5 +37,6 @@ futures.workspace = true
 thiserror.workspace = true
 webpki-roots.workspace = true
 derive_builder.workspace = true
+opaque-debug.workspace = true
 
 tracing = { workspace = true, optional = true }

--- a/tlsn/tlsn-prover/src/state.rs
+++ b/tlsn/tlsn-prover/src/state.rs
@@ -10,18 +10,19 @@ use mpz_share_conversion::{ConverterSender, Gf2_128};
 use tls_core::{dns::ServerName, handshake::HandshakeData, key::PublicKey};
 use tlsn_core::{SubstringsCommitment, Transcript};
 
-use crate::ProverError;
+use crate::{Mux, ProverError};
 
 /// The state for the initialized [Prover](crate::Prover)
-#[derive(Debug)]
-pub struct Initialized<T> {
+pub struct Initialized {
     pub(crate) server_name: ServerName,
-    pub(crate) notary_mux: T,
+    pub(crate) notary_mux: Mux,
 }
 
+opaque_debug::implement!(Initialized);
+
 /// The state for the [Prover](crate::Prover) during notarization
-pub struct Notarize<T> {
-    pub(crate) notary_mux: T,
+pub struct Notarize {
+    pub(crate) notary_mux: Mux,
 
     pub(crate) vm: DEAPVm<SharedSender, SharedReceiver>,
     pub(crate) ot_fut: Pin<Box<dyn FusedFuture<Output = Result<(), ProverError>> + Send + 'static>>,
@@ -38,23 +39,16 @@ pub struct Notarize<T> {
     pub(crate) substring_commitments: Vec<SubstringsCommitment>,
 }
 
-impl<T> std::fmt::Debug for Notarize<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Notarizing")
-            .field("transcript_tx", &self.transcript_tx)
-            .field("transcript_rx", &self.transcript_rx)
-            .finish()
-    }
-}
+opaque_debug::implement!(Notarize);
 
 #[allow(missing_docs)]
 pub trait ProverState: sealed::Sealed {}
 
-impl<T> ProverState for Initialized<T> {}
-impl<T> ProverState for Notarize<T> {}
+impl ProverState for Initialized {}
+impl ProverState for Notarize {}
 
 mod sealed {
     pub trait Sealed {}
-    impl<T> Sealed for super::Initialized<T> {}
-    impl<T> Sealed for super::Notarize<T> {}
+    impl Sealed for super::Initialized {}
+    impl Sealed for super::Notarize {}
 }


### PR DESCRIPTION
This PR simply factors out the generic over multiplexer in the prover and notary, and impls opaque_debug on state while I was in there.

This couples them to both `bincode` and `yamux`, but this is fine for now. If we want to support other formats and/or muxers we can add that as a feature later.