### PR TITLE
refactor(universal-hash): mpz upgrade

### DIFF
--- a/components/universal-hash/Cargo.toml
+++ b/components/universal-hash/Cargo.toml
@@ -9,17 +9,21 @@ version = "0.1.0-alpha.5"
 edition = "2021"
 
 [features]
-default = ["ghash", "mock"]
-tracing = ["dep:tracing"]
+default = ["ghash", "ideal"]
 ghash = []
-mock = []
+ideal = ["dep:ghash_rc"]
 
 [dependencies]
 # tlsn
-mpz-core = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "9f7403b" }
-mpz-fields = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "9f7403b" }
-mpz-share-conversion-core = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "9f7403b" }
-mpz-share-conversion = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "9f7403b" }
+mpz-core = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "477448c" }
+mpz-common = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "477448c", features = [
+    "ideal",
+] }
+mpz-fields = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "477448c" }
+mpz-share-conversion-core = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "477448c" }
+mpz-share-conversion = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "477448c" }
+
+ghash_rc = { package = "ghash", version = "0.5", optional = true }
 
 # async
 async-trait = "0.1"
@@ -29,12 +33,19 @@ futures-util = "0.3"
 # error/log
 thiserror = "1"
 opaque-debug = "0.3"
-tracing = { version = "0.1", optional = true }
+tracing = "0.1"
 
 # misc
 derive_builder = "0.12"
 
 [dev-dependencies]
+mpz-common = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "477448c", features = [
+    "test-utils",
+] }
+mpz-share-conversion = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "477448c", features = [
+    "ideal",
+] }
+
 ghash_rc = { package = "ghash", version = "0.5" }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 criterion = "0.5"

--- a/components/universal-hash/src/ghash/ghash_core/mod.rs
+++ b/components/universal-hash/src/ghash/ghash_core/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use self::core::GhashCore;
 
 use mpz_fields::{compute_product_repeated, gf2_128::Gf2_128};
 use thiserror::Error;
