### PR TITLE
Fix PRF benchmark

### DIFF
--- a/components/prf/hmac-sha256/benches/prf.rs
+++ b/components/prf/hmac-sha256/benches/prf.rs
@@ -9,6 +9,8 @@ async fn bench_prf() {
     let mut leader = MpcPrf::new(leader_vm.new_thread("bench_thread").await.unwrap());
     let mut follower = MpcPrf::new(follower_vm.new_thread("bench_thread").await.unwrap());
 
+    futures::try_join!(leader.setup(), follower.setup()).unwrap();
+
     let pms = [42u8; 32];
 
     let client_random = [0u8; 32];


### PR DESCRIPTION
## Issue

https://github.com/tlsnotary/tlsn/issues/348

## Error

when call `cargo bench` at `./components/prf/hmac-sha256`, panicked with these messages:
```
Benchmarking prf/prf: Warming up for 3.0000 sthread 'main' panicked at hmac-sha256/benches/prf.rs:29:6:
called `Result::unwrap()` on an `Err` value: InvalidState(Initialized)
```

## Cause

The error caused since the state was still `Initialized`.

In the commit https://github.com/tlsnotary/tlsn/commit/329858b0fd25fed8928ebab622d5390253737de0 , we separated the building session keys as setup() function. So, we must call the method `setup()` before calling each `compute_xx()` methods.

## What I did on this PR

added this line

```diff
    let mut leader = MpcPrf::new(leader_vm.new_thread("bench_thread").await.unwrap());
    let mut follower = MpcPrf::new(follower_vm.new_thread("bench_thread").await.unwrap());

+    futures::try_join!(leader.setup(), follower.setup()).unwrap();

    let pms = [42u8; 32];
```

## How to review

1. call `cargo bench` at `./components/prf/hmac-sha256`.
2. make sure bench works.

