### PR TITLE
chore: add rebase action

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -7,12 +7,12 @@ jobs:
     name: Rebase
     runs-on: ubuntu-latest
     if: >-
-      github.event.issue.pull_request != '' && 
+      github.event.issue.pull_request != '' &&
       contains(github.event.comment.body, '/rebase') &&
       github.event.comment.author_association == 'MEMBER'
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo


### PR DESCRIPTION
This adds an action for rebasing a PR to make it easier to maintain a linear commit history without having a trusted individual force push the branch.