### PR TITLE
perf: adjust mux config

### DIFF
--- a/tlsn/tlsn-prover/src/tls/mod.rs
+++ b/tlsn/tlsn-prover/src/tls/mod.rs
@@ -75,6 +75,7 @@ impl Prover<state::Initialized> {
         socket: S,
     ) -> Result<Prover<state::Setup>, ProverError> {
         let mut mux_config = yamux::Config::default();
+        // See PR #418
         mux_config.set_max_num_streams(40);
         mux_config.set_max_buffer_size(16 * 1024 * 1024);
         mux_config.set_receive_window(16 * 1024 * 1024);

--- a/tlsn/tlsn-verifier/src/tls/mod.rs
+++ b/tlsn/tlsn-verifier/src/tls/mod.rs
@@ -73,6 +73,7 @@ impl Verifier<state::Initialized> {
         socket: S,
     ) -> Result<Verifier<state::Setup>, VerifierError> {
         let mut mux_config = yamux::Config::default();
+        // See PR #418
         mux_config.set_max_num_streams(40);
         mux_config.set_max_buffer_size(16 * 1024 * 1024);
         mux_config.set_receive_window(16 * 1024 * 1024);


### PR DESCRIPTION
This PR adjusts the multiplexer config to increase the receive window. This will reduce the effects of throttling as latency increases and should give us a theoretical throughput of ~300Mbps @ 60ms per stream instead of ~33Mbps.

The trade-off here is that it increases the memory allocated to buffers. Due to this, I capped the max streams to 40 to prevent DoS (our protocol uses a static number of streams, 33 atm). The existing default configuration provides a max of 8192 streams, which works out to ~2Gb maximum allocation if they were all opened. With the new settings the maximum allocation is 640Mb.

Newer versions of the `yamux` crate scale the window dynamically based on latency + number of opened streams. But their API has breaking changes that we need to fix if we want to bump later.