### PR TITLE
`tlsn-formats`: fix commitment error on empty header values and empty strings in JSON body

### DIFF
--- a/tlsn/Cargo.toml
+++ b/tlsn/Cargo.toml
@@ -56,9 +56,7 @@ bincode = "1"
 hex = "0.4"
 bytes = "1.4"
 opaque-debug = "0.3"
-# TODO: switch spansy back to the sinui0 repo with updated rev
-# spansy = { git = "https://github.com/sinui0/spansy", rev = "becb33d" }
-spansy = { git = "https://github.com/rozag/spansy", rev = "db4aac8" }
+spansy = { git = "https://github.com/sinui0/spansy", rev = "c63d835" }
 
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/tlsn/Cargo.toml
+++ b/tlsn/Cargo.toml
@@ -56,7 +56,9 @@ bincode = "1"
 hex = "0.4"
 bytes = "1.4"
 opaque-debug = "0.3"
-spansy = { git = "https://github.com/sinui0/spansy", rev = "becb33d" }
+# TODO: switch spansy back to the sinui0 repo with updated rev
+# spansy = { git = "https://github.com/sinui0/spansy", rev = "becb33d" }
+spansy = { git = "https://github.com/rozag/spansy", rev = "ecd79a1" }
 
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/tlsn/Cargo.toml
+++ b/tlsn/Cargo.toml
@@ -58,7 +58,7 @@ bytes = "1.4"
 opaque-debug = "0.3"
 # TODO: switch spansy back to the sinui0 repo with updated rev
 # spansy = { git = "https://github.com/sinui0/spansy", rev = "becb33d" }
-spansy = { git = "https://github.com/rozag/spansy", rev = "ecd79a1" }
+spansy = { git = "https://github.com/rozag/spansy", rev = "db4aac8" }
 
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/tlsn/tlsn-formats/src/http/commitment.rs
+++ b/tlsn/tlsn-formats/src/http/commitment.rs
@@ -154,6 +154,11 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
         let mut commitments = Vec::new();
 
         for header in self.request.0.headers_with_name(name) {
+            // Cannot commit to an empty header value
+            if header.value.span().is_empty() {
+                continue;
+            }
+
             let id = self.header_internal(header)?;
             commitments.push(id);
         }
@@ -172,6 +177,11 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
         let mut commitments = Vec::new();
 
         for header in &self.request.0.headers {
+            // Cannot commit to an empty header value
+            if header.value.span().is_empty() {
+                continue;
+            }
+
             let name = header.name.span().as_str().to_string();
             let id = self.header_internal(header)?;
 
@@ -208,7 +218,13 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
                 continue;
             }
 
-            let range = header.value.span().range();
+            // Cannot commit to an empty header value
+            let span = header.value.span();
+            if span.is_empty() {
+                continue;
+            }
+
+            let range = span.range();
             if !range.is_subset(&self.committed) {
                 self.header_internal(header)?;
             }
@@ -275,6 +291,11 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
         let mut commitments = Vec::new();
 
         for header in self.response.0.headers_with_name(name) {
+            // Cannot commit to an empty header value
+            if header.value.span().is_empty() {
+                continue;
+            }
+
             let id = self.header_internal(header)?;
             commitments.push(id);
         }
@@ -293,6 +314,11 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
         let mut commitments = Vec::new();
 
         for header in &self.response.0.headers {
+            // Cannot commit to an empty header value
+            if header.value.span().is_empty() {
+                continue;
+            }
+
             let name = header.name.span().as_str().to_string();
             let id = self.header_internal(header)?;
 
@@ -328,7 +354,13 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
                 continue;
             }
 
-            let range = header.value.span().range();
+            // Cannot commit to an empty header value
+            let span = header.value.span();
+            if span.is_empty() {
+                continue;
+            }
+
+            let range = span.range();
             if !range.is_subset(&self.committed) {
                 self.header_internal(header)?;
             }

