### PR TITLE
fix(tlsn-formats): fix commitment error caused by empty headers

### DIFF
--- a/tlsn/tlsn-formats/tests/fixtures/http/request_get_empty_header
+++ b/tlsn/tlsn-formats/tests/fixtures/http/request_get_empty_header
@@ -1,0 +1,4 @@
+GET / HTTP/1.1
+Host: localhost
+Empty-Header: 
+

--- a/tlsn/tlsn-formats/tests/fixtures/http/response_empty_header
+++ b/tlsn/tlsn-formats/tests/fixtures/http/response_empty_header
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+Cookie: very-secret-cookie
+Content-Length: 0
+Empty-Header: 
+


### PR DESCRIPTION
This PR fixes commitment errors which arise from empty HTTP headers.