### PR TITLE
chore(tls-client): clippy fix

### DIFF
--- a/components/tls/tls-client/src/client/handy.rs
+++ b/components/tls/tls-client/src/client/handy.rs
@@ -95,7 +95,7 @@ mod test {
     #[test]
     fn test_noclientsessionstorage_drops_put() {
         let c = NoClientSessionStorage {};
-        assert_eq!(c.put(vec![0x01], vec![0x02]), false);
+        assert!(!c.put(vec![0x01], vec![0x02]));
     }
 
     #[test]
@@ -110,13 +110,13 @@ mod test {
     #[test]
     fn test_clientsessionmemorycache_accepts_put() {
         let c = ClientSessionMemoryCache::new(4);
-        assert_eq!(c.put(vec![0x01], vec![0x02]), true);
+        assert!(c.put(vec![0x01], vec![0x02]));
     }
 
     #[test]
     fn test_clientsessionmemorycache_persists_put() {
         let c = ClientSessionMemoryCache::new(4);
-        assert_eq!(c.put(vec![0x01], vec![0x02]), true);
+        assert!(c.put(vec![0x01], vec![0x02]));
         assert_eq!(c.get(&[0x01]), Some(vec![0x02]));
         assert_eq!(c.get(&[0x01]), Some(vec![0x02]));
     }
@@ -124,19 +124,19 @@ mod test {
     #[test]
     fn test_clientsessionmemorycache_overwrites_put() {
         let c = ClientSessionMemoryCache::new(4);
-        assert_eq!(c.put(vec![0x01], vec![0x02]), true);
-        assert_eq!(c.put(vec![0x01], vec![0x04]), true);
+        assert!(c.put(vec![0x01], vec![0x02]));
+        assert!(c.put(vec![0x01], vec![0x04]));
         assert_eq!(c.get(&[0x01]), Some(vec![0x04]));
     }
 
     #[test]
     fn test_clientsessionmemorycache_drops_to_maintain_size_invariant() {
         let c = ClientSessionMemoryCache::new(2);
-        assert_eq!(c.put(vec![0x01], vec![0x02]), true);
-        assert_eq!(c.put(vec![0x03], vec![0x04]), true);
-        assert_eq!(c.put(vec![0x05], vec![0x06]), true);
-        assert_eq!(c.put(vec![0x07], vec![0x08]), true);
-        assert_eq!(c.put(vec![0x09], vec![0x0a]), true);
+        assert!(c.put(vec![0x01], vec![0x02]));
+        assert!(c.put(vec![0x03], vec![0x04]));
+        assert!(c.put(vec![0x05], vec![0x06]));
+        assert!(c.put(vec![0x07], vec![0x08]));
+        assert!(c.put(vec![0x09], vec![0x0a]));
 
         let count = c.get(&[0x01]).iter().count()
             + c.get(&[0x03]).iter().count()

--- a/components/tls/tls-client/src/sign.rs
+++ b/components/tls/tls-client/src/sign.rs
@@ -69,7 +69,7 @@ impl CertifiedKey {
 
     /// The end-entity certificate.
     pub fn end_entity_cert(&self) -> Result<&tls_core::key::Certificate, SignError> {
-        self.cert.get(0).ok_or(SignError(()))
+        self.cert.first().ok_or(SignError(()))
     }
 
     /// Check the certificate chain for validity:

--- a/components/tls/tls-client/tests/api.rs
+++ b/components/tls/tls-client/tests/api.rs
@@ -14,7 +14,7 @@ use std::{
     },
 };
 
-use log;
+
 
 #[cfg(feature = "quic")]
 use tls_client::quic::{self, ClientQuicExt, QuicExt, ServerQuicExt};
@@ -110,12 +110,12 @@ async fn version_test(
     result: Option<ProtocolVersion>,
 ) {
     let client_versions = if client_versions.is_empty() {
-        &tls_client::ALL_VERSIONS
+        tls_client::ALL_VERSIONS
     } else {
         client_versions
     };
     let server_versions = if server_versions.is_empty() {
-        &rustls::ALL_VERSIONS
+        rustls::ALL_VERSIONS
     } else {
         server_versions
     };
@@ -1036,7 +1036,7 @@ where
         Ok(())
     }
 
-    fn write_vectored<'b>(&mut self, b: &[io::IoSlice<'b>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, b: &[io::IoSlice<'_>]) -> io::Result<usize> {
         let mut total = 0;
         let mut lengths = vec![];
         for bytes in b {
@@ -2029,7 +2029,7 @@ async fn servered_write_for_server_handshake_no_half_rtt_with_client_auth() {
 #[tokio::test]
 async fn servered_write_for_server_handshake_no_half_rtt_by_default() {
     let server_config = make_server_config(KeyType::Rsa);
-    assert_eq!(server_config.send_half_rtt_data, false);
+    assert!(!server_config.send_half_rtt_data);
     check_half_rtt_does_not_work(server_config).await;
 }
 
@@ -3144,7 +3144,7 @@ async fn test_client_mtu_reduction() {
         fn flush(&mut self) -> io::Result<()> {
             panic!()
         }
-        fn write_vectored<'b>(&mut self, b: &[io::IoSlice<'b>]) -> io::Result<usize> {
+        fn write_vectored(&mut self, b: &[io::IoSlice<'_>]) -> io::Result<usize> {
             let writes = b.iter().map(|slice| slice.len()).collect::<Vec<usize>>();
             let len = writes.iter().sum();
             self.writevs.push(writes);
@@ -3280,7 +3280,7 @@ async fn test_client_rejects_illegal_tls13_ccs() {
     send(&mut client, &mut server);
     server.process_new_packets().unwrap();
 
-    let (mut server, mut client) = (server.into(), client.into());
+    let (mut server, mut client) = (server.into(), client);
 
     receive_altered(&mut server, corrupt_ccs, &mut client);
     assert_eq!(

--- a/components/tls/tls-client/tests/common/mod.rs
+++ b/components/tls/tls-client/tests/common/mod.rs
@@ -596,11 +596,7 @@ impl io::Read for FailsReads {
 }
 
 pub fn version_compat(v: Option<rustls::ProtocolVersion>) -> Option<tls_client::ProtocolVersion> {
-    if let Some(v) = v {
-        Some(tls_client::ProtocolVersion::from(v.get_u16()))
-    } else {
-        None
-    }
+    v.map(|v| tls_client::ProtocolVersion::from(v.get_u16()))
 }
 
 pub struct BlockingIo<T>(pub T);


### PR DESCRIPTION
This PR appeases clippy for the `tls-client` crate using `clippy fix`