### PR TITLE
Modify notary url parsing to make it generic for both ip and domain

### DIFF
--- a/notary-server/README.md
+++ b/notary-server/README.md
@@ -38,6 +38,7 @@ docker run --init -p 127.0.0.1:7047:7047 ghcr.io/tlsnotary/tlsn/notary-server:la
 ```bash
 docker run --init -p 127.0.0.1:7047:7047 -v <your config folder path>:/root/.notary-server/config ghcr.io/tlsnotary/tlsn/notary-server:latest
 ```
+P/S: When running this notary-server image against a [prover](https://github.com/tlsnotary/tlsn/tree/dev/tlsn/examples), please ensure that the prover's tagged version is the same as the version tag of this image.
 
 #### Building from source
 1. Configure the server setting in this config [file](./config/config.yaml).

--- a/notary-server/README.md
+++ b/notary-server/README.md
@@ -38,7 +38,7 @@ docker run --init -p 127.0.0.1:7047:7047 ghcr.io/tlsnotary/tlsn/notary-server:la
 ```bash
 docker run --init -p 127.0.0.1:7047:7047 -v <your config folder path>:/root/.notary-server/config ghcr.io/tlsnotary/tlsn/notary-server:latest
 ```
-P/S: When running this notary-server image against a [prover](https://github.com/tlsnotary/tlsn/tree/dev/tlsn/examples), please ensure that the prover's tagged version is the same as the version tag of this image.
+P/S: When running this notary-server image against a [prover](https://github.com/tlsnotary/tlsn/tree/3e0dcc77d5b8b7d6739ca725f36345108ebecd75/tlsn/examples), please ensure that the prover's tagged version is the same as the version tag of this image.
 
 #### Building from source
 1. Configure the server setting in this config [file](./config/config.yaml).

--- a/tlsn/examples/discord/discord_dm.rs
+++ b/tlsn/examples/discord/discord_dm.rs
@@ -6,14 +6,7 @@ use futures::AsyncWriteExt;
 use hyper::{body::to_bytes, client::conn::Parts, Body, Request, StatusCode};
 use rustls::{Certificate, ClientConfig, RootCertStore};
 use serde::{Deserialize, Serialize};
-use std::{
-    env,
-    fs::File as StdFile,
-    io::BufReader,
-    net::{IpAddr, SocketAddr},
-    ops::Range,
-    sync::Arc,
-};
+use std::{env, fs::File as StdFile, io::BufReader, ops::Range, sync::Arc};
 use tlsn_core::proof::TlsProof;
 use tokio::{fs::File, io::AsyncWriteExt as _, net::TcpStream};
 use tokio_rustls::TlsConnector;
@@ -221,12 +214,9 @@ async fn setup_notary_connection() -> (tokio_rustls::client::TlsStream<TcpStream
         .with_no_client_auth();
     let notary_connector = TlsConnector::from(Arc::new(client_notary_config));
 
-    let notary_socket = tokio::net::TcpStream::connect(SocketAddr::new(
-        IpAddr::V4(NOTARY_HOST.parse().unwrap()),
-        NOTARY_PORT,
-    ))
-    .await
-    .unwrap();
+    let notary_socket = tokio::net::TcpStream::connect((NOTARY_HOST, NOTARY_PORT))
+        .await
+        .unwrap();
 
     let notary_tls_socket = notary_connector
         // Require the domain name of notary server to be the same as that in the server cert

--- a/tlsn/examples/twitter/twitter_dm.rs
+++ b/tlsn/examples/twitter/twitter_dm.rs
@@ -6,14 +6,7 @@ use futures::AsyncWriteExt;
 use hyper::{body::to_bytes, client::conn::Parts, Body, Request, StatusCode};
 use rustls::{Certificate, ClientConfig, RootCertStore};
 use serde::{Deserialize, Serialize};
-use std::{
-    env,
-    fs::File as StdFile,
-    io::BufReader,
-    net::{IpAddr, SocketAddr},
-    ops::Range,
-    sync::Arc,
-};
+use std::{env, fs::File as StdFile, io::BufReader, ops::Range, sync::Arc};
 use tokio::{fs::File, io::AsyncWriteExt as _, net::TcpStream};
 use tokio_rustls::TlsConnector;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
@@ -210,12 +203,9 @@ async fn setup_notary_connection() -> (tokio_rustls::client::TlsStream<TcpStream
         .with_no_client_auth();
     let notary_connector = TlsConnector::from(Arc::new(client_notary_config));
 
-    let notary_socket = tokio::net::TcpStream::connect(SocketAddr::new(
-        IpAddr::V4(NOTARY_HOST.parse().unwrap()),
-        NOTARY_PORT,
-    ))
-    .await
-    .unwrap();
+    let notary_socket = tokio::net::TcpStream::connect((NOTARY_HOST, NOTARY_PORT))
+        .await
+        .unwrap();
 
     let notary_tls_socket = notary_connector
         // Require the domain name of notary server to be the same as that in the server cert


### PR DESCRIPTION
Make it generic to parse notary url in the prover example — so that we can just easily use ip address or domain name as the notary host 