### PR TITLE
Interactive verifier

### DIFF
--- a/notary-server/src/service.rs
+++ b/notary-server/src/service.rs
@@ -162,10 +162,10 @@ pub async fn notary_service<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
 
     let mut config_builder = VerifierConfig::builder();
 
-    config_builder.id(session_id);
+    config_builder = config_builder.id(session_id);
 
     if let Some(max_transcript_size) = max_transcript_size {
-        config_builder.max_transcript_size(max_transcript_size);
+        config_builder = config_builder.max_transcript_size(max_transcript_size);
     }
 
     let config = config_builder.build()?;

--- a/tlsn/Cargo.toml
+++ b/tlsn/Cargo.toml
@@ -3,7 +3,7 @@ members = [
     "tlsn-core",
     "tlsn-verifier",
     "tlsn-prover",
-    "tlsn-formats",
+#    "tlsn-formats",
     "tlsn-server-fixture",
     "tests-integration",
     "examples",
@@ -16,7 +16,7 @@ tlsn-prover = { path = "tlsn-prover" }
 tlsn-verifier = { path = "tlsn-verifier" }
 tlsn-server-fixture = { path = "tlsn-server-fixture" }
 
-tlsn-formats = { path = "tlsn-formats" }
+#tlsn-formats = { path = "tlsn-formats" }
 
 tlsn-tls-core = { path = "../components/tls/tls-core" }
 tlsn-tls-mpc = { path = "../components/tls/tls-mpc" }

--- a/tlsn/examples/discord/discord_dm_verifier.rs
+++ b/tlsn/examples/discord/discord_dm_verifier.rs
@@ -31,8 +31,9 @@ fn main() {
     let SessionProof {
         // The session header that was signed by the Notary is a succinct commitment to the TLS transcript.
         header,
-        // This is the server name, checked against the certificate chain shared in the TLS handshake.
-        server_name,
+        // This is the session_info, which contains the server_name, that is checked against the
+        // certificate chain shared in the TLS handshake.
+        session_info,
         ..
     } = session;
 
@@ -51,7 +52,7 @@ fn main() {
     println!("-------------------------------------------------------------------");
     println!(
         "Successfully verified that the bytes below came from a session with {:?} at {}.",
-        server_name, time
+        session_info.server_name, time
     );
     println!("Note that the bytes which the Prover chose not to disclose are shown as X.");
     println!();

--- a/tlsn/examples/simple/simple_verifier.rs
+++ b/tlsn/examples/simple/simple_verifier.rs
@@ -31,8 +31,9 @@ fn main() {
     let SessionProof {
         // The session header that was signed by the Notary is a succinct commitment to the TLS transcript.
         header,
-        // This is the server name, checked against the certificate chain shared in the TLS handshake.
-        server_name,
+        // This is the session_info, which contains the server_name, that is checked against the
+        // certificate chain shared in the TLS handshake.
+        session_info,
         ..
     } = session;
 
@@ -51,7 +52,7 @@ fn main() {
     println!("-------------------------------------------------------------------");
     println!(
         "Successfully verified that the bytes below came from a session with {:?} at {}.",
-        server_name, time
+        session_info.server_name, time
     );
     println!("Note that the bytes which the Prover chose not to disclose are shown as X.");
     println!();

--- a/tlsn/tests-integration/Cargo.toml
+++ b/tlsn/tests-integration/Cargo.toml
@@ -7,9 +7,10 @@ publish = false
 [dev-dependencies]
 tlsn-core.workspace = true
 tlsn-tls-core.workspace = true
-tlsn-prover = { workspace = true, features = ["tracing", "formats"] }
+tlsn-prover = { workspace = true, features = ["tracing"] }
 tlsn-verifier = { workspace = true, features = ["tracing"] }
 tlsn-server-fixture.workspace = true
+tlsn-utils.workspace = true
 
 p256 = { workspace = true, features = ["ecdsa"] }
 hyper = { workspace = true, features = ["client", "http1"] }

--- a/tlsn/tests-integration/tests/verify.rs
+++ b/tlsn/tests-integration/tests/verify.rs
@@ -1,0 +1,119 @@
+use futures::AsyncWriteExt;
+use hyper::{body::to_bytes, Body, Request, StatusCode};
+use tls_core::{anchors::RootCertStore, verify::WebPkiVerifier};
+use tlsn_core::{proof::SessionInfo, Direction, RedactedTranscript};
+use tlsn_prover::tls::{Prover, ProverConfig};
+use tlsn_server_fixture::{CA_CERT_DER, SERVER_DOMAIN};
+use tlsn_verifier::tls::{Verifier, VerifierConfig};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
+use tracing::instrument;
+use utils::range::RangeSet;
+
+#[tokio::test]
+#[ignore]
+async fn verify() {
+    tracing_subscriber::fmt::init();
+
+    let (socket_0, socket_1) = tokio::io::duplex(2 << 23);
+
+    let (_, (sent, received, _session_info)) = tokio::join!(prover(socket_0), verifier(socket_1));
+
+    assert_eq!(sent.authed(), &RangeSet::from(0..sent.data().len() - 1));
+    assert_eq!(
+        sent.redacted(),
+        &RangeSet::from(sent.data().len() - 1..sent.data().len())
+    );
+
+    assert_eq!(received.authed(), &RangeSet::from(2..received.data().len()));
+    assert_eq!(received.redacted(), &RangeSet::from(0..2));
+}
+
+#[instrument(skip(notary_socket))]
+async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socket: T) {
+    let (client_socket, server_socket) = tokio::io::duplex(2 << 16);
+
+    let server_task = tokio::spawn(tlsn_server_fixture::bind(server_socket.compat()));
+
+    let mut root_store = RootCertStore::empty();
+    root_store
+        .add(&tls_core::key::Certificate(CA_CERT_DER.to_vec()))
+        .unwrap();
+
+    let prover = Prover::new(
+        ProverConfig::builder()
+            .id("test")
+            .server_dns(SERVER_DOMAIN)
+            .root_cert_store(root_store)
+            .build()
+            .unwrap(),
+    )
+    .setup(notary_socket.compat())
+    .await
+    .unwrap();
+
+    let (tls_connection, prover_fut) = prover.connect(client_socket.compat()).await.unwrap();
+
+    let prover_task = tokio::spawn(prover_fut);
+
+    let (mut request_sender, connection) = hyper::client::conn::handshake(tls_connection.compat())
+        .await
+        .unwrap();
+
+    let connection_task = tokio::spawn(connection.without_shutdown());
+
+    let request = Request::builder()
+        .uri(format!("https://{}", SERVER_DOMAIN))
+        .header("Host", SERVER_DOMAIN)
+        .header("Connection", "close")
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = request_sender.send_request(request).await.unwrap();
+
+    assert!(response.status() == StatusCode::OK);
+
+    println!(
+        "{:?}",
+        String::from_utf8_lossy(&to_bytes(response.into_body()).await.unwrap())
+    );
+
+    server_task.await.unwrap();
+
+    let mut client_socket = connection_task.await.unwrap().unwrap().io.into_inner();
+
+    client_socket.close().await.unwrap();
+
+    let mut prover = prover_task.await.unwrap().unwrap().start_prove();
+
+    let sent_transcript_len = prover.sent_transcript().data().len();
+    let recv_transcript_len = prover.recv_transcript().data().len();
+
+    // Reveal parts of the transcript
+    _ = prover.reveal(0..sent_transcript_len - 1, Direction::Sent);
+    _ = prover.reveal(2..recv_transcript_len, Direction::Received);
+    prover.prove().await.unwrap();
+
+    prover.finalize().await.unwrap()
+}
+
+#[instrument(skip(socket))]
+async fn verifier<T: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>(
+    socket: T,
+) -> (RedactedTranscript, RedactedTranscript, SessionInfo) {
+    let mut root_store = RootCertStore::empty();
+    root_store
+        .add(&tls_core::key::Certificate(CA_CERT_DER.to_vec()))
+        .unwrap();
+
+    let verifier_config = VerifierConfig::builder()
+        .id("test")
+        .cert_verifier(WebPkiVerifier::new(root_store, None))
+        .build()
+        .unwrap();
+    let verifier = Verifier::new(verifier_config);
+
+    let (sent, received, session_info) = verifier.verify(socket.compat()).await.unwrap();
+    (sent, received, session_info)
+}

--- a/tlsn/tlsn-core/src/msg.rs
+++ b/tlsn/tlsn-core/src/msg.rs
@@ -1,8 +1,9 @@
 //! Protocol message types.
 
 use serde::{Deserialize, Serialize};
+use utils::range::RangeSet;
 
-use crate::{merkle::MerkleRoot, signature::Signature, SessionHeader};
+use crate::{merkle::MerkleRoot, proof::SessionInfo, signature::Signature, SessionHeader};
 
 /// Top-level enum for all messages
 #[derive(Debug, Serialize, Deserialize)]
@@ -13,6 +14,10 @@ pub enum TlsnMessage {
     SignedSessionHeader(SignedSessionHeader),
     /// A session header.
     SessionHeader(SessionHeader),
+    /// Information about the TLS session
+    SessionInfo(SessionInfo),
+    /// Information about the values the prover wants to prove
+    ProvingInfo(ProvingInfo),
 }
 
 /// A signed session header.
@@ -22,4 +27,15 @@ pub struct SignedSessionHeader {
     pub header: SessionHeader,
     /// The notary's signature
     pub signature: Signature,
+}
+
+/// Information about the values the prover wants to prove
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ProvingInfo {
+    /// The ids for the sent transcript
+    pub sent_ids: RangeSet<usize>,
+    /// The ids for the received transcript
+    pub recv_ids: RangeSet<usize>,
+    /// Purported cleartext values
+    pub cleartext: Vec<u8>,
 }

--- a/tlsn/tlsn-core/src/proof/mod.rs
+++ b/tlsn/tlsn-core/src/proof/mod.rs
@@ -1,9 +1,21 @@
 //! Different types of proofs used in the TLSNotary protocol.
 
+mod session;
 mod substrings;
-mod tls;
 
+pub use session::{default_cert_verifier, SessionInfo, SessionProof, SessionProofError};
 pub use substrings::{
     SubstringsProof, SubstringsProofBuilder, SubstringsProofBuilderError, SubstringsProofError,
 };
-pub use tls::{SessionProof, TlsProof};
+
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+/// Proof that a transcript of communications took place between a Prover and Server.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TlsProof {
+    /// Proof of the TLS handshake, server identity, and commitments to the transcript.
+    pub session: SessionProof,
+    /// Proof regarding the contents of the transcript.
+    pub substrings: SubstringsProof,
+}

--- a/tlsn/tlsn-core/src/proof/session.rs
+++ b/tlsn/tlsn-core/src/proof/session.rs
@@ -1,4 +1,4 @@
-use web_time::{Duration, SystemTime};
+use web_time::{Duration, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -11,20 +11,10 @@ use tls_core::{
 };
 
 use crate::{
-    proof::SubstringsProof,
     session::SessionHeader,
     signature::{Signature, SignatureVerifyError},
-    NotaryPublicKey, ServerName,
+    HandshakeSummary, NotaryPublicKey, ServerName,
 };
-
-/// Proof that a transcript of communications took place between a Prover and Server.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct TlsProof {
-    /// Proof of the TLS handshake, server identity, and commitments to the transcript.
-    pub session: SessionProof,
-    /// Proof regarding the contents of the transcript.
-    pub substrings: SubstringsProof,
-}
 
 /// An error that can occur while verifying a [`SessionProof`].
 #[derive(Debug, thiserror::Error)]
@@ -47,21 +37,21 @@ pub enum SessionProofError {
     InvalidServerCertificate(String),
 }
 
-/// Proof of the TLS handshake, server identity, and commitments to the the transcript.
+/// A session proof which is created from a [crate::session::NotarizedSession]
+///
+/// Proof of the TLS handshake, server identity, and commitments to the transcript.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SessionProof {
     /// The session header
     pub header: SessionHeader,
-    /// The server name.
-    pub server_name: ServerName,
     /// Signature for the session header, if the notary signed it
     pub signature: Option<Signature>,
-    /// Decommitment to the TLS handshake and server identity.
-    pub handshake_data_decommitment: Decommitment<HandshakeData>,
+    /// Information about the server
+    pub session_info: SessionInfo,
 }
 
 impl SessionProof {
-    /// Verify the session proof, returning the server's name.
+    /// Verify the session proof.
     ///
     /// # Arguments
     ///
@@ -79,26 +69,8 @@ impl SessionProof {
             .ok_or(SessionProofError::MissingNotarySignature)?;
 
         signature.verify(&self.header.to_bytes(), notary_public_key)?;
-
-        // Verify server name
-        let server_name = TlsServerName::try_from(self.server_name.as_ref())
-            .map_err(|e| SessionProofError::InvalidServerName(e.to_string()))?;
-
-        // Verify handshake
-        self.handshake_data_decommitment
-            .verify(self.header.handshake_summary().handshake_commitment())
-            .map_err(|e| SessionProofError::InvalidHandshake(e.to_string()))?;
-
-        // Verify server certificate
-        self.handshake_data_decommitment
-            .data()
-            .verify(
-                cert_verifier,
-                SystemTime::UNIX_EPOCH
-                    + Duration::from_secs(self.header.handshake_summary().time()),
-                &server_name,
-            )
-            .map_err(|e| SessionProofError::InvalidServerCertificate(e.to_string()))?;
+        self.session_info
+            .verify(self.header.handshake_summary(), cert_verifier)?;
 
         Ok(())
     }
@@ -116,7 +88,61 @@ impl SessionProof {
     }
 }
 
-fn default_cert_verifier() -> WebPkiVerifier {
+/// Contains information about the session
+///
+/// Includes the [ServerName] and the decommitment to the [HandshakeData].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionInfo {
+    /// The server name.
+    pub server_name: ServerName,
+    /// Decommitment to the TLS handshake and server identity.
+    pub handshake_decommitment: Decommitment<HandshakeData>,
+}
+
+impl SessionInfo {
+    /// Verify the session info.
+    pub fn verify(
+        &self,
+        handshake_summary: &HandshakeSummary,
+        cert_verifier: &impl ServerCertVerifier,
+    ) -> Result<(), SessionProofError> {
+        // Verify server name
+        let server_name = TlsServerName::try_from(self.server_name.as_ref())
+            .map_err(|e| SessionProofError::InvalidServerName(e.to_string()))?;
+
+        // Verify handshake
+        self.handshake_decommitment
+            .verify(handshake_summary.handshake_commitment())
+            .map_err(|e| SessionProofError::InvalidHandshake(e.to_string()))?;
+
+        // Verify server certificate
+        self.handshake_decommitment
+            .data()
+            .verify(
+                cert_verifier,
+                UNIX_EPOCH + Duration::from_secs(handshake_summary.time()),
+                &server_name,
+            )
+            .map_err(|e| SessionProofError::InvalidServerCertificate(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Verify the session info using trust anchors from the `webpki-roots` crate.
+    ///
+    /// # Arguments
+    ///
+    /// * `notary_public_key` - The public key of the notary.
+    pub fn verify_with_default_cert_verifier(
+        &self,
+        handshake_summary: &HandshakeSummary,
+    ) -> Result<(), SessionProofError> {
+        self.verify(handshake_summary, &default_cert_verifier())
+    }
+}
+
+/// Create a new [`WebPkiVerifier`] with the default trust anchors from the `webpki-roots` crate.
+pub fn default_cert_verifier() -> WebPkiVerifier {
     let mut root_store = RootCertStore::empty();
     root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
         OwnedTrustAnchor::from_subject_spki_name_constraints(

--- a/tlsn/tlsn-core/src/session/mod.rs
+++ b/tlsn/tlsn-core/src/session/mod.rs
@@ -10,7 +10,10 @@ pub use data::SessionData;
 pub use handshake::{HandshakeSummary, HandshakeVerifyError};
 pub use header::{SessionHeader, SessionHeaderVerifyError};
 
-use crate::{proof::SessionProof, signature::Signature};
+use crate::{
+    proof::{SessionInfo, SessionProof},
+    signature::Signature,
+};
 
 /// A validated notarized session stored by the Prover
 #[derive(Serialize, Deserialize)]
@@ -34,11 +37,15 @@ impl NotarizedSession {
 
     /// Returns a proof of the TLS session
     pub fn session_proof(&self) -> SessionProof {
+        let session_info = SessionInfo {
+            server_name: self.data.session_info().server_name.clone(),
+            handshake_decommitment: self.data.session_info().handshake_decommitment.clone(),
+        };
+
         SessionProof {
             header: self.header.clone(),
-            server_name: self.data.server_name().clone(),
             signature: self.signature.clone(),
-            handshake_data_decommitment: self.data.handshake_data_decommitment().clone(),
+            session_info,
         }
     }
 

--- a/tlsn/tlsn-core/src/transcript.rs
+++ b/tlsn/tlsn-core/src/transcript.rs
@@ -136,7 +136,8 @@ pub struct TranscriptSlice {
 }
 
 impl TranscriptSlice {
-    pub(crate) fn new(range: Range<usize>, data: Vec<u8>) -> Self {
+    /// Creates a new transcript slice.
+    pub fn new(range: Range<usize>, data: Vec<u8>) -> Self {
         Self { range, data }
     }
 

--- a/tlsn/tlsn-prover/Cargo.toml
+++ b/tlsn/tlsn-prover/Cargo.toml
@@ -9,8 +9,8 @@ version = "0.1.0-alpha.3"
 edition = "2021"
 
 [features]
-default = ["formats"]
-formats = ["dep:tlsn-formats"]
+default = []
+#formats = ["dep:tlsn-formats"]
 tracing = [
     "dep:tracing",
     "tlsn-tls-client-async/tracing",
@@ -23,7 +23,7 @@ tlsn-tls-core.workspace = true
 tlsn-tls-client.workspace = true
 tlsn-tls-client-async.workspace = true
 tlsn-core.workspace = true
-tlsn-formats = { workspace = true, optional = true }
+#tlsn-formats = { workspace = true, optional = true }
 tlsn-tls-mpc.workspace = true
 uid-mux.workspace = true
 

--- a/tlsn/tlsn-prover/src/tls/error.rs
+++ b/tlsn/tlsn-prover/src/tls/error.rs
@@ -1,5 +1,4 @@
 use std::error::Error;
-
 use tls_mpc::MpcTlsError;
 use tlsn_core::commitment::TranscriptCommitmentBuilderError;
 
@@ -27,6 +26,8 @@ pub enum ProverError {
     ServerNoCloseNotify,
     #[error(transparent)]
     CommitmentError(#[from] CommitmentError),
+    #[error("Range exceeds transcript length")]
+    InvalidRange,
 }
 
 impl From<MpcTlsError> for ProverError {
@@ -37,6 +38,24 @@ impl From<MpcTlsError> for ProverError {
 
 impl From<mpz_ot::OTError> for ProverError {
     fn from(e: mpz_ot::OTError) -> Self {
+        Self::MpcError(Box::new(e))
+    }
+}
+
+impl From<mpz_garble::VmError> for ProverError {
+    fn from(e: mpz_garble::VmError) -> Self {
+        Self::MpcError(Box::new(e))
+    }
+}
+
+impl From<mpz_garble::MemoryError> for ProverError {
+    fn from(e: mpz_garble::MemoryError) -> Self {
+        Self::MpcError(Box::new(e))
+    }
+}
+
+impl From<mpz_garble::ProveError> for ProverError {
+    fn from(e: mpz_garble::ProveError) -> Self {
         Self::MpcError(Box::new(e))
     }
 }

--- a/tlsn/tlsn-prover/src/tls/future.rs
+++ b/tlsn/tlsn-prover/src/tls/future.rs
@@ -1,0 +1,67 @@
+//! This module collects futures which are used by the [Prover].
+
+use super::{state, Prover, ProverError};
+use futures::{future::FusedFuture, Future};
+use std::pin::Pin;
+
+/// Prover future which must be polled for the TLS connection to make progress.
+pub struct ProverFuture {
+    #[allow(clippy::type_complexity)]
+    pub(crate) fut:
+        Pin<Box<dyn Future<Output = Result<Prover<state::Closed>, ProverError>> + Send + 'static>>,
+}
+
+impl Future for ProverFuture {
+    type Output = Result<Prover<state::Closed>, ProverError>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        self.fut.as_mut().poll(cx)
+    }
+}
+
+/// A future which must be polled for the muxer to make progress.
+pub(crate) struct MuxFuture {
+    pub(crate) fut: Pin<Box<dyn FusedFuture<Output = Result<(), ProverError>> + Send + 'static>>,
+}
+
+impl Future for MuxFuture {
+    type Output = Result<(), ProverError>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        self.fut.as_mut().poll(cx)
+    }
+}
+
+impl FusedFuture for MuxFuture {
+    fn is_terminated(&self) -> bool {
+        self.fut.is_terminated()
+    }
+}
+
+/// A future which must be polled for the Oblivious Transfer protocol to make progress.
+pub(crate) struct OTFuture {
+    pub(crate) fut: Pin<Box<dyn FusedFuture<Output = Result<(), ProverError>> + Send + 'static>>,
+}
+
+impl Future for OTFuture {
+    type Output = Result<(), ProverError>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        self.fut.as_mut().poll(cx)
+    }
+}
+
+impl FusedFuture for OTFuture {
+    fn is_terminated(&self) -> bool {
+        self.fut.is_terminated()
+    }
+}

--- a/tlsn/tlsn-prover/src/tls/mod.rs
+++ b/tlsn/tlsn-prover/src/tls/mod.rs
@@ -7,61 +7,40 @@
 
 mod config;
 mod error;
+mod future;
+mod notarize;
+mod prove;
 pub mod state;
 
 pub use config::{ProverConfig, ProverConfigBuilder, ProverConfigBuilderError};
 pub use error::ProverError;
+pub use future::ProverFuture;
 
-use ff::ShareConversionReveal;
-use futures::{
-    future::FusedFuture, AsyncRead, AsyncWrite, Future, FutureExt, SinkExt, StreamExt, TryFutureExt,
-};
-use rand::Rng;
-use std::{pin::Pin, sync::Arc};
-use tls_client_async::{bind_client, ClosedConnection, TlsConnection};
-use tls_mpc::{setup_components, MpcTlsLeader, TlsRole};
-
+use crate::Mux;
+use error::OTShutdownError;
+use future::{MuxFuture, OTFuture};
+use futures::{AsyncRead, AsyncWrite, FutureExt, StreamExt, TryFutureExt};
 use mpz_garble::{config::Role as DEAPRole, protocol::deap::DEAPVm};
 use mpz_ot::{
     actor::kos::{ReceiverActor, SenderActor, SharedReceiver, SharedSender},
     chou_orlandi, kos,
 };
 use mpz_share_conversion as ff;
+use rand::Rng;
+use state::{Notarize, Prove};
+use std::sync::Arc;
 use tls_client::{ClientConnection, ServerName as TlsServerName};
-use tlsn_core::{
-    commitment::TranscriptCommitmentBuilder,
-    msg::{SignedSessionHeader, TlsnMessage},
-    transcript::Transcript,
-    NotarizedSession, ServerName, SessionData,
-};
+use tls_client_async::{bind_client, ClosedConnection, TlsConnection};
+use tls_mpc::{setup_components, MpcTlsLeader, TlsRole};
+use tlsn_core::transcript::Transcript;
+use uid_mux::{yamux, UidYamux};
+use utils_aio::{codec::BincodeMux, mux::MuxChannel};
+
+#[cfg(feature = "formats")]
+use http::{state as http_state, HttpProver, HttpProverError};
+
 #[cfg(feature = "tracing")]
 use tracing::{debug, debug_span, instrument, Instrument};
-use uid_mux::{yamux, UidYamux};
-use utils_aio::{codec::BincodeMux, expect_msg_or_err, mux::MuxChannel};
-
-use error::OTShutdownError;
-
-use crate::{
-    http::{state as http_state, HttpProver, HttpProverError},
-    Mux,
-};
-
-/// Prover future which must be polled for the TLS connection to make progress.
-pub struct ProverFuture {
-    #[allow(clippy::type_complexity)]
-    fut: Pin<Box<dyn Future<Output = Result<Prover<state::Closed>, ProverError>> + Send + 'static>>,
-}
-
-impl Future for ProverFuture {
-    type Output = Result<Prover<state::Closed>, ProverError>;
-
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        self.fut.as_mut().poll(cx)
-    }
-}
 
 /// A prover instance.
 #[derive(Debug)]
@@ -233,107 +212,22 @@ impl Prover<state::Closed> {
     ///
     /// If the verifier is a Notary, this function will transition the prover to the next state
     /// where it can generate commitments to the transcript prior to finalization.
-    pub fn start_notarize(self) -> Prover<state::Notarize> {
+    pub fn start_notarize(self) -> Prover<Notarize> {
         Prover {
             config: self.config,
             state: self.state.into(),
         }
     }
-}
 
-impl Prover<state::Notarize> {
-    /// Returns the transcript of the sent requests
-    pub fn sent_transcript(&self) -> &Transcript {
-        &self.state.transcript_tx
-    }
-
-    /// Returns the transcript of the received responses
-    pub fn recv_transcript(&self) -> &Transcript {
-        &self.state.transcript_rx
-    }
-
-    /// Returns the transcript commitment builder
-    pub fn commitment_builder(&mut self) -> &mut TranscriptCommitmentBuilder {
-        &mut self.state.builder
-    }
-
-    /// Finalize the notarization returning a [`NotarizedSession`]
-    #[cfg_attr(feature = "tracing", instrument(level = "info", skip(self), err))]
-    pub async fn finalize(self) -> Result<NotarizedSession, ProverError> {
-        let state::Notarize {
-            mut notary_mux,
-            mut mux_fut,
-            mut vm,
-            mut ot_fut,
-            mut gf2,
-            start_time,
-            handshake_decommitment,
-            server_public_key,
-            transcript_tx,
-            transcript_rx,
-            builder,
-        } = self.state;
-
-        let commitments = builder.build()?;
-
-        let session_data = SessionData::new(
-            ServerName::Dns(self.config.server_dns().to_string()),
-            handshake_decommitment,
-            transcript_tx,
-            transcript_rx,
-            commitments,
-        );
-
-        let merkle_root = session_data.commitments().merkle_root();
-
-        let mut notarize_fut = Box::pin(async move {
-            let mut channel = notary_mux.get_channel("notarize").await?;
-
-            channel
-                .send(TlsnMessage::TranscriptCommitmentRoot(merkle_root))
-                .await?;
-
-            let notary_encoder_seed = vm
-                .finalize()
-                .await
-                .map_err(|e| ProverError::MpcError(Box::new(e)))?
-                .expect("encoder seed returned");
-
-            // This is a temporary approach until a maliciously secure share conversion protocol is implemented.
-            // The prover is essentially revealing the TLS MAC key. In some exotic scenarios this allows a malicious
-            // TLS verifier to modify the prover's request.
-            gf2.reveal()
-                .await
-                .map_err(|e| ProverError::MpcError(Box::new(e)))?;
-
-            let signed_header = expect_msg_or_err!(channel, TlsnMessage::SignedSessionHeader)?;
-
-            Ok::<_, ProverError>((notary_encoder_seed, signed_header))
-        })
-        .fuse();
-
-        let (notary_encoder_seed, SignedSessionHeader { header, signature }) = futures::select_biased! {
-            res = notarize_fut => res?,
-            _ = ot_fut => return Err(OTShutdownError)?,
-            _ = mux_fut => return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
-        };
-
-        // Check the header is consistent with the Prover's view
-        header
-            .verify(
-                start_time,
-                &server_public_key,
-                &session_data.commitments().merkle_root(),
-                &notary_encoder_seed,
-                session_data.handshake_data_decommitment(),
-            )
-            .map_err(|_| {
-                ProverError::NotarizationError(
-                    "notary signed an inconsistent session header".to_string(),
-                )
-            })?;
-
-        Ok(NotarizedSession::new(header, Some(signature), session_data))
+    /// Starts proving the TLS session.
+    ///
+    /// This function transitions the prover into a state where it can prove content of the
+    /// transcript.
+    pub fn start_prove(self) -> Prover<Prove> {
+        Prover {
+            config: self.config,
+            state: self.state.into(),
+        }
     }
 }
 
@@ -454,48 +348,4 @@ async fn setup_mpc_backend(
     debug!("MPC backend setup complete");
 
     Ok((mpc_tls, vm, ot_recv, gf2, ot_fut))
-}
-
-/// A future which must be polled for the muxer to make progress.
-pub(crate) struct MuxFuture {
-    fut: Pin<Box<dyn FusedFuture<Output = Result<(), ProverError>> + Send + 'static>>,
-}
-
-impl Future for MuxFuture {
-    type Output = Result<(), ProverError>;
-
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        self.fut.as_mut().poll(cx)
-    }
-}
-
-impl FusedFuture for MuxFuture {
-    fn is_terminated(&self) -> bool {
-        self.fut.is_terminated()
-    }
-}
-
-/// A future which must be polled for the Oblivious Transfer protocol to make progress.
-pub(crate) struct OTFuture {
-    fut: Pin<Box<dyn FusedFuture<Output = Result<(), ProverError>> + Send + 'static>>,
-}
-
-impl Future for OTFuture {
-    type Output = Result<(), ProverError>;
-
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        self.fut.as_mut().poll(cx)
-    }
-}
-
-impl FusedFuture for OTFuture {
-    fn is_terminated(&self) -> bool {
-        self.fut.is_terminated()
-    }
 }

--- a/tlsn/tlsn-prover/src/tls/notarize.rs
+++ b/tlsn/tlsn-prover/src/tls/notarize.rs
@@ -1,0 +1,115 @@
+//! This module handles the notarization phase of the prover.
+//!
+//! The prover deals with a TLS verifier that is only a notary.
+
+use crate::tls::error::OTShutdownError;
+
+use super::{ff::ShareConversionReveal, state::Notarize, Prover, ProverError};
+use futures::{FutureExt, SinkExt, StreamExt};
+use tlsn_core::{
+    commitment::TranscriptCommitmentBuilder,
+    msg::{SignedSessionHeader, TlsnMessage},
+    transcript::Transcript,
+    NotarizedSession, ServerName, SessionData,
+};
+#[cfg(feature = "tracing")]
+use tracing::instrument;
+use utils_aio::{expect_msg_or_err, mux::MuxChannel};
+
+impl Prover<Notarize> {
+    /// Returns the transcript of the sent requests
+    pub fn sent_transcript(&self) -> &Transcript {
+        &self.state.transcript_tx
+    }
+
+    /// Returns the transcript of the received responses
+    pub fn recv_transcript(&self) -> &Transcript {
+        &self.state.transcript_rx
+    }
+
+    /// Returns the transcript commitment builder
+    pub fn commitment_builder(&mut self) -> &mut TranscriptCommitmentBuilder {
+        &mut self.state.builder
+    }
+
+    /// Finalize the notarization returning a [`NotarizedSession`]
+    #[cfg_attr(feature = "tracing", instrument(level = "info", skip(self), err))]
+    pub async fn finalize(self) -> Result<NotarizedSession, ProverError> {
+        let Notarize {
+            mut notary_mux,
+            mut mux_fut,
+            mut vm,
+            mut ot_fut,
+            mut gf2,
+            start_time,
+            handshake_decommitment,
+            server_public_key,
+            transcript_tx,
+            transcript_rx,
+            builder,
+        } = self.state;
+
+        let commitments = builder.build()?;
+
+        let session_data = SessionData::new(
+            ServerName::Dns(self.config.server_dns().to_string()),
+            handshake_decommitment,
+            transcript_tx,
+            transcript_rx,
+            commitments,
+        );
+
+        let merkle_root = session_data.commitments().merkle_root();
+
+        let mut notarize_fut = Box::pin(async move {
+            let mut channel = notary_mux.get_channel("notarize").await?;
+
+            channel
+                .send(TlsnMessage::TranscriptCommitmentRoot(merkle_root))
+                .await?;
+
+            let notary_encoder_seed = vm
+                .finalize()
+                .await
+                .map_err(|e| ProverError::MpcError(Box::new(e)))?
+                .expect("encoder seed returned");
+
+            // This is a temporary approach until a maliciously secure share conversion protocol is implemented.
+            // The prover is essentially revealing the TLS MAC key. In some exotic scenarios this allows a malicious
+            // TLS verifier to modify the prover's request.
+            gf2.reveal()
+                .await
+                .map_err(|e| ProverError::MpcError(Box::new(e)))?;
+
+            let signed_header = expect_msg_or_err!(channel, TlsnMessage::SignedSessionHeader)?;
+
+            Ok::<_, ProverError>((notary_encoder_seed, signed_header))
+        })
+        .fuse();
+
+        let (notary_encoder_seed, SignedSessionHeader { header, signature }) = futures::select_biased! {
+            res = notarize_fut => res?,
+            _ = ot_fut => return Err(OTShutdownError)?,
+            _ = &mut mux_fut => return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
+        };
+        // Wait for the notary to correctly close the connection
+        mux_fut.await?;
+
+        // Check the header is consistent with the Prover's view
+        header
+            .verify(
+                start_time,
+                &server_public_key,
+                &session_data.commitments().merkle_root(),
+                &notary_encoder_seed,
+                &session_data.session_info().handshake_decommitment,
+            )
+            .map_err(|_| {
+                ProverError::NotarizationError(
+                    "notary signed an inconsistent session header".to_string(),
+                )
+            })?;
+
+        Ok(NotarizedSession::new(header, Some(signature), session_data))
+    }
+}

--- a/tlsn/tlsn-prover/src/tls/prove.rs
+++ b/tlsn/tlsn-prover/src/tls/prove.rs
@@ -1,0 +1,206 @@
+//! This module handles the proving phase of the prover.
+//!
+//! Here the prover deals with a verifier directly, so there is no notary involved. Instead
+//! the verifier directly verifies parts of the transcript.
+
+use super::{state::Prove as ProveState, Prover, ProverError};
+use crate::tls::error::OTShutdownError;
+use futures::{FutureExt, SinkExt};
+use mpz_garble::{Memory, Prove, Vm};
+use mpz_share_conversion::ShareConversionReveal;
+use tlsn_core::{
+    msg::TlsnMessage, proof::SessionInfo, transcript::get_value_ids, Direction, ServerName,
+    Transcript,
+};
+use utils::range::{RangeSet, RangeUnion};
+use utils_aio::mux::MuxChannel;
+
+#[cfg(feature = "tracing")]
+use tracing::info;
+
+impl Prover<ProveState> {
+    /// Returns the transcript of the sent requests
+    pub fn sent_transcript(&self) -> &Transcript {
+        &self.state.transcript_tx
+    }
+
+    /// Returns the transcript of the received responses
+    pub fn recv_transcript(&self) -> &Transcript {
+        &self.state.transcript_rx
+    }
+
+    /// Reveal certain parts of the transcripts to the verifier
+    ///
+    /// This function allows to collect certain transcript ranges. When [Prover::prove] is called, these
+    /// ranges will be opened to the verifier.
+    ///
+    /// # Arguments
+    /// * `ranges` - The ranges of the transcript to reveal
+    /// * `direction` - The direction of the transcript to reveal
+    pub fn reveal(
+        &mut self,
+        ranges: impl Into<RangeSet<usize>>,
+        direction: Direction,
+    ) -> Result<(), ProverError> {
+        let sent_ids = &mut self.state.proving_info.sent_ids;
+        let recv_ids = &mut self.state.proving_info.recv_ids;
+
+        let range_set = ranges.into();
+
+        // Check ranges
+        let transcript = match direction {
+            Direction::Sent => &self.state.transcript_tx,
+            Direction::Received => &self.state.transcript_rx,
+        };
+
+        if range_set.max().unwrap_or_default() > transcript.data().len() {
+            return Err(ProverError::InvalidRange);
+        }
+
+        match direction {
+            Direction::Sent => *sent_ids = sent_ids.union(&range_set),
+            Direction::Received => *recv_ids = recv_ids.union(&range_set),
+        }
+
+        Ok(())
+    }
+
+    /// Prove transcript values
+    pub async fn prove(&mut self) -> Result<(), ProverError> {
+        let mut proving_info = std::mem::take(&mut self.state.proving_info);
+
+        let mut prove_fut = Box::pin(async {
+            // Create a new channel and vm thread if not already present
+            let channel = if let Some(ref mut channel) = self.state.channel {
+                channel
+            } else {
+                self.state.channel = Some(self.state.verify_mux.get_channel("prove-verify").await?);
+                self.state.channel.as_mut().unwrap()
+            };
+
+            let prove_thread = if let Some(ref mut prove_thread) = self.state.prove_thread {
+                prove_thread
+            } else {
+                self.state.prove_thread = Some(self.state.vm.new_thread("prove-verify").await?);
+                self.state.prove_thread.as_mut().unwrap()
+            };
+
+            // Now prove the transcript parts which have been marked for reveal
+            let sent_value_ids = proving_info
+                .sent_ids
+                .iter_ranges()
+                .map(|r| get_value_ids(&r.into(), Direction::Sent).collect::<Vec<String>>());
+            let recv_value_ids = proving_info
+                .recv_ids
+                .iter_ranges()
+                .map(|r| get_value_ids(&r.into(), Direction::Received).collect::<Vec<String>>());
+
+            let value_refs = sent_value_ids
+                .chain(recv_value_ids)
+                .map(|ids| {
+                    let inner_refs = ids
+                        .iter()
+                        .map(|id| {
+                            prove_thread
+                                .get_value(id.as_str())
+                                .expect("Byte should be in VM memory")
+                        })
+                        .collect::<Vec<_>>();
+
+                    prove_thread
+                        .array_from_values(inner_refs.as_slice())
+                        .expect("Byte should be in VM Memory")
+                })
+                .collect::<Vec<_>>();
+
+            // Extract cleartext we want to reveal from transcripts
+            let mut cleartext =
+                Vec::with_capacity(proving_info.sent_ids.len() + proving_info.recv_ids.len());
+            proving_info
+                .sent_ids
+                .iter_ranges()
+                .for_each(|r| cleartext.extend_from_slice(&self.state.transcript_tx.data()[r]));
+            proving_info
+                .recv_ids
+                .iter_ranges()
+                .for_each(|r| cleartext.extend_from_slice(&self.state.transcript_rx.data()[r]));
+            proving_info.cleartext = cleartext;
+
+            // Send the proving info to the verifier
+            channel.send(TlsnMessage::ProvingInfo(proving_info)).await?;
+
+            #[cfg(feature = "tracing")]
+            info!("Sent proving info to verifier");
+
+            // Prove the revealed transcript parts
+            prove_thread.prove(value_refs.as_slice()).await?;
+
+            #[cfg(feature = "tracing")]
+            info!("Successfully proved cleartext");
+
+            Ok::<_, ProverError>(())
+        })
+        .fuse();
+
+        futures::select_biased! {
+            res = prove_fut => res?,
+            _ = &mut self.state.ot_fut => return Err(OTShutdownError)?,
+            _ = &mut self.state.mux_fut => return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
+        };
+
+        Ok(())
+    }
+
+    /// Finalize the proving
+    pub async fn finalize(self) -> Result<(), ProverError> {
+        let ProveState {
+            mut verify_mux,
+            mut mux_fut,
+            mut vm,
+            mut ot_fut,
+            mut gf2,
+            handshake_decommitment,
+            ..
+        } = self.state;
+
+        // Create session data and session_info
+        let session_info = SessionInfo {
+            server_name: ServerName::Dns(self.config.server_dns().to_string()),
+            handshake_decommitment,
+        };
+
+        let mut finalize_fut = Box::pin(async move {
+            let mut channel = verify_mux.get_channel("finalize").await?;
+
+            _ = vm
+                .finalize()
+                .await
+                .map_err(|e| ProverError::MpcError(Box::new(e)))?
+                .expect("encoder seed returned");
+
+            // This is a temporary approach until a maliciously secure share conversion protocol is implemented.
+            // The prover is essentially revealing the TLS MAC key. In some exotic scenarios this allows a malicious
+            // TLS verifier to modify the prover's request.
+            gf2.reveal()
+                .await
+                .map_err(|e| ProverError::MpcError(Box::new(e)))?;
+
+            // Send session_info to the verifier
+            channel.send(TlsnMessage::SessionInfo(session_info)).await?;
+
+            Ok::<_, ProverError>(())
+        })
+        .fuse();
+
+        futures::select_biased! {
+            res = finalize_fut => res?,
+            _ = ot_fut => return Err(OTShutdownError)?,
+            _ = &mut mux_fut => return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
+        };
+
+        // We need to wait for the verifier to correctly close the connection. Otherwise the prover
+        // would rush ahead and close the connection before the verifier has finished.
+        mux_fut.await?;
+        Ok(())
+    }
+}

--- a/tlsn/tlsn-prover/src/tls/state.rs
+++ b/tlsn/tlsn-prover/src/tls/state.rs
@@ -1,21 +1,23 @@
 //! TLS prover states.
 
-use std::collections::HashMap;
-
-use mpz_garble_core::{encoding_state, EncodedValue};
-use mpz_ot::actor::kos::{SharedReceiver, SharedSender};
-
-use mpz_core::commit::Decommitment;
-use mpz_garble::protocol::deap::{DEAPVm, PeerEncodings};
-use mpz_share_conversion::{ConverterSender, Gf2_128};
-use tls_core::{handshake::HandshakeData, key::PublicKey};
-use tls_mpc::MpcTlsLeader;
-use tlsn_core::{commitment::TranscriptCommitmentBuilder, Transcript};
-
 use crate::{
     tls::{MuxFuture, OTFuture},
     Mux,
 };
+use mpz_core::commit::Decommitment;
+use mpz_garble::protocol::deap::{DEAPThread, DEAPVm, PeerEncodings};
+use mpz_garble_core::{encoding_state, EncodedValue};
+use mpz_ot::actor::kos::{SharedReceiver, SharedSender};
+use mpz_share_conversion::{ConverterSender, Gf2_128};
+use std::collections::HashMap;
+use tls_core::{handshake::HandshakeData, key::PublicKey};
+use tls_mpc::MpcTlsLeader;
+use tlsn_core::{
+    commitment::TranscriptCommitmentBuilder,
+    msg::{ProvingInfo, TlsnMessage},
+    Transcript,
+};
+use utils_aio::duplex::Duplex;
 
 /// Entry state
 pub struct Initialized;
@@ -107,6 +109,43 @@ impl From<Closed> for Notarize {
     }
 }
 
+/// Proving state.
+pub struct Prove {
+    pub(crate) verify_mux: Mux,
+    pub(crate) mux_fut: MuxFuture,
+
+    pub(crate) vm: DEAPVm<SharedSender, SharedReceiver>,
+    pub(crate) ot_fut: OTFuture,
+    pub(crate) gf2: ConverterSender<Gf2_128, SharedSender>,
+
+    pub(crate) handshake_decommitment: Decommitment<HandshakeData>,
+
+    pub(crate) transcript_tx: Transcript,
+    pub(crate) transcript_rx: Transcript,
+
+    pub(crate) proving_info: ProvingInfo,
+    pub(crate) channel: Option<Box<dyn Duplex<TlsnMessage>>>,
+    pub(crate) prove_thread: Option<DEAPThread<SharedSender, SharedReceiver>>,
+}
+
+impl From<Closed> for Prove {
+    fn from(state: Closed) -> Self {
+        Self {
+            verify_mux: state.notary_mux,
+            mux_fut: state.mux_fut,
+            vm: state.vm,
+            ot_fut: state.ot_fut,
+            gf2: state.gf2,
+            handshake_decommitment: state.handshake_decommitment,
+            transcript_tx: state.transcript_tx,
+            transcript_rx: state.transcript_rx,
+            proving_info: ProvingInfo::default(),
+            channel: None,
+            prove_thread: None,
+        }
+    }
+}
+
 #[allow(missing_docs)]
 pub trait ProverState: sealed::Sealed {}
 
@@ -114,6 +153,7 @@ impl ProverState for Initialized {}
 impl ProverState for Setup {}
 impl ProverState for Closed {}
 impl ProverState for Notarize {}
+impl ProverState for Prove {}
 
 mod sealed {
     pub trait Sealed {}
@@ -121,6 +161,7 @@ mod sealed {
     impl Sealed for super::Setup {}
     impl Sealed for super::Closed {}
     impl Sealed for super::Notarize {}
+    impl Sealed for super::Prove {}
 }
 
 fn collect_encodings(

--- a/tlsn/tlsn-verifier/Cargo.toml
+++ b/tlsn/tlsn-verifier/Cargo.toml
@@ -23,6 +23,7 @@ mpz-core.workspace = true
 mpz-garble.workspace = true
 mpz-ot.workspace = true
 mpz-share-conversion.workspace = true
+mpz-circuits.workspace = true
 
 futures.workspace = true
 thiserror.workspace = true

--- a/tlsn/tlsn-verifier/src/tls/config.rs
+++ b/tlsn/tlsn-verifier/src/tls/config.rs
@@ -1,12 +1,16 @@
 use mpz_ot::{chou_orlandi, kos};
 use mpz_share_conversion::{ReceiverConfig, SenderConfig};
+use std::fmt::{Debug, Formatter, Result};
+use tls_core::verify::{ServerCertVerifier, WebPkiVerifier};
 use tls_mpc::{MpcTlsCommonConfig, MpcTlsFollowerConfig};
+use tlsn_core::proof::default_cert_verifier;
 
 const DEFAULT_MAX_TRANSCRIPT_SIZE: usize = 1 << 14; // 16Kb
 
-/// Configuration for the [`Verifier`](crate::Verifier)
+/// Configuration for the [`Verifier`](crate::tls::Verifier)
 #[allow(missing_docs)]
-#[derive(Debug, Clone, derive_builder::Builder)]
+#[derive(derive_builder::Builder)]
+#[builder(pattern = "owned")]
 pub struct VerifierConfig {
     #[builder(setter(into))]
     id: String,
@@ -16,6 +20,22 @@ pub struct VerifierConfig {
     /// This includes the number of bytes sent and received to the server.
     #[builder(default = "DEFAULT_MAX_TRANSCRIPT_SIZE")]
     max_transcript_size: usize,
+    #[builder(
+        pattern = "owned",
+        setter(strip_option),
+        default = "Some(default_cert_verifier())"
+    )]
+    cert_verifier: Option<WebPkiVerifier>,
+}
+
+impl Debug for VerifierConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        f.debug_struct("VerifierConfig")
+            .field("id", &self.id)
+            .field("max_transcript_size", &self.max_transcript_size)
+            .field("cert_verifier", &"_")
+            .finish()
+    }
 }
 
 impl VerifierConfig {
@@ -32,6 +52,13 @@ impl VerifierConfig {
     /// Get the maximum transcript size in bytes.
     pub fn max_transcript_size(&self) -> usize {
         self.max_transcript_size
+    }
+
+    /// Get the certificate verifier.
+    pub fn cert_verifier(&self) -> &impl ServerCertVerifier {
+        self.cert_verifier
+            .as_ref()
+            .expect("Certificate verifier should be set")
     }
 
     pub(crate) fn build_base_ot_sender_config(&self) -> chou_orlandi::SenderConfig {

--- a/tlsn/tlsn-verifier/src/tls/error.rs
+++ b/tlsn/tlsn-verifier/src/tls/error.rs
@@ -1,5 +1,4 @@
 use std::error::Error;
-
 use tls_mpc::MpcTlsError;
 
 /// An error that can occur during TLS verification.
@@ -12,6 +11,8 @@ pub enum VerifierError {
     MuxerError(#[from] utils_aio::mux::MuxerError),
     #[error("error occurred in MPC protocol: {0}")]
     MpcError(Box<dyn Error + Send + 'static>),
+    #[error("Range exceeds transcript length")]
+    InvalidRange,
 }
 
 impl From<MpcTlsError> for VerifierError {
@@ -34,6 +35,30 @@ impl From<mpz_ot::actor::kos::SenderActorError> for VerifierError {
 
 impl From<mpz_ot::actor::kos::ReceiverActorError> for VerifierError {
     fn from(e: mpz_ot::actor::kos::ReceiverActorError) -> Self {
+        Self::MpcError(Box::new(e))
+    }
+}
+
+impl From<mpz_garble::VerifyError> for VerifierError {
+    fn from(e: mpz_garble::VerifyError) -> Self {
+        Self::MpcError(Box::new(e))
+    }
+}
+
+impl From<mpz_garble::MemoryError> for VerifierError {
+    fn from(e: mpz_garble::MemoryError) -> Self {
+        Self::MpcError(Box::new(e))
+    }
+}
+
+impl From<tlsn_core::proof::SessionProofError> for VerifierError {
+    fn from(e: tlsn_core::proof::SessionProofError) -> Self {
+        Self::MpcError(Box::new(e))
+    }
+}
+
+impl From<mpz_garble::VmError> for VerifierError {
+    fn from(e: mpz_garble::VmError) -> Self {
         Self::MpcError(Box::new(e))
     }
 }

--- a/tlsn/tlsn-verifier/src/tls/future.rs
+++ b/tlsn/tlsn-verifier/src/tls/future.rs
@@ -1,0 +1,50 @@
+//! This module collects futures which are used by the [Verifier](crate::tls::Verifier).
+
+use super::{OTSenderActor, VerifierError};
+use futures::{future::FusedFuture, Future};
+use std::pin::Pin;
+
+/// A future which must be polled for the muxer to make progress.
+pub(crate) struct MuxFuture {
+    pub(crate) fut: Pin<Box<dyn FusedFuture<Output = Result<(), VerifierError>> + Send + 'static>>,
+}
+
+impl Future for MuxFuture {
+    type Output = Result<(), VerifierError>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        self.fut.as_mut().poll(cx)
+    }
+}
+
+impl FusedFuture for MuxFuture {
+    fn is_terminated(&self) -> bool {
+        self.fut.is_terminated()
+    }
+}
+
+/// A future which must be polled for the Oblivious Transfer protocol to make progress.
+pub(crate) struct OTFuture {
+    pub(crate) fut:
+        Pin<Box<dyn FusedFuture<Output = Result<OTSenderActor, VerifierError>> + Send + 'static>>,
+}
+
+impl Future for OTFuture {
+    type Output = Result<OTSenderActor, VerifierError>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        self.fut.as_mut().poll(cx)
+    }
+}
+
+impl FusedFuture for OTFuture {
+    fn is_terminated(&self) -> bool {
+        self.fut.is_terminated()
+    }
+}

--- a/tlsn/tlsn-verifier/src/tls/mod.rs
+++ b/tlsn/tlsn-verifier/src/tls/mod.rs
@@ -2,23 +2,20 @@
 
 pub(crate) mod config;
 mod error;
+mod future;
+mod notarize;
 pub mod state;
+mod verify;
 
 pub use config::{VerifierConfig, VerifierConfigBuilder, VerifierConfigBuilderError};
 pub use error::VerifierError;
 
-use std::{
-    pin::Pin,
-    time::{SystemTime, UNIX_EPOCH},
-};
-
+use crate::{tls::future::OTFuture, Mux};
+use future::MuxFuture;
 use futures::{
-    future::FusedFuture,
     stream::{SplitSink, SplitStream},
-    AsyncRead, AsyncWrite, Future, FutureExt, SinkExt, StreamExt, TryFutureExt,
+    AsyncRead, AsyncWrite, FutureExt, StreamExt, TryFutureExt,
 };
-
-use mpz_core::serialize::CanonicalSerialize;
 use mpz_garble::{config::Role as GarbleRole, protocol::deap::DEAPVm};
 use mpz_ot::{
     actor::kos::{
@@ -27,18 +24,14 @@ use mpz_ot::{
     chou_orlandi, kos,
 };
 use mpz_share_conversion as ff;
-use mpz_share_conversion::ShareConversionVerify;
 use rand::Rng;
 use signature::Signer;
+use state::{Notarize, Verify};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tls_mpc::{setup_components, MpcTlsFollower, TlsRole};
-use tlsn_core::{
-    msg::{SignedSessionHeader, TlsnMessage},
-    HandshakeSummary, SessionHeader, Signature,
-};
+use tlsn_core::{proof::SessionInfo, RedactedTranscript, SessionHeader, Signature};
 use uid_mux::{yamux, UidYamux};
-use utils_aio::{codec::BincodeMux, duplex::Duplex, expect_msg_or_err, mux::MuxChannel};
-
-use crate::Mux;
+use utils_aio::{codec::BincodeMux, duplex::Duplex, mux::MuxChannel};
 
 #[cfg(feature = "tracing")]
 use tracing::{debug, info, instrument};
@@ -123,8 +116,23 @@ impl Verifier<state::Initialized> {
             .await?
             .run()
             .await?
-            .notarize(signer)
+            .start_notarize()
+            .finalize(signer)
             .await
+    }
+
+    /// Runs the TLS verifier to completion, verifying the TLS session.
+    ///
+    /// This is a convenience method which runs all the steps needed for verification.
+    pub async fn verify<S: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
+        self,
+        socket: S,
+    ) -> Result<(RedactedTranscript, RedactedTranscript, SessionInfo), VerifierError> {
+        let mut verifier = self.setup(socket).await?.run().await?.start_verify();
+        let (redacted_sent, redacted_received) = verifier.receive().await?;
+
+        let session_info = verifier.finalize().await?;
+        Ok((redacted_sent, redacted_received, session_info))
     }
 }
 
@@ -186,92 +194,26 @@ impl Verifier<state::Setup> {
 }
 
 impl Verifier<state::Closed> {
-    /// Notarizes the TLS session.
-    pub async fn notarize<T>(self, signer: &impl Signer<T>) -> Result<SessionHeader, VerifierError>
-    where
-        T: Into<Signature>,
-    {
-        let state::Closed {
-            mut mux,
-            mut mux_fut,
-            mut vm,
-            ot_send,
-            ot_recv,
-            ot_fut,
-            mut gf2,
-            encoder_seed,
-            start_time,
-            server_ephemeral_key,
-            handshake_commitment,
-            sent_len,
-            recv_len,
-        } = self.state;
+    /// Starts notarization of the TLS session.
+    ///
+    /// If the verifier is a Notary, this function will transition the verifier to the next state
+    /// where it can sign the prover's commitments to the transcript.
+    pub fn start_notarize(self) -> Verifier<Notarize> {
+        Verifier {
+            config: self.config,
+            state: self.state.into(),
+        }
+    }
 
-        let notarize_fut = async {
-            let mut notarize_channel = mux.get_channel("notarize").await?;
-
-            let merkle_root =
-                expect_msg_or_err!(notarize_channel, TlsnMessage::TranscriptCommitmentRoot)?;
-
-            // Finalize all MPC before signing the session header
-            let (mut ot_sender_actor, _, _) = futures::try_join!(
-                ot_fut,
-                ot_send.shutdown().map_err(VerifierError::from),
-                ot_recv.shutdown().map_err(VerifierError::from)
-            )?;
-
-            ot_sender_actor.reveal().await?;
-
-            vm.finalize()
-                .await
-                .map_err(|e| VerifierError::MpcError(Box::new(e)))?;
-
-            gf2.verify()
-                .await
-                .map_err(|e| VerifierError::MpcError(Box::new(e)))?;
-
-            #[cfg(feature = "tracing")]
-            info!("Finalized all MPC");
-
-            let handshake_summary =
-                HandshakeSummary::new(start_time, server_ephemeral_key, handshake_commitment);
-
-            let session_header = SessionHeader::new(
-                encoder_seed,
-                merkle_root,
-                sent_len,
-                recv_len,
-                handshake_summary,
-            );
-
-            let signature = signer.sign(&session_header.to_bytes());
-
-            #[cfg(feature = "tracing")]
-            info!("Signed session header");
-
-            notarize_channel
-                .send(TlsnMessage::SignedSessionHeader(SignedSessionHeader {
-                    header: session_header.clone(),
-                    signature: signature.into(),
-                }))
-                .await?;
-
-            #[cfg(feature = "tracing")]
-            info!("Sent session header");
-
-            Ok::<_, VerifierError>(session_header)
-        };
-
-        let session_header = futures::select! {
-            res = notarize_fut.fuse() => res?,
-            _ = &mut mux_fut => Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
-        };
-
-        let mut mux = mux.into_inner();
-
-        futures::try_join!(mux.close().map_err(VerifierError::from), mux_fut)?;
-
-        Ok(session_header)
+    /// Starts verification of the TLS session.
+    ///
+    /// This function transitions the verifier into a state where it can verify content of the
+    /// transcript.
+    pub fn start_verify(self) -> Verifier<Verify> {
+        Verifier {
+            config: self.config,
+            state: self.state.into(),
+        }
     }
 }
 
@@ -394,48 +336,4 @@ async fn setup_mpc_backend(
     debug!("MPC backend setup complete");
 
     Ok((mpc_tls, vm, ot_send, ot_recv, gf2, ot_fut))
-}
-
-/// A future which must be polled for the muxer to make progress.
-pub(crate) struct MuxFuture {
-    fut: Pin<Box<dyn FusedFuture<Output = Result<(), VerifierError>> + Send + 'static>>,
-}
-
-impl Future for MuxFuture {
-    type Output = Result<(), VerifierError>;
-
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        self.fut.as_mut().poll(cx)
-    }
-}
-
-impl FusedFuture for MuxFuture {
-    fn is_terminated(&self) -> bool {
-        self.fut.is_terminated()
-    }
-}
-
-/// A future which must be polled for the Oblivious Transfer protocol to make progress.
-pub(crate) struct OTFuture {
-    fut: Pin<Box<dyn FusedFuture<Output = Result<OTSenderActor, VerifierError>> + Send + 'static>>,
-}
-
-impl Future for OTFuture {
-    type Output = Result<OTSenderActor, VerifierError>;
-
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        self.fut.as_mut().poll(cx)
-    }
-}
-
-impl FusedFuture for OTFuture {
-    fn is_terminated(&self) -> bool {
-        self.fut.is_terminated()
-    }
 }

--- a/tlsn/tlsn-verifier/src/tls/notarize.rs
+++ b/tlsn/tlsn-verifier/src/tls/notarize.rs
@@ -1,0 +1,107 @@
+//! This module handles the notarization phase of the verifier.
+//!
+//! The TLS verifier is only a notary.
+
+use super::{state::Notarize, Verifier, VerifierError};
+use futures::{FutureExt, SinkExt, StreamExt, TryFutureExt};
+use mpz_core::serialize::CanonicalSerialize;
+use mpz_share_conversion::ShareConversionVerify;
+use signature::Signer;
+use tlsn_core::{
+    msg::{SignedSessionHeader, TlsnMessage},
+    HandshakeSummary, SessionHeader, Signature,
+};
+use utils_aio::{expect_msg_or_err, mux::MuxChannel};
+
+#[cfg(feature = "tracing")]
+use tracing::info;
+
+impl Verifier<Notarize> {
+    /// Notarizes the TLS session.
+    pub async fn finalize<T>(self, signer: &impl Signer<T>) -> Result<SessionHeader, VerifierError>
+    where
+        T: Into<Signature>,
+    {
+        let Notarize {
+            mut mux,
+            mut mux_fut,
+            mut vm,
+            ot_send,
+            ot_recv,
+            ot_fut,
+            mut gf2,
+            encoder_seed,
+            start_time,
+            server_ephemeral_key,
+            handshake_commitment,
+            sent_len,
+            recv_len,
+        } = self.state;
+
+        let notarize_fut = async {
+            let mut notarize_channel = mux.get_channel("notarize").await?;
+
+            let merkle_root =
+                expect_msg_or_err!(notarize_channel, TlsnMessage::TranscriptCommitmentRoot)?;
+
+            // Finalize all MPC before signing the session header
+            let (mut ot_sender_actor, _, _) = futures::try_join!(
+                ot_fut,
+                ot_send.shutdown().map_err(VerifierError::from),
+                ot_recv.shutdown().map_err(VerifierError::from)
+            )?;
+
+            ot_sender_actor.reveal().await?;
+
+            vm.finalize()
+                .await
+                .map_err(|e| VerifierError::MpcError(Box::new(e)))?;
+
+            gf2.verify()
+                .await
+                .map_err(|e| VerifierError::MpcError(Box::new(e)))?;
+
+            #[cfg(feature = "tracing")]
+            info!("Finalized all MPC");
+
+            let handshake_summary =
+                HandshakeSummary::new(start_time, server_ephemeral_key, handshake_commitment);
+
+            let session_header = SessionHeader::new(
+                encoder_seed,
+                merkle_root,
+                sent_len,
+                recv_len,
+                handshake_summary,
+            );
+
+            let signature = signer.sign(&session_header.to_bytes());
+
+            #[cfg(feature = "tracing")]
+            info!("Signed session header");
+
+            notarize_channel
+                .send(TlsnMessage::SignedSessionHeader(SignedSessionHeader {
+                    header: session_header.clone(),
+                    signature: signature.into(),
+                }))
+                .await?;
+
+            #[cfg(feature = "tracing")]
+            info!("Sent session header");
+
+            Ok::<_, VerifierError>(session_header)
+        };
+
+        let session_header = futures::select! {
+            res = notarize_fut.fuse() => res?,
+            _ = &mut mux_fut => Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
+        };
+
+        let mut mux = mux.into_inner();
+
+        futures::try_join!(mux.close().map_err(VerifierError::from), mux_fut)?;
+
+        Ok(session_header)
+    }
+}

--- a/tlsn/tlsn-verifier/src/tls/state.rs
+++ b/tlsn/tlsn-verifier/src/tls/state.rs
@@ -1,14 +1,16 @@
 //! TLS Verifier state.
 
 use mpz_core::hash::Hash;
-use mpz_garble::protocol::deap::DEAPVm;
+use mpz_garble::protocol::deap::{DEAPThread, DEAPVm};
 use mpz_ot::actor::kos::{SharedReceiver, SharedSender};
 use mpz_share_conversion::{ConverterReceiver, Gf2_128};
 use tls_core::key::PublicKey;
 use tls_mpc::MpcTlsFollower;
+use tlsn_core::msg::TlsnMessage;
+use utils_aio::duplex::Duplex;
 
 use crate::{
-    tls::{MuxFuture, OTFuture},
+    tls::future::{MuxFuture, OTFuture},
     Mux,
 };
 
@@ -56,13 +58,102 @@ pub struct Closed {
 
 opaque_debug::implement!(Closed);
 
+/// Notarizing state.
+pub struct Notarize {
+    pub(crate) mux: Mux,
+    pub(crate) mux_fut: MuxFuture,
+
+    pub(crate) vm: DEAPVm<SharedSender, SharedReceiver>,
+    pub(crate) ot_send: SharedSender,
+    pub(crate) ot_recv: SharedReceiver,
+    pub(crate) ot_fut: OTFuture,
+    pub(crate) gf2: ConverterReceiver<Gf2_128, SharedReceiver>,
+
+    pub(crate) encoder_seed: [u8; 32],
+    pub(crate) start_time: u64,
+    pub(crate) server_ephemeral_key: PublicKey,
+    pub(crate) handshake_commitment: Hash,
+    pub(crate) sent_len: usize,
+    pub(crate) recv_len: usize,
+}
+
+opaque_debug::implement!(Notarize);
+
+impl From<Closed> for Notarize {
+    fn from(value: Closed) -> Self {
+        Self {
+            mux: value.mux,
+            mux_fut: value.mux_fut,
+            vm: value.vm,
+            ot_send: value.ot_send,
+            ot_recv: value.ot_recv,
+            ot_fut: value.ot_fut,
+            gf2: value.gf2,
+            encoder_seed: value.encoder_seed,
+            start_time: value.start_time,
+            server_ephemeral_key: value.server_ephemeral_key,
+            handshake_commitment: value.handshake_commitment,
+            sent_len: value.sent_len,
+            recv_len: value.recv_len,
+        }
+    }
+}
+
+/// Verifying state.
+pub struct Verify {
+    pub(crate) mux: Mux,
+    pub(crate) mux_fut: MuxFuture,
+
+    pub(crate) vm: DEAPVm<SharedSender, SharedReceiver>,
+    pub(crate) ot_send: SharedSender,
+    pub(crate) ot_recv: SharedReceiver,
+    pub(crate) ot_fut: OTFuture,
+    pub(crate) gf2: ConverterReceiver<Gf2_128, SharedReceiver>,
+
+    pub(crate) start_time: u64,
+    pub(crate) server_ephemeral_key: PublicKey,
+    pub(crate) handshake_commitment: Hash,
+    pub(crate) sent_len: usize,
+    pub(crate) recv_len: usize,
+
+    pub(crate) channel: Option<Box<dyn Duplex<TlsnMessage>>>,
+    pub(crate) verify_thread: Option<DEAPThread<SharedSender, SharedReceiver>>,
+}
+
+opaque_debug::implement!(Verify);
+
+impl From<Closed> for Verify {
+    fn from(value: Closed) -> Self {
+        Self {
+            mux: value.mux,
+            mux_fut: value.mux_fut,
+            vm: value.vm,
+            ot_send: value.ot_send,
+            ot_recv: value.ot_recv,
+            ot_fut: value.ot_fut,
+            gf2: value.gf2,
+            start_time: value.start_time,
+            server_ephemeral_key: value.server_ephemeral_key,
+            handshake_commitment: value.handshake_commitment,
+            sent_len: value.sent_len,
+            recv_len: value.recv_len,
+            channel: None,
+            verify_thread: None,
+        }
+    }
+}
+
 impl VerifierState for Initialized {}
 impl VerifierState for Setup {}
 impl VerifierState for Closed {}
+impl VerifierState for Notarize {}
+impl VerifierState for Verify {}
 
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::Initialized {}
     impl Sealed for super::Setup {}
     impl Sealed for super::Closed {}
+    impl Sealed for super::Notarize {}
+    impl Sealed for super::Verify {}
 }

--- a/tlsn/tlsn-verifier/src/tls/verify.rs
+++ b/tlsn/tlsn-verifier/src/tls/verify.rs
@@ -1,0 +1,197 @@
+//! This module handles the verification phase of the verifier.
+//!
+//! The TLS verifier is an application-specific verifier.
+
+use super::{state::Verify as VerifyState, Verifier, VerifierError};
+use futures::{FutureExt, StreamExt, TryFutureExt};
+use mpz_circuits::types::Value;
+use mpz_garble::{Memory, Verify, Vm};
+use mpz_share_conversion::ShareConversionVerify;
+use tlsn_core::{
+    msg::TlsnMessage, proof::SessionInfo, transcript::get_value_ids, Direction, HandshakeSummary,
+    RedactedTranscript, TranscriptSlice,
+};
+use utils_aio::{expect_msg_or_err, mux::MuxChannel};
+
+#[cfg(feature = "tracing")]
+use tracing::info;
+
+impl Verifier<VerifyState> {
+    /// Receives the **purported** transcript from the Prover.
+    ///
+    /// # Warning
+    ///
+    /// The content of the received transcripts can not be considered authentic until after finalization.
+    pub async fn receive(
+        &mut self,
+    ) -> Result<(RedactedTranscript, RedactedTranscript), VerifierError> {
+        let verify_fut = async {
+            // Create a new channel and vm thread if not already present
+            let channel = if let Some(ref mut channel) = self.state.channel {
+                channel
+            } else {
+                self.state.channel = Some(self.state.mux.get_channel("prove-verify").await?);
+                self.state.channel.as_mut().unwrap()
+            };
+
+            let verify_thread = if let Some(ref mut verify_thread) = self.state.verify_thread {
+                verify_thread
+            } else {
+                self.state.verify_thread = Some(self.state.vm.new_thread("prove-verify").await?);
+                self.state.verify_thread.as_mut().unwrap()
+            };
+
+            // Receive the proving info from the prover
+            let mut proving_info = expect_msg_or_err!(channel, TlsnMessage::ProvingInfo)?;
+            let mut cleartext = proving_info.cleartext.clone();
+
+            #[cfg(feature = "tracing")]
+            info!("Received proving info from prover");
+
+            // Check ranges
+            if proving_info.sent_ids.max().unwrap_or_default() > self.state.sent_len
+                || proving_info.recv_ids.max().unwrap_or_default() > self.state.recv_len
+            {
+                return Err(VerifierError::InvalidRange);
+            }
+
+            // Now verify the transcript parts which the prover wants to reveal
+            let sent_value_ids = proving_info
+                .sent_ids
+                .iter_ranges()
+                .map(|r| get_value_ids(&r.into(), Direction::Sent).collect::<Vec<String>>());
+            let recv_value_ids = proving_info
+                .recv_ids
+                .iter_ranges()
+                .map(|r| get_value_ids(&r.into(), Direction::Received).collect::<Vec<String>>());
+
+            let value_refs = sent_value_ids
+                .chain(recv_value_ids)
+                .map(|ids| {
+                    let inner_refs = ids
+                        .iter()
+                        .map(|id| {
+                            verify_thread
+                                .get_value(id.as_str())
+                                .expect("Byte should be in VM memory")
+                        })
+                        .collect::<Vec<_>>();
+
+                    verify_thread
+                        .array_from_values(inner_refs.as_slice())
+                        .expect("Byte should be in VM Memory")
+                })
+                .collect::<Vec<_>>();
+
+            let values = proving_info
+                .sent_ids
+                .iter_ranges()
+                .chain(proving_info.recv_ids.iter_ranges())
+                .map(|range| {
+                    Value::Array(cleartext.drain(..range.len()).map(|b| (b).into()).collect())
+                })
+                .collect::<Vec<_>>();
+
+            // Check that purported values are correct
+            verify_thread.verify(&value_refs, &values).await?;
+
+            #[cfg(feature = "tracing")]
+            info!("Successfully verified purported cleartext");
+
+            // Create redacted transcripts
+            let mut transcripts = proving_info
+                .sent_ids
+                .iter_ranges()
+                .chain(proving_info.recv_ids.iter_ranges())
+                .map(|range| {
+                    TranscriptSlice::new(
+                        range.clone(),
+                        proving_info.cleartext.drain(..range.len()).collect(),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            let recv_transcripts =
+                transcripts.split_off(proving_info.sent_ids.iter_ranges().count());
+            let (sent_redacted, recv_redacted) = (
+                RedactedTranscript::new(self.state.sent_len, transcripts),
+                RedactedTranscript::new(self.state.recv_len, recv_transcripts),
+            );
+
+            #[cfg(feature = "tracing")]
+            info!("Successfully created redacted transcripts");
+
+            Ok::<_, VerifierError>((sent_redacted, recv_redacted))
+        };
+
+        futures::select! {
+            res = verify_fut.fuse() => res,
+            _ = &mut self.state.mux_fut => Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
+        }
+    }
+
+    /// Verify the TLS session.
+    pub async fn finalize(self) -> Result<SessionInfo, VerifierError> {
+        let VerifyState {
+            mut mux,
+            mut mux_fut,
+            mut vm,
+            ot_send,
+            ot_recv,
+            ot_fut,
+            mut gf2,
+            start_time,
+            server_ephemeral_key,
+            handshake_commitment,
+            ..
+        } = self.state;
+
+        let finalize_fut = async {
+            let mut channel = mux.get_channel("finalize").await?;
+
+            // Finalize all MPC
+            let (mut ot_sender_actor, _, _) = futures::try_join!(
+                ot_fut,
+                ot_send.shutdown().map_err(VerifierError::from),
+                ot_recv.shutdown().map_err(VerifierError::from)
+            )?;
+
+            ot_sender_actor.reveal().await?;
+
+            vm.finalize()
+                .await
+                .map_err(|e| VerifierError::MpcError(Box::new(e)))?;
+
+            gf2.verify()
+                .await
+                .map_err(|e| VerifierError::MpcError(Box::new(e)))?;
+
+            let session_info = expect_msg_or_err!(channel, TlsnMessage::SessionInfo)?;
+
+            #[cfg(feature = "tracing")]
+            info!("Finalized all MPC");
+
+            Ok::<_, VerifierError>(session_info)
+        };
+
+        let session_info = futures::select! {
+            res = finalize_fut.fuse() => res?,
+            _ = &mut mux_fut => Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?,
+        };
+
+        let handshake_summary =
+            HandshakeSummary::new(start_time, server_ephemeral_key, handshake_commitment);
+
+        // Verify the TLS session
+        session_info.verify(&handshake_summary, self.config.cert_verifier())?;
+
+        #[cfg(feature = "tracing")]
+        info!("Successfully verified session");
+
+        let mut mux = mux.into_inner();
+
+        futures::try_join!(mux.close().map_err(VerifierError::from), mux_fut)?;
+
+        Ok(session_info)
+    }
+}


### PR DESCRIPTION
* Added necessary state and state transitions

* Move Prover future into its own module

* Put phase-specific prover code into its own modules

* Make `ProverFuture` public again

* Added `Into` from `Closed` to `Verify` for `Prover` state transition

* Added first part of finalize method for `Prover<Verify>`

* Rename `SessionData` to `NotarizedSessionData` and introduce `SessionData` for interactive verifier flow

* Added first sketches for HttpProver and Prover with Verifier state

* Introduced wrapper `ServerInfo`

`ServerInfo` is generated by `SessionData` and is the non-notarization version of `SessionProof`

* Crate `ServerInfo` from `SessionData` in Prover<Verify> flow

* Introduced another module for direct substring proofs.

* WIP: Added dirty first version of prover flow...

* Move `RangeCollector` and restore substring module

* Tidy up tlsn-core and finish first version of prover flow for dealing with a verifier

* Refactored verifier

* Added `Verify` state for `Verifier`

* WIP: Added first draft for verify flow...

* Added more parts of verifier flow

* Adapt tests to new api changes

* Add some logging and improve code here and there

* Added `ProofBuilder` trait and started implementing it for `SubstringsProofBuilder`

* WIP: Tinkering with lifetimes...

* Resolved lifetime issues

* Refactor module `proof` to support another implementor of `SubstringProofBuilder`

* WIP: Adding `LabelProofBuilder`...

* Streamlined api

* Improved decoding flow

* Include lengths in `LabelProof`

* Improved structure of `LabelProof` and finished `verify`

* Added integration test for verify flow

* Add tests for `LabelProof`

* Improve test for `LabelProof::verify`

* Make tlsn compile without `tlsn-formats`

* Restore `tlsn-formats` from `dev` and temporarily remove from workspace

* Add first batch of feedback

* Add further feedback

* Separated decoding from finalization

* Add warning comment to `Verifier::receive`

* Remove unnecessary traits

* Adapt test

* Repair notarize integration test

* Add `decode` call to prover for verify integration test

* Simplified `LabelProof` and renamed to `TranscriptProof`

* Add range check to `reconstruct`

* Roll back changes to `tlsn-prover/src/http`

* Rename `Verify` to `Prove`

* Added more feedback

* Various code improvements

* Remove `SessionData`

* Restore naming of `TlsProof` and `SessionData`

* Improve error handling

* Adapt prove-verify flow to new API

* Finalize VM first

* Fix prover closing connection too early

* Add correct server certificate and assert correct redactions

* Fix imports after rebase

* Fix api test in `tlsn-core`

* Add feedback

* Fix linting in integration test