--- a/tlsn/tlsn-formats/src/http/commitment.rs
+++ b/tlsn/tlsn-formats/src/http/commitment.rs
@@ -151,16 +151,15 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
     ///
     /// * `name` - The name of the header value to commit.
     pub fn header(&mut self, name: &str) -> Result<Vec<CommitmentId>, HttpCommitmentBuilderError> {
-        let headers = self.request.0.all_headers_with_name(name);
-        if headers.is_empty() {
-            return Err(HttpCommitmentBuilderError::MissingHeader(name.to_string()));
-        }
-
         let mut commitments = Vec::new();
 
-        for header in headers {
+        for header in self.request.0.headers_with_name(name) {
             let id = self.header_internal(header)?;
             commitments.push(id);
+        }
+
+        if commitments.is_empty() {
+            return Err(HttpCommitmentBuilderError::MissingHeader(name.to_string()));
         }
 
         Ok(commitments)
@@ -273,16 +272,15 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
     ///
     /// * `name` - The name of the header value to commit.
     pub fn header(&mut self, name: &str) -> Result<Vec<CommitmentId>, HttpCommitmentBuilderError> {
-        let headers = self.response.0.all_headers_with_name(name);
-        if headers.is_empty() {
-            return Err(HttpCommitmentBuilderError::MissingHeader(name.to_string()));
-        }
-
         let mut commitments = Vec::new();
 
-        for header in headers {
+        for header in self.response.0.headers_with_name(name) {
             let id = self.header_internal(header)?;
             commitments.push(id);
+        }
+
+        if commitments.is_empty() {
+            return Err(HttpCommitmentBuilderError::MissingHeader(name.to_string()));
         }
 
         Ok(commitments)

--- a/tlsn/tlsn-formats/src/http/commitment.rs
+++ b/tlsn/tlsn-formats/src/http/commitment.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use crate::http::{Body, BodyCommitmentBuilder, Request, Response};
-use spansy::{http::Header, Spanned};
+use spansy::Spanned;
 use tlsn_core::{
     commitment::{CommitmentId, TranscriptCommitmentBuilder, TranscriptCommitmentBuilderError},
     Direction,
@@ -156,13 +156,7 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
             .0
             .header(name)
             .ok_or(HttpCommitmentBuilderError::MissingHeader(name.to_string()))?;
-        self.header_internal(header)
-    }
 
-    fn header_internal(
-        &mut self,
-        header: &Header,
-    ) -> Result<CommitmentId, HttpCommitmentBuilderError> {
         let range = header.value.span().range();
         let id = self.builder.commit_sent(range.clone())?;
 
@@ -179,7 +173,7 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
 
         for header in &self.request.0.headers {
             let name = header.name.span().as_str().to_string();
-            let id = self.header_internal(header)?;
+            let id = self.header(&name)?;
 
             commitments.push((name, id));
         }
@@ -216,7 +210,7 @@ impl<'a> HttpRequestCommitmentBuilder<'a> {
 
             let range = header.value.span().range();
             if !range.is_subset(&self.committed) {
-                self.header_internal(header)?;
+                self.header(&name)?;
             }
         }
 
@@ -271,13 +265,7 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
             .0
             .header(name)
             .ok_or(HttpCommitmentBuilderError::MissingHeader(name.to_string()))?;
-        self.header_internal(header)
-    }
 
-    fn header_internal(
-        &mut self,
-        header: &Header,
-    ) -> Result<CommitmentId, HttpCommitmentBuilderError> {
         self.builder
             .commit_recv(header.value.span().range())
             .map_err(From::from)
@@ -291,7 +279,7 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
 
         for header in &self.response.0.headers {
             let name = header.name.span().as_str().to_string();
-            let id = self.header_internal(header)?;
+            let id = self.header(&name)?;
 
             commitments.push((name, id));
         }
@@ -327,7 +315,7 @@ impl<'a> HttpResponseCommitmentBuilder<'a> {
 
             let range = header.value.span().range();
             if !range.is_subset(&self.committed) {
-                self.header_internal(header)?;
+                self.header(&name)?;
             }
         }
 

--- a/tlsn/tlsn-formats/src/http/mod.rs
+++ b/tlsn/tlsn-formats/src/http/mod.rs
@@ -205,4 +205,45 @@ mod tests {
         assert_eq!(&recv.data()[25..43], b"very-secret-cookie");
         assert_eq!(&recv.data()[180..194], b"Hello World!!!");
     }
+
+    #[test]
+    fn test_http_commit_duplicate_headers() {
+        let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let rx: &[u8] = b"HTTP/1.1 200 OK\r\nSet-Cookie: lang=en; Path=/\r\n\
+        Set-Cookie: fang=fen; Path=/\r\n\r\n";
+        let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
+            fixtures::encoding_provider(tx, rx),
+            tx.len(),
+            rx.len(),
+        );
+
+        let requests = parse_requests(Bytes::copy_from_slice(TX)).unwrap();
+        let responses = parse_responses(Bytes::copy_from_slice(RX)).unwrap();
+
+        HttpCommitmentBuilder::new(&mut transcript_commitment_builder, &requests, &responses)
+            .build()
+            .unwrap();
+
+        // TODO: shoudl be fixed for .build() and .headers()!
+
+        let commitments = transcript_commitment_builder.build().unwrap();
+
+        // Path
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (4..5).into(), Direction::Sent)
+            .is_some());
+        // Host
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (22..31).into(), Direction::Sent)
+            .is_some());
+
+        // Set-Cookie 1
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (29..44).into(), Direction::Received)
+            .is_some());
+        // Set-Cookie 2
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (58..74).into(), Direction::Received)
+            .is_some());
+    }
 }

