### PR TITLE
`tlsn-formats`: fix error on duplicate headers

### DIFF
--- a/tlsn/tlsn-formats/src/http/commitment.rs
+++ b/tlsn/tlsn-formats/src/http/commitment.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use crate::http::{Body, BodyCommitmentBuilder, Request, Response};
-use spansy::{http::Header, Spanned};
+use spansy::Spanned;
 use tlsn_core::{
     commitment::{CommitmentId, TranscriptCommitmentBuilder, TranscriptCommitmentBuilderError},
     Direction,
@@ -156,13 +156,7 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
             .0
             .header(name)
             .ok_or(HttpCommitmentBuilderError::MissingHeader(name.to_string()))?;
-        self.header_internal(header)
-    }
 
-    fn header_internal(
-        &mut self,
-        header: &Header,
-    ) -> Result<CommitmentId, HttpCommitmentBuilderError> {
         let range = header.value.span().range();
         let id = self.builder.commit_sent(range.clone())?;
 
@@ -179,7 +173,7 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
 
         for header in &self.request.0.headers {
             let name = header.name.span().as_str().to_string();
-            let id = self.header_internal(header)?;
+            let id = self.header(&name)?;
 
             commitments.push((name, id));
         }
@@ -216,7 +210,7 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
 
             let range = header.value.span().range();
             if !range.is_subset(&self.committed) {
-                self.header_internal(header)?;
+                self.header(&name)?;
             }
         }
 
@@ -271,13 +265,7 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
             .0
             .header(name)
             .ok_or(HttpCommitmentBuilderError::MissingHeader(name.to_string()))?;
-        self.header_internal(header)
-    }
 
-    fn header_internal(
-        &mut self,
-        header: &Header,
-    ) -> Result<CommitmentId, HttpCommitmentBuilderError> {
         self.builder
             .commit_recv(header.value.span().range())
             .map_err(From::from)
@@ -291,7 +279,7 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
 
         for header in &self.response.0.headers {
             let name = header.name.span().as_str().to_string();
-            let id = self.header_internal(header)?;
+            let id = self.header(&name)?;
 
             commitments.push((name, id));
         }
@@ -327,7 +315,7 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
 
             let range = header.value.span().range();
             if !range.is_subset(&self.committed) {
-                self.header_internal(header)?;
+                self.header(&name)?;
             }
         }
 

--- a/tlsn/tlsn-formats/src/http/mod.rs
+++ b/tlsn/tlsn-formats/src/http/mod.rs
@@ -205,4 +205,45 @@ mod tests {
         assert_eq!(&recv.data()[25..43], b"very-secret-cookie");
         assert_eq!(&recv.data()[180..194], b"Hello World!!!");
     }
+
+    #[test]
+    fn test_http_commit_duplicate_headers() {
+        let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let rx: &[u8] = b"HTTP/1.1 200 OK\r\nSet-Cookie: lang=en; Path=/\r\n\
+        Set-Cookie: fang=fen; Path=/\r\n\r\n";
+        let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
+            fixtures::encoding_provider(tx, rx),
+            tx.len(),
+            rx.len(),
+        );
+
+        let requests = parse_requests(Bytes::copy_from_slice(TX)).unwrap();
+        let responses = parse_responses(Bytes::copy_from_slice(RX)).unwrap();
+
+        HttpCommitmentBuilder::new(&mut transcript_commitment_builder, &requests, &responses)
+            .build()
+            .unwrap();
+
+        // TODO: shoudl be fixed for .build() and .headers()!
+
+        let commitments = transcript_commitment_builder.build().unwrap();
+
+        // Path
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (4..5).into(), Direction::Sent)
+            .is_some());
+        // Host
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (22..31).into(), Direction::Sent)
+            .is_some());
+
+        // Set-Cookie 1
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (29..44).into(), Direction::Received)
+            .is_some());
+        // Set-Cookie 2
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (58..74).into(), Direction::Received)
+            .is_some());
+    }
 }

