### PR TITLE
fix(tlsn-formats): prevent duplicate json array commitment

### DIFF
--- a/tlsn/tlsn-formats/src/json/commit.rs
+++ b/tlsn/tlsn-formats/src/json/commit.rs
@@ -149,11 +149,13 @@ pub trait JsonCommit {
             .commit(array, direction)
             .map_err(|e| JsonCommitError::new_with_source("failed to commit array", e))?;
 
-        builder
-            .commit(&array.without_values(), direction)
-            .map_err(|e| {
-                JsonCommitError::new_with_source("failed to commit array excluding values", e)
-            })?;
+        if !array.elems.is_empty() {
+            builder
+                .commit(&array.without_values(), direction)
+                .map_err(|e| {
+                    JsonCommitError::new_with_source("failed to commit array excluding values", e)
+                })?;
+        }
 
         // TODO: Commit each value separately, but we need a strategy for handling
         // separators.


### PR DESCRIPTION
This PR fixes the default JSON committer to check if an array is empty prior to trying to commit to the values. Otherwise it causes a duplicate commitment error.