+use tracing::instrument;
 
 #[derive(Debug, Error)]
 pub(crate) enum GhashError {
@@ -42,10 +43,7 @@ pub(crate) enum GhashError {
 ///
 /// * `present_odd_mul_shares`  - Multiplicative odd shares already present.
 /// * `needed`                  - How many powers we need including odd and even.
-#[cfg_attr(
-    feature = "tracing",
-    tracing::instrument(level = "trace", skip(present_odd_mul_shares))
-)]
+#[instrument(level = "trace", skip(present_odd_mul_shares))]
 fn compute_missing_mul_shares(present_odd_mul_shares: &mut Vec<Gf2_128>, needed: usize) {
     // Divide by 2 and round up.
     let needed_odd_powers: usize = needed / 2 + (needed & 1);
@@ -76,10 +74,7 @@ fn compute_missing_mul_shares(present_odd_mul_shares: &mut Vec<Gf2_128>, needed:
 ///                          multiplicative shares.
 /// * `add_shares`         - All additive shares (even and odd) we already have. This is a mutable
 ///                          reference to cached_add_shares in [crate::ghash::state::Intermediate].
-#[cfg_attr(
-    feature = "tracing",
-    tracing::instrument(level = "trace", skip(new_add_odd_shares, add_shares))
-)]
+#[instrument(level = "trace", skip_all)]
 fn compute_new_add_shares(new_add_odd_shares: &[Gf2_128], add_shares: &mut Vec<Gf2_128>) {
     for (odd_share, current_odd_power) in new_add_odd_shares
         .iter()

--- a/components/universal-hash/src/ghash/ghash_inner/config.rs
+++ b/components/universal-hash/src/ghash/ghash_inner/config.rs
@@ -3,9 +3,6 @@ use derive_builder::Builder;
 #[derive(Debug, Clone, Builder)]
 /// Configuration struct for [Ghash](crate::ghash::Ghash).
 pub struct GhashConfig {
-    /// The instance ID.
-    #[builder(setter(into))]
-    pub id: String,
     /// Initial number of block shares to provision.
     #[builder(default = "1026")]
     pub initial_block_count: usize,

--- a/components/universal-hash/src/ghash/ghash_inner/ideal.rs
+++ b/components/universal-hash/src/ghash/ghash_inner/ideal.rs
@@ -1,0 +1,183 @@
+//! Ideal GHASH functionality.
+
+use async_trait::async_trait;
+use ghash_rc::{
+    universal_hash::{KeyInit, UniversalHash as UniversalHashReference},
+    GHash,
+};
+use mpz_common::{
+    ideal::{ideal_f2p, Alice, Bob},
+    Context,
+};
+
+use crate::{UniversalHash, UniversalHashError};
+
+/// An ideal GHASH functionality.
+#[derive(Debug)]
+pub struct IdealGhash<Ctx> {
+    role: Role,
+    context: Ctx,
+}
+
+#[derive(Debug)]
+enum Role {
+    Alice(Alice<GHash>),
+    Bob(Bob<GHash>),
+}
+
+#[async_trait]
+impl<Ctx: Context> UniversalHash for IdealGhash<Ctx> {
+    async fn set_key(&mut self, key: Vec<u8>) -> Result<(), UniversalHashError> {
+        match &mut self.role {
+            Role::Alice(alice) => {
+                alice
+                    .call(
+                        &mut self.context,
+                        key,
+                        |ghash, alice_key, bob_key: Vec<u8>| {
+                            let key = alice_key
+                                .into_iter()
+                                .zip(bob_key)
+                                .map(|(a, b)| a ^ b)
+                                .collect::<Vec<_>>();
+                            *ghash = GHash::new_from_slice(&key).unwrap();
+                            ((), ())
+                        },
+                    )
+                    .await
+            }
+            Role::Bob(bob) => {
+                bob.call(
+                    &mut self.context,
+                    key,
+                    |ghash, alice_key: Vec<u8>, bob_key| {
+                        let key = alice_key
+                            .into_iter()
+                            .zip(bob_key)
+                            .map(|(a, b)| a ^ b)
+                            .collect::<Vec<_>>();
+                        *ghash = GHash::new_from_slice(&key).unwrap();
+                        ((), ())
+                    },
+                )
+                .await
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn setup(&mut self) -> Result<(), UniversalHashError> {
+        Ok(())
+    }
+
+    async fn preprocess(&mut self) -> Result<(), UniversalHashError> {
+        Ok(())
+    }
+
+    async fn finalize(&mut self, input: Vec<u8>) -> Result<Vec<u8>, UniversalHashError> {
+        Ok(match &mut self.role {
+            Role::Alice(alice) => {
+                alice
+                    .call(
+                        &mut self.context,
+                        input,
+                        |ghash, alice_input, bob_input: Vec<u8>| {
+                            assert_eq!(&alice_input, &bob_input);
+
+                            let mut ghash = ghash.clone();
+                            ghash.update_padded(&alice_input);
+                            let output = ghash.finalize().to_vec();
+
+                            let output_bob = vec![0; output.len()];
+                            let output_alice: Vec<u8> = output
+                                .iter()
+                                .zip(output_bob.iter().copied())
+                                .map(|(o, b)| o ^ b)
+                                .collect();
+                            (output_alice, output_bob)
+                        },
+                    )
+                    .await
+            }
+            Role::Bob(bob) => {
+                bob.call(
+                    &mut self.context,
+                    input,
+                    |ghash, alice_input: Vec<u8>, bob_input| {
+                        assert_eq!(&alice_input, &bob_input);
+
+                        let mut ghash = ghash.clone();
+                        ghash.update_padded(&alice_input);
+                        let output = ghash.finalize();
+
+                        let output_bob = vec![0; output.len()];
+                        let output_alice: Vec<u8> = output
+                            .iter()
+                            .zip(output_bob.iter().copied())
+                            .map(|(o, b)| o ^ b)
+                            .collect();
+                        (output_alice, output_bob)
+                    },
+                )
+                .await
+            }
+        })
+    }
+}
+
+/// Creates an ideal GHASH pair.
+pub fn ideal_ghash<Ctx: Context>(
+    context_alice: Ctx,
+    context_bob: Ctx,
+) -> (IdealGhash<Ctx>, IdealGhash<Ctx>) {
+    let (alice, bob) = ideal_f2p(GHash::new_from_slice(&[0u8; 16]).unwrap());
+    (
+        IdealGhash {
+            role: Role::Alice(alice),
+            context: context_alice,
+        },
+        IdealGhash {
+            role: Role::Bob(bob),
+            context: context_bob,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpz_common::executor::test_st_executor;
+
+    #[tokio::test]
+    async fn test_ideal_ghash() {
+        let (ctx_a, ctx_b) = test_st_executor(8);
+        let (mut alice, mut bob) = ideal_ghash(ctx_a, ctx_b);
+
+        let alice_key = vec![42u8; 16];
+        let bob_key = vec![69u8; 16];
+        let key = alice_key
+            .iter()
+            .zip(bob_key.iter())
+            .map(|(a, b)| a ^ b)
+            .collect::<Vec<_>>();
+
+        tokio::try_join!(
+            alice.set_key(alice_key.clone()),
+            bob.set_key(bob_key.clone())
+        )
+        .unwrap();
+
+        let input = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        let (output_a, output_b) =
+            tokio::try_join!(alice.finalize(input.clone()), bob.finalize(input.clone())).unwrap();
+
+        let mut ghash = GHash::new_from_slice(&key).unwrap();
+        ghash.update_padded(&input);
+        let expected_output = ghash.finalize();
+
+        let output: Vec<u8> = output_a.iter().zip(output_b).map(|(a, b)| a ^ b).collect();
+        assert_eq!(output, expected_output.to_vec());
+    }
+}

--- a/components/universal-hash/src/ghash/ghash_inner/mod.rs
+++ b/components/universal-hash/src/ghash/ghash_inner/mod.rs
@@ -6,13 +6,16 @@ use crate::{
     UniversalHash, UniversalHashError,
 };
 use async_trait::async_trait;
+use mpz_common::{Context, Preprocess};
 use mpz_core::Block;
-use mpz_share_conversion::{Gf2_128, ShareConversion};
+use mpz_fields::gf2_128::Gf2_128;
+use mpz_share_conversion::{ShareConversionError, ShareConvert};
 use std::fmt::Debug;
+use tracing::instrument;
 
 mod config;
-#[cfg(feature = "mock")]
-pub(crate) mod mock;
+#[cfg(feature = "ideal")]
+pub(crate) mod ideal;
 
 pub use config::{GhashConfig, GhashConfigBuilder, GhashConfigBuilderError};
 
@@ -26,16 +29,17 @@ enum State {
 /// This is the common instance used by both sender and receiver.
 ///
 /// It is an aio wrapper which mostly uses [GhashCore] for computation.
-#[derive(Debug)]
-pub struct Ghash<C> {
+pub struct Ghash<C, Ctx> {
     state: State,
     config: GhashConfig,
     converter: C,
+    context: Ctx,
 }
 
-impl<C> Ghash<C>
+impl<C, Ctx> Ghash<C, Ctx>
 where
-    C: ShareConversion<Gf2_128> + Send + Sync + Debug,
+    Ctx: Context,
+    C: ShareConvert<Ctx, Gf2_128>,
 {
     /// Creates a new instance.
     ///
@@ -44,41 +48,53 @@ where
     /// * `config`      - The configuration for this Ghash instance.
     /// * `converter`   - An instance which allows to convert multiplicative into additive shares
     ///                   and vice versa.
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "info", ret))]
-    pub fn new(config: GhashConfig, converter: C) -> Self {
+    /// * `context`     - The context.
+    pub fn new(config: GhashConfig, converter: C, context: Ctx) -> Self {
         Self {
             state: State::Init,
             config,
             converter,
+            context,
         }
     }
 
     /// Computes all the additive shares of the hashkey powers.
     ///
     /// We need this when the max block count changes.
-    #[cfg_attr(feature = "tracing", tracing::instrument(level = "debug", err))]
+    #[instrument(level = "debug", skip_all, err)]
     async fn compute_add_shares(
         &mut self,
         core: GhashCore<Intermediate>,
     ) -> Result<GhashCore<Finalized>, UniversalHashError> {
         let odd_mul_shares = core.odd_mul_shares();
 
-        let add_shares = self.converter.to_additive(odd_mul_shares).await?;
+        let add_shares = self
+            .converter
+            .to_additive(&mut self.context, odd_mul_shares)
+            .await?;
         let core = core.add_new_add_shares(&add_shares);
 
         Ok(core)
     }
 }
 
+impl<C, Ctx> Debug for Ghash<C, Ctx> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Ghash")
+            .field("state", &self.state)
+            .field("config", &self.config)
+            .field("converter", &"{{ .. }}".to_string())
+            .finish()
+    }
+}
+
 #[async_trait]
-impl<C> UniversalHash for Ghash<C>
+impl<Ctx, C> UniversalHash for Ghash<C, Ctx>
 where
-    C: ShareConversion<Gf2_128> + Send + Sync + Debug,
+    Ctx: Context,
+    C: Preprocess<Ctx, Error = ShareConversionError> + ShareConvert<Ctx, Gf2_128> + Send,
 {
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(level = "info", skip(key), err)
-    )]
+    #[instrument(level = "info", fields(thread = %self.context.id()), skip_all, err)]
     async fn set_key(&mut self, key: Vec<u8>) -> Result<(), UniversalHashError> {
         if key.len() != 16 {
             return Err(UniversalHashError::KeyLengthError(16, key.len()));
@@ -96,7 +112,10 @@ where
         // GHASH reflects the bits of the key.
         let h_additive = Gf2_128::new(u128::from_be_bytes(h_additive).reverse_bits());
 
-        let h_multiplicative = self.converter.to_multiplicative(vec![h_additive]).await?;
+        let h_multiplicative = self
+            .converter
+            .to_multiplicative(&mut self.context, vec![h_additive])
+            .await?;
 
         let core = GhashCore::new(self.config.initial_block_count);
         let core = core.compute_odd_mul_powers(h_multiplicative[0]);
@@ -107,10 +126,21 @@ where
         Ok(())
     }
 
-    #[cfg_attr(
-        feature = "tracing",
-        tracing::instrument(level = "info", skip_all, err)
-    )]
+    #[instrument(level = "debug", fields(thread = %self.context.id()), skip_all, err)]
+    async fn setup(&mut self) -> Result<(), UniversalHashError> {
+        self.converter.alloc(self.config.max_block_count);
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", fields(thread = %self.context.id()), skip_all, err)]
+    async fn preprocess(&mut self) -> Result<(), UniversalHashError> {
+        self.converter.preprocess(&mut self.context).await?;
+
+        Ok(())
+    }
+
+    #[instrument(level = "debug", fields(thread = %self.context.id()), skip_all, err)]
     async fn finalize(&mut self, mut input: Vec<u8>) -> Result<Vec<u8>, UniversalHashError> {
         // Divide by block length and round up.
         let block_count = input.len() / 16 + (input.len() % 16 != 0) as usize;
@@ -160,49 +190,62 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{mock::mock_ghash_pair, GhashConfig, UniversalHash};
+    use crate::{
+        ghash::{Ghash, GhashConfig},
+        UniversalHash,
+    };
     use ghash_rc::{
         universal_hash::{KeyInit, UniversalHash as UniversalHashReference},
         GHash as GhashReference,
     };
+    use mpz_common::{executor::test_st_executor, Context};
+    use mpz_share_conversion::ideal::{ideal_share_converter, IdealShareConverter};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha12Rng;
 
-    fn create_pair(id: &str, block_count: usize) -> (impl UniversalHash, impl UniversalHash) {
+    fn create_pair<Ctx: Context>(
+        block_count: usize,
+        context_alice: Ctx,
+        context_bob: Ctx,
+    ) -> (
+        Ghash<IdealShareConverter, Ctx>,
+        Ghash<IdealShareConverter, Ctx>,
+    ) {
+        let (convert_a, convert_b) = ideal_share_converter();
+
         let config = GhashConfig::builder()
-            .id(id)
             .initial_block_count(block_count)
             .build()
             .unwrap();
 
-        mock_ghash_pair(config.clone(), config)
+        (
+            Ghash::new(config.clone(), convert_a, context_alice),
+            Ghash::new(config, convert_b, context_bob),
+        )
     }
 
     #[tokio::test]
     async fn test_ghash_output() {
+        let (ctx_a, ctx_b) = test_st_executor(8);
         let mut rng = ChaCha12Rng::from_seed([0; 32]);
         let h: u128 = rng.gen();
         let sender_key: u128 = rng.gen();
         let receiver_key: u128 = h ^ sender_key;
         let message: Vec<u8> = (0..128).map(|_| rng.gen()).collect();
 
-        let (mut sender, mut receiver) = create_pair("test", 1);
+        let (mut sender, mut receiver) = create_pair(1, ctx_a, ctx_b);
 
-        let (sender_setup_fut, receiver_setup_fut) = (
+        tokio::try_join!(
             sender.set_key(sender_key.to_be_bytes().to_vec()),
-            receiver.set_key(receiver_key.to_be_bytes().to_vec()),
-        );
+            receiver.set_key(receiver_key.to_be_bytes().to_vec())
+        )
+        .unwrap();
 
-        let (sender_result, receiver_result) = tokio::join!(sender_setup_fut, receiver_setup_fut);
-        sender_result.unwrap();
-        receiver_result.unwrap();
-
-        let sender_share_fut = sender.finalize(message.clone());
-        let receiver_share_fut = receiver.finalize(message.clone());
-
-        let (sender_share, receiver_share) = tokio::join!(sender_share_fut, receiver_share_fut);
-        let sender_share = sender_share.unwrap();
-        let receiver_share = receiver_share.unwrap();
+        let (sender_share, receiver_share) = tokio::try_join!(
+            sender.finalize(message.clone()),
+            receiver.finalize(message.clone())
+        )
+        .unwrap();
 
         let tag = sender_share
             .iter()
@@ -215,6 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ghash_output_padded() {
+        let (ctx_a, ctx_b) = test_st_executor(8);
         let mut rng = ChaCha12Rng::from_seed([0; 32]);
         let h: u128 = rng.gen();
         let sender_key: u128 = rng.gen();
@@ -223,23 +267,19 @@ mod tests {
         // Message length is not a multiple of the block length
         let message: Vec<u8> = (0..126).map(|_| rng.gen()).collect();
 
-        let (mut sender, mut receiver) = create_pair("test", 1);
+        let (mut sender, mut receiver) = create_pair(1, ctx_a, ctx_b);
 
-        let (sender_setup_fut, receiver_setup_fut) = (
+        tokio::try_join!(
             sender.set_key(sender_key.to_be_bytes().to_vec()),
-            receiver.set_key(receiver_key.to_be_bytes().to_vec()),
-        );
+            receiver.set_key(receiver_key.to_be_bytes().to_vec())
+        )
+        .unwrap();
 
-        let (sender_result, receiver_result) = tokio::join!(sender_setup_fut, receiver_setup_fut);
-        sender_result.unwrap();
-        receiver_result.unwrap();
-
-        let sender_share_fut = sender.finalize(message.clone());
-        let receiver_share_fut = receiver.finalize(message.clone());
-
-        let (sender_share, receiver_share) = tokio::join!(sender_share_fut, receiver_share_fut);
-        let sender_share = sender_share.unwrap();
-        let receiver_share = receiver_share.unwrap();
+        let (sender_share, receiver_share) = tokio::try_join!(
+            sender.finalize(message.clone()),
+            receiver.finalize(message.clone())
+        )
+        .unwrap();
 
         let tag = sender_share
             .iter()
@@ -252,6 +292,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ghash_long_message() {
+        let (ctx_a, ctx_b) = test_st_executor(8);
         let mut rng = ChaCha12Rng::from_seed([0; 32]);
         let h: u128 = rng.gen();
         let sender_key: u128 = rng.gen();
@@ -262,30 +303,27 @@ mod tests {
         let long_message: Vec<u8> = (0..192).map(|_| rng.gen()).collect();
 
         // Create and setup sender and receiver for short message length.
-        let (mut sender, mut receiver) = create_pair("test", 1);
+        let (mut sender, mut receiver) = create_pair(1, ctx_a, ctx_b);
 
-        let (sender_setup_fut, receiver_setup_fut) = (
+        tokio::try_join!(
             sender.set_key(sender_key.to_be_bytes().to_vec()),
-            receiver.set_key(receiver_key.to_be_bytes().to_vec()),
-        );
-
-        let (sender_result, receiver_result) = tokio::join!(sender_setup_fut, receiver_setup_fut);
-        sender_result.unwrap();
-        receiver_result.unwrap();
+            receiver.set_key(receiver_key.to_be_bytes().to_vec())
+        )
+        .unwrap();
 
         // Compute the shares for the short message.
-        let sender_share_fut = sender.finalize(short_message.clone());
-        let receiver_share_fut = receiver.finalize(short_message.clone());
-
-        let (sender_result, receiver_result) = tokio::join!(sender_share_fut, receiver_share_fut);
-        let (_, _) = (sender_result.unwrap(), receiver_result.unwrap());
+        tokio::try_join!(
+            sender.finalize(short_message.clone()),
+            receiver.finalize(short_message.clone())
+        )
+        .unwrap();
 
         // Now compute the shares for the longer message.
-        let sender_share_fut = sender.finalize(long_message.clone());
-        let receiver_share_fut = receiver.finalize(long_message.clone());
-
-        let (sender_result, receiver_result) = tokio::join!(sender_share_fut, receiver_share_fut);
-        let (sender_share, receiver_share) = (sender_result.unwrap(), receiver_result.unwrap());
+        let (sender_share, receiver_share) = tokio::try_join!(
+            sender.finalize(long_message.clone()),
+            receiver.finalize(long_message.clone())
+        )
+        .unwrap();
 
         let tag = sender_share
             .iter()
@@ -296,11 +334,11 @@ mod tests {
         assert_eq!(tag, ghash_reference_impl(h, &long_message));
 
         // We should still be able to generate a Ghash output for the shorter message.
-        let sender_share_fut = sender.finalize(short_message.clone());
-        let receiver_share_fut = receiver.finalize(short_message.clone());
-
-        let (sender_result, receiver_result) = tokio::join!(sender_share_fut, receiver_share_fut);
-        let (sender_share, receiver_share) = (sender_result.unwrap(), receiver_result.unwrap());
+        let (sender_share, receiver_share) = tokio::try_join!(
+            sender.finalize(short_message.clone()),
+            receiver.finalize(short_message.clone())
+        )
+        .unwrap();
 
         let tag = sender_share
             .iter()

--- a/components/universal-hash/src/ghash/mod.rs
+++ b/components/universal-hash/src/ghash/mod.rs
@@ -1,6 +1,6 @@
 mod ghash_core;
 mod ghash_inner;
 
-#[cfg(feature = "mock")]
-pub use ghash_inner::mock::*;
+#[cfg(feature = "ideal")]
+pub use ghash_inner::ideal::{ideal_ghash, IdealGhash};
 pub use ghash_inner::{Ghash, GhashConfig, GhashConfigBuilder, GhashConfigBuilderError};

--- a/components/universal-hash/src/lib.rs
+++ b/components/universal-hash/src/lib.rs
@@ -34,6 +34,12 @@ pub trait UniversalHash: Send {
     /// * `key` - Key to use for the hash function.
     async fn set_key(&mut self, key: Vec<u8>) -> Result<(), UniversalHashError>;
 
+    /// Performs any necessary one-time setup.
+    async fn setup(&mut self) -> Result<(), UniversalHashError>;
+
+    /// Preprocesses the hash function.
+    async fn preprocess(&mut self) -> Result<(), UniversalHashError>;
+
     /// Computes hash of the input, padding the input to the block size
     /// if needed.
     ///


### PR DESCRIPTION
This PR updates the `universal-hash` crate to use the new `mpz` API.

*Note*: The exact commit of `mpz` is not settled yet, we will update this prior to release.

# Changes
- A bit of general clean up
- Adds preprocessing
- Replaces the mock impl with an ideal impl