--- a/tlsn/tlsn-formats/src/http/mod.rs
+++ b/tlsn/tlsn-formats/src/http/mod.rs
@@ -210,15 +210,15 @@ mod tests {
     fn test_http_commit_duplicate_headers() {
         let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         let rx: &[u8] = b"HTTP/1.1 200 OK\r\nSet-Cookie: lang=en; Path=/\r\n\
-        Set-Cookie: fang=fen; Path=/\r\n\r\n";
+        Set-Cookie: fang=fen; Path=/\r\nContent-Length: 14\r\n\r\n{\"foo\": \"bar\"}";
         let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
             fixtures::encoding_provider(tx, rx),
             tx.len(),
             rx.len(),
         );
 
-        let requests = parse_requests(Bytes::copy_from_slice(TX)).unwrap();
-        let responses = parse_responses(Bytes::copy_from_slice(RX)).unwrap();
+        let requests = parse_requests(Bytes::copy_from_slice(tx)).unwrap();
+        let responses = parse_responses(Bytes::copy_from_slice(rx)).unwrap();
 
         HttpCommitmentBuilder::new(&mut transcript_commitment_builder, &requests, &responses)
             .build()

--- a/tlsn/tlsn-formats/src/http/mod.rs
+++ b/tlsn/tlsn-formats/src/http/mod.rs
@@ -207,16 +207,17 @@ mod tests {
     }
 
     #[test]
-    fn test_http_commit_duplicate_headers() {
-        let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    fn test_http_commit_duplicate_headers_call_build() {
+        let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\nAccept: application/json\r\n\
+        Accept: application/xml\r\n\r\n";
         let rx: &[u8] = b"HTTP/1.1 200 OK\r\nSet-Cookie: lang=en; Path=/\r\n\
         Set-Cookie: fang=fen; Path=/\r\nContent-Length: 14\r\n\r\n{\"foo\": \"bar\"}";
+
         let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
             fixtures::encoding_provider(tx, rx),
             tx.len(),
             rx.len(),
         );
-
         let requests = parse_requests(Bytes::copy_from_slice(tx)).unwrap();
         let responses = parse_responses(Bytes::copy_from_slice(rx)).unwrap();
 
@@ -224,7 +225,51 @@ mod tests {
             .build()
             .unwrap();
 
-        // TODO: shoudl be fixed for .build() and .headers()!
+        let commitments = transcript_commitment_builder.build().unwrap();
+
+        // Path
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (4..5).into(), Direction::Sent)
+            .is_some());
+        // Host
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (22..31).into(), Direction::Sent)
+            .is_some());
+
+        // Set-Cookie 1
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (29..44).into(), Direction::Received)
+            .is_some());
+        // Set-Cookie 2
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (58..74).into(), Direction::Received)
+            .is_some());
+    }
+
+    #[test]
+    fn test_http_commit_duplicate_headers_call_headers() {
+        let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\nAccept: application/json\r\n\
+        Accept: application/xml\r\n\r\n";
+        let rx: &[u8] = b"HTTP/1.1 200 OK\r\nSet-Cookie: lang=en; Path=/\r\n\
+        Set-Cookie: fang=fen; Path=/\r\nContent-Length: 14\r\n\r\n{\"foo\": \"bar\"}";
+
+        let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
+            fixtures::encoding_provider(tx, rx),
+            tx.len(),
+            rx.len(),
+        );
+        let requests = parse_requests(Bytes::copy_from_slice(tx)).unwrap();
+        let responses = parse_responses(Bytes::copy_from_slice(rx)).unwrap();
+
+        let mut http_builder =
+            HttpCommitmentBuilder::new(&mut transcript_commitment_builder, &requests, &responses);
+
+        let mut req_builder = http_builder.request(0).unwrap();
+        req_builder.path().unwrap();
+        req_builder.headers().unwrap();
+
+        let mut resp_builder = http_builder.response(0).unwrap();
+        resp_builder.headers().unwrap();
 
         let commitments = transcript_commitment_builder.build().unwrap();
 


### PR DESCRIPTION
This resolves #374