### PR TITLE
CI/CD check is added to identify the number of stable versions deployed

### DIFF
--- a/cd-scripts/appspec-scripts/before_install.sh
+++ b/cd-scripts/appspec-scripts/before_install.sh
@@ -3,7 +3,15 @@ set -e
 
 APP_NAME=$(echo $APPLICATION_NAME | awk -F- '{ print $2 }')
 
-if [ $APP_NAME = "nightly" ]; then
+if [ $APP_NAME = "stable" ]; then
+  VERSIONS_DEPLOYED=$(find ~/ -maxdepth 1 -type d -name 'stable_*')
+  VERSIONS_DEPLOYED_COUNT=$(echo $VERSIONS_DEPLOYED | wc -w)
+
+  if [ $VERSIONS_DEPLOYED_COUNT -gt 3 ]; then
+    echo "More than 3 stable versions found"
+    exit 1
+  fi
+else
   if [ ! -d ~/$APP_NAME ]; then
     mkdir ~/$APP_NAME
   fi


### PR DESCRIPTION
An extra check was added to the CI/CD CodeDeploy scripts to verify if there are more than three stable versions deployed. If this condition is met, the deployment will be interrupted.