### PR TITLE
docs(tlsn-formats): remove dead argument docs

### DIFF
--- a/tlsn/tlsn-formats/src/http/commit.rs
+++ b/tlsn/tlsn-formats/src/http/commit.rs
@@ -84,7 +84,6 @@ pub trait HttpCommit {
     /// # Arguments
     ///
     /// * `builder` - The transcript commitment builder.
-    /// * `direction` - The direction of the transcript (sent or received).
     /// * `transcript` - The transcript to commit.
     fn commit_transcript(
         &mut self,


### PR DESCRIPTION
This slipped past me on #380 , just removes some doc lines.