### PR TITLE
fix: adjust code to unused_qualifications errors

### DIFF
--- a/components/tls/tls-client/src/cipher.rs
+++ b/components/tls/tls-client/src/cipher.rs
@@ -42,17 +42,17 @@ impl MessageDecrypter for InvalidMessageDecrypter {
 
 /// A write or read IV.
 #[derive(Default)]
-pub(crate) struct Iv(pub(crate) [u8; ring::aead::NONCE_LEN]);
+pub(crate) struct Iv(pub(crate) [u8; aead::NONCE_LEN]);
 
 impl Iv {
     #[cfg(feature = "tls12")]
-    fn new(value: [u8; ring::aead::NONCE_LEN]) -> Self {
+    fn new(value: [u8; aead::NONCE_LEN]) -> Self {
         Self(value)
     }
 
     #[cfg(feature = "tls12")]
     pub(crate) fn copy(value: &[u8]) -> Self {
-        debug_assert_eq!(value.len(), ring::aead::NONCE_LEN);
+        debug_assert_eq!(value.len(), aead::NONCE_LEN);
         let mut iv = Self::new(Default::default());
         iv.0.copy_from_slice(value);
         iv
@@ -80,8 +80,8 @@ impl From<hkdf::Okm<'_, IvLen>> for Iv {
     }
 }
 
-pub(crate) fn make_nonce(iv: &Iv, seq: u64) -> ring::aead::Nonce {
-    let mut nonce = [0u8; ring::aead::NONCE_LEN];
+pub(crate) fn make_nonce(iv: &Iv, seq: u64) -> aead::Nonce {
+    let mut nonce = [0u8; aead::NONCE_LEN];
     codec::put_u64(seq, &mut nonce[4..]);
 
     nonce.iter_mut().zip(iv.0.iter()).for_each(|(nonce, iv)| {

--- a/components/tls/tls-client/src/client/builder.rs
+++ b/components/tls/tls-client/src/client/builder.rs
@@ -86,7 +86,7 @@ impl ConfigBuilder<WantsTransparencyPolicyOrClientCert> {
     /// This function fails if `key_der` is invalid.
     pub fn with_single_cert(
         self,
-        cert_chain: Vec<tls_core::key::Certificate>,
+        cert_chain: Vec<key::Certificate>,
         key_der: key::PrivateKey,
     ) -> Result<ClientConfig, Error> {
         self.with_logs(None).with_single_cert(cert_chain, key_der)
@@ -146,7 +146,7 @@ impl ConfigBuilder<WantsClientCert> {
     /// This function fails if `key_der` is invalid.
     pub fn with_single_cert(
         self,
-        cert_chain: Vec<tls_core::key::Certificate>,
+        cert_chain: Vec<key::Certificate>,
         key_der: key::PrivateKey,
     ) -> Result<ClientConfig, Error> {
         let resolver = handy::AlwaysResolvesClientCert::new(cert_chain, &key_der)?;

--- a/components/tls/tls-client/src/client/handy.rs
+++ b/components/tls/tls-client/src/client/handy.rs
@@ -64,7 +64,7 @@ pub(super) struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesClientCert {
     pub(super) fn new(
-        chain: Vec<tls_core::key::Certificate>,
+        chain: Vec<key::Certificate>,
         priv_key: &key::PrivateKey,
     ) -> Result<Self, Error> {
         let key = sign::any_supported_type(priv_key)

--- a/components/tls/tls-client/src/conn.rs
+++ b/components/tls/tls-client/src/conn.rs
@@ -232,7 +232,7 @@ impl ConnectionCommon {
 
     /// Reads out any buffered plaintext received from the peer. Returns the
     /// number of bytes read.
-    pub fn read_plaintext(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    pub fn read_plaintext(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.common_state.received_plaintext.read(buf)
     }
 

--- a/components/tls/tls-client/src/sign.rs
+++ b/components/tls/tls-client/src/sign.rs
@@ -38,7 +38,7 @@ pub trait Signer: Send + Sync {
 #[derive(Clone)]
 pub struct CertifiedKey {
     /// The certificate chain.
-    pub cert: Vec<tls_core::key::Certificate>,
+    pub cert: Vec<key::Certificate>,
 
     /// The certified key.
     pub key: Arc<dyn SigningKey>,
@@ -58,7 +58,7 @@ impl CertifiedKey {
     ///
     /// The cert chain must not be empty. The first certificate in the chain
     /// must be the end-entity certificate.
-    pub fn new(cert: Vec<tls_core::key::Certificate>, key: Arc<dyn SigningKey>) -> Self {
+    pub fn new(cert: Vec<key::Certificate>, key: Arc<dyn SigningKey>) -> Self {
         Self {
             cert,
             key,
@@ -68,7 +68,7 @@ impl CertifiedKey {
     }
 
     /// The end-entity certificate.
-    pub fn end_entity_cert(&self) -> Result<&tls_core::key::Certificate, SignError> {
+    pub fn end_entity_cert(&self) -> Result<&key::Certificate, SignError> {
         self.cert.first().ok_or(SignError(()))
     }
 


### PR DESCRIPTION
Hey!

I tried to build the `tlsn/examples`, but `cargo build` failed with a bunch of 'unnecessary qualification' errors.

```
examples [main] cargo build --release --example simple_prover
   Compiling tlsn-tls-client v0.1.0-alpha.5 (/Users/mwarzynski/Work/tlsnotary/tlsn/components/tls/tls-client)
error: unnecessary qualification
   --> /Users/mwarzynski/Work/tlsnotary/tlsn/components/tls/tls-client/src/cipher.rs:45:38
    |
45  | pub(crate) struct Iv(pub(crate) [u8; ring::aead::NONCE_LEN]);
    |                                      ^^^^^^^^^^^^^^^^^^^^^
    |
```

This PR fixes this issue.

```
examples [mw-unused_qualifications] cargo version
cargo 1.78.0 (54d8815d0 2024-03-26)
examples [mw-unused_qualifications] cargo build --release --example simple_prover
    Finished `release` profile [optimized] target(s) in 0.21s
```