### PR TITLE
fix(formats): skip committing to empty header values

### DIFF
--- a/tlsn/tlsn-formats/src/http/commitment.rs
+++ b/tlsn/tlsn-formats/src/http/commitment.rs
@@ -168,10 +168,17 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
     /// Commits all request headers.
     ///
     /// Returns a vector of the names of the headers that were committed and their commitment IDs.
+    ///
+    /// Headers with empty values are skipped.
     pub fn headers(&mut self) -> Result<Vec<(String, CommitmentId)>, HttpCommitmentBuilderError> {
         let mut commitments = Vec::new();
 
         for header in &self.request.0.headers {
+            // Skip headers with empty values
+            if header.value.span().is_empty() {
+                continue;
+            }
+
             let name = header.name.span().as_str().to_string();
             let id = self.header(&name)?;
 
@@ -192,6 +199,8 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
     ///
     /// This commits to everything that has not already been committed, including a commitment
     /// to the format data of the request.
+    ///
+    /// Headers with empty values are skipped.
     pub fn build(mut self) -> Result<(), HttpCommitmentBuilderError> {
         // Commit to the path if it has not already been committed.
         let path_range = self.request.0.path.range();
@@ -201,6 +210,11 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
 
         // Commit to any headers that have not already been committed.
         for header in &self.request.0.headers {
+            // Skip headers with empty values
+            if header.value.span().is_empty() {
+                continue;
+            }
+
             let name = header.name.span().as_str().to_ascii_lowercase();
 
             // Public headers can not be committed separately
@@ -274,10 +288,17 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
     /// Commits all response headers.
     ///
     /// Returns a vector of the names of the headers that were committed and their commitment IDs.
+    ///
+    /// Headers with empty values are skipped.
     pub fn headers(&mut self) -> Result<Vec<(String, CommitmentId)>, HttpCommitmentBuilderError> {
         let mut commitments = Vec::new();
 
         for header in &self.response.0.headers {
+            // Skip headers with empty values
+            if header.value.span().is_empty() {
+                continue;
+            }
+
             let name = header.name.span().as_str().to_string();
             let id = self.header(&name)?;
 
@@ -306,6 +327,11 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
     pub fn build(mut self) -> Result<(), HttpCommitmentBuilderError> {
         // Commit to any headers that have not already been committed.
         for header in &self.response.0.headers {
+            // Skip headers with empty values
+            if header.value.span().is_empty() {
+                continue;
+            }
+
             let name = header.name.span().as_str().to_ascii_lowercase();
 
             // Public headers can not be committed separately

--- a/tlsn/tlsn-formats/src/http/mod.rs
+++ b/tlsn/tlsn-formats/src/http/mod.rs
@@ -205,4 +205,25 @@ mod tests {
         assert_eq!(&recv.data()[25..43], b"very-secret-cookie");
         assert_eq!(&recv.data()[180..194], b"Hello World!!!");
     }
+
+    #[test]
+    fn test_http_commit_empty_headers() {
+        let tx: &[u8] = b"GET /hello HTTP/1.1\r\nHost: localhost\r\nEmpty: \r\n\r\n";
+        let rx: &[u8] = b"HTTP/1.1 200 OK\r\nEmpty: \r\nContent-Length: 0\r\n\r\n";
+
+        let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
+            fixtures::encoding_provider(tx, rx),
+            tx.len(),
+            rx.len(),
+        );
+
+        let requests = parse_requests(Bytes::copy_from_slice(tx)).unwrap();
+        let responses = parse_responses(Bytes::copy_from_slice(rx)).unwrap();
+
+        HttpCommitmentBuilder::new(&mut transcript_commitment_builder, &requests, &responses)
+            .build()
+            .unwrap();
+
+        transcript_commitment_builder.build().unwrap();
+    }
 }


### PR DESCRIPTION
This PR fixes a bug which causes an error when empty header values are present in an HTTP record.

# Changes
- Skip committing to header values which are empty