### PR TITLE
docs: describe execution modes

### DIFF
--- a/crates/components/stream-cipher/src/config.rs
+++ b/crates/components/stream-cipher/src/config.rs
@@ -47,10 +47,14 @@ impl std::fmt::Debug for InputText {
     }
 }
 
+/// The mode of execution.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ExecutionMode {
+    /// Computes either the plaintext or the ciphertext.
     Mpc,
+    /// Computes the ciphertext and proves its authenticity and correctness.
     Prove,
+    /// Computes the ciphertext and verifies its authenticity and correctness.
     Verify,
 }
 


### PR DESCRIPTION
This PR adds the missing description to the execution modes. First discussed in https://github.com/tlsnotary/tlsn/pull/455#discussion_r1531848868