### PR TITLE
Make CORS permissive

### DIFF
--- a/notary-server/Cargo.toml
+++ b/notary-server/Cargo.toml
@@ -33,6 +33,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-rustls = { version = "0.24.1" }
 tokio-util = { version = "0.7", features = ["compat"] }
 tower = { version = "0.4.12", features = ["make"] }
+tower-http = { version = "0.4.4", features = ["cors"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.19"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/notary-server/src/server.rs
+++ b/notary-server/src/server.rs
@@ -5,7 +5,6 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use tower_http::cors::CorsLayer;
 use eyre::{ensure, eyre, Result};
 use futures_util::future::poll_fn;
 use hyper::server::{
@@ -21,6 +20,7 @@ use std::{
     pin::Pin,
     sync::Arc,
 };
+use tower_http::cors::CorsLayer;
 
 use tokio::{fs::File, net::TcpListener};
 use tokio_rustls::TlsAcceptor;

--- a/notary-server/src/server.rs
+++ b/notary-server/src/server.rs
@@ -5,6 +5,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use tower_http::cors::CorsLayer;
 use eyre::{ensure, eyre, Result};
 use futures_util::future::poll_fn;
 use hyper::server::{
@@ -137,6 +138,7 @@ pub async fn run_server(config: &NotaryServerProperties) -> Result<(), NotarySer
             NotaryGlobals,
         >(notary_globals.clone()))
         .route("/notarize", get(upgrade_protocol))
+        .layer(CorsLayer::permissive())
         .with_state(notary_globals);
     let mut app = router.into_make_service();
 


### PR DESCRIPTION
Disable CORS as the notary server is meant to be consumed by all origins.

cc @yuroitaki  @0xtsukino 