--- a/tlsn/tlsn-formats/src/http/mod.rs
+++ b/tlsn/tlsn-formats/src/http/mod.rs
@@ -210,15 +210,15 @@ mod tests {
     fn test_http_commit_duplicate_headers() {
         let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
         let rx: &[u8] = b"HTTP/1.1 200 OK\r\nSet-Cookie: lang=en; Path=/\r\n\
-        Set-Cookie: fang=fen; Path=/\r\n\r\n";
+        Set-Cookie: fang=fen; Path=/\r\nContent-Length: 14\r\n\r\n{\"foo\": \"bar\"}";
         let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
             fixtures::encoding_provider(tx, rx),
             tx.len(),
             rx.len(),
         );
 
-        let requests = parse_requests(Bytes::copy_from_slice(TX)).unwrap();
-        let responses = parse_responses(Bytes::copy_from_slice(RX)).unwrap();
+        let requests = parse_requests(Bytes::copy_from_slice(tx)).unwrap();
+        let responses = parse_responses(Bytes::copy_from_slice(rx)).unwrap();
 
         HttpCommitmentBuilder::new(&mut transcript_commitment_builder, &requests, &responses)
             .build()

--- a/tlsn/tlsn-formats/src/http/mod.rs
+++ b/tlsn/tlsn-formats/src/http/mod.rs
@@ -207,16 +207,17 @@ mod tests {
     }
 
     #[test]
-    fn test_http_commit_duplicate_headers() {
-        let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    fn test_http_commit_duplicate_headers_call_build() {
+        let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\nAccept: application/json\r\n\
+        Accept: application/xml\r\n\r\n";
         let rx: &[u8] = b"HTTP/1.1 200 OK\r\nSet-Cookie: lang=en; Path=/\r\n\
         Set-Cookie: fang=fen; Path=/\r\nContent-Length: 14\r\n\r\n{\"foo\": \"bar\"}";
+
         let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
             fixtures::encoding_provider(tx, rx),
             tx.len(),
             rx.len(),
         );
-
         let requests = parse_requests(Bytes::copy_from_slice(tx)).unwrap();
         let responses = parse_responses(Bytes::copy_from_slice(rx)).unwrap();
 
@@ -224,7 +225,51 @@ mod tests {
             .build()
             .unwrap();
 
-        // TODO: shoudl be fixed for .build() and .headers()!
+        let commitments = transcript_commitment_builder.build().unwrap();
+
+        // Path
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (4..5).into(), Direction::Sent)
+            .is_some());
+        // Host
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (22..31).into(), Direction::Sent)
+            .is_some());
+
+        // Set-Cookie 1
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (29..44).into(), Direction::Received)
+            .is_some());
+        // Set-Cookie 2
+        assert!(commitments
+            .get_id_by_info(CommitmentKind::Blake3, (58..74).into(), Direction::Received)
+            .is_some());
+    }
+
+    #[test]
+    fn test_http_commit_duplicate_headers_call_headers() {
+        let tx: &[u8] = b"GET / HTTP/1.1\r\nHost: localhost\r\nAccept: application/json\r\n\
+        Accept: application/xml\r\n\r\n";
+        let rx: &[u8] = b"HTTP/1.1 200 OK\r\nSet-Cookie: lang=en; Path=/\r\n\
+        Set-Cookie: fang=fen; Path=/\r\nContent-Length: 14\r\n\r\n{\"foo\": \"bar\"}";
+
+        let mut transcript_commitment_builder = TranscriptCommitmentBuilder::new(
+            fixtures::encoding_provider(tx, rx),
+            tx.len(),
+            rx.len(),
+        );
+        let requests = parse_requests(Bytes::copy_from_slice(tx)).unwrap();
+        let responses = parse_responses(Bytes::copy_from_slice(rx)).unwrap();
+
+        let mut http_builder =
+            HttpCommitmentBuilder::new(&mut transcript_commitment_builder, &requests, &responses);
+
+        let mut req_builder = http_builder.request(0).unwrap();
+        req_builder.path().unwrap();
+        req_builder.headers().unwrap();
+
+        let mut resp_builder = http_builder.response(0).unwrap();
+        resp_builder.headers().unwrap();
 
         let commitments = transcript_commitment_builder.build().unwrap();
 

--- a/tlsn/tlsn-formats/src/http/parse.rs
+++ b/tlsn/tlsn-formats/src/http/parse.rs
@@ -90,7 +90,8 @@ pub fn parse_requests(data: Bytes) -> Result<Vec<(Request, Option<Body>)>, Parse
             let range = body.span().range();
             let body = data.slice(range.clone());
 
-            let body = if let Some(content_type) = request.header("content-type") {
+            let body = if let Some(content_type) = request.headers_with_name("content-type").next()
+            {
                 parse_body(
                     index,
                     content_type.value.span().as_bytes(),
@@ -129,7 +130,8 @@ pub fn parse_responses(data: Bytes) -> Result<Vec<(Response, Option<Body>)>, Par
             let range = body.span().range();
             let body = data.slice(range.clone());
 
-            let body = if let Some(content_type) = response.header("content-type") {
+            let body = if let Some(content_type) = response.headers_with_name("content-type").next()
+            {
                 parse_body(
                     index,
                     content_type.value.span().as_bytes(),

--- a/tlsn/tlsn-formats/src/http/proof.rs
+++ b/tlsn/tlsn-formats/src/http/proof.rs
@@ -162,23 +162,27 @@ impl<'a, 'b> HttpRequestProofBuilder<'a, 'b> {
         Ok(self)
     }
 
-    /// Reveals the value of the given header.
+    /// Reveals the value of all the headers with the given name.
     ///
     /// # Arguments
     ///
     /// * `name` - The name of the header value to reveal.
     pub fn header(&mut self, name: &str) -> Result<&mut Self, HttpProofBuilderError> {
-        let header = self
-            .request
-            .0
-            .header(name)
-            .ok_or_else(|| HttpProofBuilderError::MissingHeader(name.to_string()))?;
+        let mut empty = true;
 
-        let id = self.commit_id(header.value.span().range()).ok_or_else(|| {
-            HttpProofBuilderError::MissingCommitment(format!("header \"{}\"", name))
-        })?;
+        for header in self.request.0.headers_with_name(name) {
+            empty = false;
 
-        self.builder.reveal(id)?;
+            let id = self.commit_id(header.value.span().range()).ok_or_else(|| {
+                HttpProofBuilderError::MissingCommitment(format!("header \"{}\"", name))
+            })?;
+
+            self.builder.reveal(id)?;
+        }
+
+        if empty {
+            return Err(HttpProofBuilderError::MissingHeader(name.to_string()));
+        }
 
         Ok(self)
     }
@@ -255,23 +259,27 @@ impl<'a, 'b> HttpResponseProofBuilder<'a, 'b> {
         Ok(self)
     }
 
-    /// Reveals the value of the given header.
+    /// Reveals the value of all the headers with the given name.
     ///
     /// # Arguments
     ///
     /// * `name` - The name of the header value to reveal.
     pub fn header(&mut self, name: &str) -> Result<&mut Self, HttpProofBuilderError> {
-        let header = self
-            .response
-            .0
-            .header(name)
-            .ok_or_else(|| HttpProofBuilderError::MissingHeader(name.to_string()))?;
+        let mut empty = true;
 
-        let id = self.commit_id(header.value.span().range()).ok_or_else(|| {
-            HttpProofBuilderError::MissingCommitment(format!("header \"{}\"", name))
-        })?;
+        for header in self.response.0.headers_with_name(name) {
+            empty = false;
 
-        self.builder.reveal(id)?;
+            let id = self.commit_id(header.value.span().range()).ok_or_else(|| {
+                HttpProofBuilderError::MissingCommitment(format!("header \"{}\"", name))
+            })?;
+
+            self.builder.reveal(id)?;
+        }
+
+        if empty {
+            return Err(HttpProofBuilderError::MissingHeader(name.to_string()));
+        }
 
         Ok(self)
     }

--- a/tlsn/tlsn-formats/src/json/commitment.rs
+++ b/tlsn/tlsn-formats/src/json/commitment.rs
@@ -134,7 +134,13 @@ impl<'a> JsonVisit for JsonCommitter<'a> {
             return;
         }
 
-        let range = node.span().range();
+        // Ignore empty strings.
+        let span = node.span();
+        if span.is_empty() {
+            return;
+        }
+
+        let range = span.range();
         if self
             .builder
             .get_id(CommitmentKind::Blake3, range.clone(), self.direction)


### PR DESCRIPTION
Prevents `"commitment builder error: can not commit to an empty range"` errors during commitment by skipping headers with empty values and empty strings in JSON bodies.

Fixes:
- https://github.com/tlsnotary/tlsn/issues/377

**Warning**: Depends on another PR:
- https://github.com/tlsnotary/tlsn/pull/375
- You can see a clean diff using this link: https://github.com/rozag/tlsn/compare/duplicate-resp-headers...rozag:tlsn:empty-values?expand=1