### PR TITLE
fix: remove close_notify guard

### DIFF
--- a/tlsn/tlsn-prover/src/lib.rs
+++ b/tlsn/tlsn-prover/src/lib.rs
@@ -173,17 +173,6 @@ impl Prover<Setup> {
                     _ = mux_fut => return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
                 };
 
-                // Extra guard to guarantee that the server sent a close_notify.
-                //
-                // DO NOT REMOVE!
-                //
-                // This is necessary, as our protocol reveals the MAC key to the Notary afterwards
-                // which could be used to authenticate modified TLS records if the Notary is
-                // in the middle of the connection.
-                if !client.received_close_notify() {
-                    return Err(ProverError::ServerNoCloseNotify);
-                }
-
                 let backend = client
                     .backend_mut()
                     .as_any_mut()


### PR DESCRIPTION
This PR removes the expectation for a TLS server to send close_notify. Most of the servers don't send it anyway (tested with https://github.com/themighty1/rustls/blob/1ffbf848789bd233c4f36a7b3f04fc31912c4371/examples/src/bin/simpleclient.rs#L57)
Additionally, we will be changing our protocol (the exact approach is tbd) so there will be no need to reveal the MAC key to the Notary.