### PR TITLE
Publish rustdoc to docs folder

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,40 @@
+name: Rust
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  rustdoc:
+    if: ( ! github.event.pull_request.draft )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain (Stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: "rustdoc"
+        run: cd tlsn; cargo doc -p tlsn-core -p tlsn-prover -p tlsn-notary --no-deps --all-features
+        # --target-dir ${GITHUB_WORKSPACE}/docs
+
+      # https://dev.to/deciduously/prepare-your-rust-api-docs-for-github-pages-2n5i
+      - name: "Add index file -> tlsn_prover"
+        run: |
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=tlsn_prover\">" > tlsn/target/doc/index.html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/dev' }}
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            publish_dir: tlsn/target/doc/
+            # cname: rustdocs.tlsnotary.org

--- a/tlsn/examples/Cargo.toml
+++ b/tlsn/examples/Cargo.toml
@@ -10,7 +10,7 @@ tlsn-notary.workspace = true
 tlsn-core.workspace = true
 tlsn-tls-core.workspace = true
 tlsn-tls-client.workspace = true
-notary-server = { version = "0.1.0", git = "https://github.com/tlsnotary/notary-server" }
+notary-server = { version = "0.1.0-alpha.1", git = "https://github.com/tlsnotary/notary-server" }
 mpz-core.workspace = true
 
 futures.workspace = true


### PR DESCRIPTION
This PR builds `rustdoc` for the `dev` branch and publishes the result to the `gh-pages` branch.

Preview at <https://tlsnotary.github.io/tlsn/>