### PR TITLE
Update CD script for easier investigation

### DIFF
--- a/cd-scripts/appspec-scripts/start_app.sh
+++ b/cd-scripts/appspec-scripts/start_app.sh
@@ -12,8 +12,7 @@ if [ $APP_NAME = "stable" ]; then
   for PORT in $STABLE_PORTS; do
     PORT_LISTENING=$(netstat -lnt4 | egrep -cw $PORT || true)
     if [ $PORT_LISTENING -eq 0 ]; then
-      cd ~/${APP_NAME}_${TAG}/tlsn/notary
-      target/release/notary-server --config-file ~/.notary/${APP_NAME}_${PORT}/config.yaml &> ~/${APP_NAME}_${TAG}/tlsn/notary.log &
+      ~/${APP_NAME}_${TAG}/tlsn/notary/target/release/notary-server --config-file ~/.notary/${APP_NAME}_${PORT}/config.yaml &> ~/${APP_NAME}_${TAG}/tlsn/notary.log &
       # Create a tag that will be used for service validation
       INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
       aws ec2 create-tags --resources $INSTANCE_ID --tags "Key=port,Value=$PORT"
@@ -21,8 +20,7 @@ if [ $APP_NAME = "stable" ]; then
     fi
   done
 else
-  cd ~/$APP_NAME/tlsn/notary
-  target/release/notary-server --config-file ~/.notary/$APP_NAME/config.yaml &> ~/$APP_NAME/tlsn/notary.log &
+  ~/$APP_NAME/tlsn/notary/target/release/notary-server --config-file ~/.notary/$APP_NAME/config.yaml &> ~/$APP_NAME/tlsn/notary.log &
 fi
 
 exit 0


### PR DESCRIPTION
With this, one can just do `pgrep -af notary-server` to find out which version is running at which port using which config file

```bash
228356 /home/ubuntu/stable_v0.1.0-alpha.3/tlsn/notary/target/release/notary-server --config-file /home/ubuntu/.notary/stable_7047/config.yaml
```