### PR TITLE
Enable deferred-decryption per default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/formats",
     "crates/notary/client",
     "crates/notary/server",
+    "crates/notary/tests-integration",
     "crates/prover",
     "crates/server-fixture",
     "crates/tests-integration",

--- a/crates/benches/bin/verifier.rs
+++ b/crates/benches/bin/verifier.rs
@@ -68,7 +68,7 @@ async fn run_instance<S: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>
             .id("test")
             .cert_verifier(cert_verifier())
             .max_sent_data(upload_size + 256)
-            .max_recv_data(download_size + 256)
+            .max_deferred_size(download_size + 256)
             .build()?,
     );
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -9,25 +9,44 @@ pub const DEFAULT_MAX_RECV_LIMIT: usize = 1 << 14;
 
 // Extra cushion room, eg. for sharing J0 blocks.
 const EXTRA_OTS: usize = 16384;
+
 const OTS_PER_BYTE_SENT: usize = 8;
+
 // Without deferred decryption we use 16, with it we use 8.
-const OTS_PER_BYTE_RECV: usize = 16;
+const OTS_PER_BYTE_RECV_ONLINE: usize = 16;
+const OTS_PER_BYTE_RECV_DEFER: usize = 8;
 
 /// Returns an estimate of the number of OTs that will be sent.
-pub fn ot_send_estimate(role: Role, max_sent_data: usize, max_recv_data: usize) -> usize {
+pub fn ot_send_estimate(
+    role: Role,
+    max_sent_data: usize,
+    max_recv_data: usize,
+    max_defer_data: usize,
+) -> usize {
     match role {
         Role::Prover => EXTRA_OTS,
         Role::Verifier => {
-            EXTRA_OTS + (max_sent_data * OTS_PER_BYTE_SENT) + (max_recv_data * OTS_PER_BYTE_RECV)
+            EXTRA_OTS
+                + (max_sent_data * OTS_PER_BYTE_SENT)
+                + (max_recv_data * OTS_PER_BYTE_RECV_ONLINE)
+                + (max_defer_data * OTS_PER_BYTE_RECV_DEFER)
         }
     }
 }
 
 /// Returns an estimate of the number of OTs that will be received.
-pub fn ot_recv_estimate(role: Role, max_sent_data: usize, max_recv_data: usize) -> usize {
+pub fn ot_recv_estimate(
+    role: Role,
+    max_sent_data: usize,
+    max_recv_data: usize,
+    max_defer_data: usize,
+) -> usize {
     match role {
         Role::Prover => {
-            EXTRA_OTS + (max_sent_data * OTS_PER_BYTE_SENT) + (max_recv_data * OTS_PER_BYTE_RECV)
+            EXTRA_OTS
+                + (max_sent_data * OTS_PER_BYTE_SENT)
+                + (max_recv_data * OTS_PER_BYTE_RECV_ONLINE)
+                + (max_defer_data * OTS_PER_BYTE_RECV_DEFER)
         }
         Role::Verifier => EXTRA_OTS,
     }

--- a/crates/examples/discord/discord_dm.rs
+++ b/crates/examples/discord/discord_dm.rs
@@ -52,7 +52,7 @@ async fn main() {
     // Send requests for configuration and notarization to the notary server.
     let notarization_request = NotarizationRequest::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_deferred_size(MAX_RECV_DATA)
         .build()
         .unwrap();
 
@@ -70,7 +70,7 @@ async fn main() {
         .id(session_id)
         .server_dns(SERVER_DOMAIN)
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_deferred_size(MAX_RECV_DATA)
         .build()
         .unwrap();
 

--- a/crates/examples/interactive/interactive.rs
+++ b/crates/examples/interactive/interactive.rs
@@ -69,9 +69,6 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
     let (mpc_tls_connection, prover_fut) =
         prover.connect(tls_client_socket.compat()).await.unwrap();
 
-    // Grab a controller for the Prover so we can enable deferred decryption.
-    let ctrl = prover_fut.control();
-
     // Wrap the connection in a TokioIo compatibility layer to use it with hyper.
     let mpc_tls_connection = TokioIo::new(mpc_tls_connection.compat());
 
@@ -86,10 +83,6 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
 
     // Spawn the connection to run in the background.
     tokio::spawn(connection);
-
-    // Enable deferred decryption. This speeds up the proving time, but doesn't
-    // let us see the decrypted data until after the connection is closed.
-    ctrl.defer_decryption().await.unwrap();
 
     // MPC-TLS: Send Request and wait for Response.
     let request = Request::builder()

--- a/crates/examples/twitter/twitter_dm.rs
+++ b/crates/examples/twitter/twitter_dm.rs
@@ -77,9 +77,6 @@ async fn main() {
     let (tls_connection, prover_fut) = prover.connect(client_socket.compat()).await.unwrap();
     let tls_connection = TokioIo::new(tls_connection.compat());
 
-    // Grab a control handle to the Prover
-    let prover_ctrl = prover_fut.control();
-
     // Spawn the Prover to be run concurrently
     let prover_task = tokio::spawn(prover_fut);
 
@@ -114,10 +111,6 @@ async fn main() {
         .unwrap();
 
     debug!("Sending request");
-
-    // Because we don't need to decrypt the response right away, we can defer decryption
-    // until after the connection is closed. This will speed up the proving process!
-    prover_ctrl.defer_decryption().await.unwrap();
 
     let response = request_sender.send_request(request).await.unwrap();
 

--- a/crates/notary/client/src/client.rs
+++ b/crates/notary/client/src/client.rs
@@ -32,9 +32,12 @@ pub struct NotarizationRequest {
     /// Maximum number of bytes that can be sent.
     #[builder(default = "DEFAULT_MAX_SENT_LIMIT")]
     max_sent_data: usize,
-    /// Maximum number of bytes that can be received.
+    /// Maximum number of bytes that can be decrypted online.
+    #[builder(default = "0")]
+    max_recv_data_online: usize,
+    /// Maximum number of bytes that will be decrypted after the TLS connection is closed.
     #[builder(default = "DEFAULT_MAX_RECV_LIMIT")]
-    max_recv_data: usize,
+    max_deferred_size: usize,
 }
 
 impl NotarizationRequest {
@@ -234,7 +237,8 @@ impl NotaryClient {
                 serde_json::to_string(&NotarizationSessionRequest {
                     client_type: ClientType::Tcp,
                     max_sent_data: Some(notarization_request.max_sent_data),
-                    max_recv_data: Some(notarization_request.max_recv_data),
+                    max_recv_data_online: Some(notarization_request.max_recv_data_online),
+                    max_deferred_size: Some(notarization_request.max_deferred_size),
                 })
                 .map_err(|err| {
                     error!("Failed to serialise http request for configuration");

--- a/crates/notary/server/openapi.yaml
+++ b/crates/notary/server/openapi.yaml
@@ -178,8 +178,11 @@ components:
         maxSentData:
           description: Maximum data that can be sent by the prover in bytes
           type: integer
-        maxRecvData:
-          description: Maximum data that can be received by the prover in bytes
+        maxRecvDataOnline:
+          description: Maximum data that can be received online by the prover in bytes
+          type: integer
+        maxDeferredSize:
+          description: Maximum data in bytes that will be decrypted locally after the session by the prover
           type: integer
       required:
         - "clientType"

--- a/crates/notary/server/src/domain/notary.rs
+++ b/crates/notary/server/src/domain/notary.rs
@@ -22,8 +22,10 @@ pub struct NotarizationSessionRequest {
     pub client_type: ClientType,
     /// Maximum data that can be sent by the prover
     pub max_sent_data: Option<usize>,
-    /// Maximum data that can be received by the prover
-    pub max_recv_data: Option<usize>,
+    /// Maximum data in bytes that can be received online by the prover
+    pub max_recv_data_online: Option<usize>,
+    /// Maximum data in bytes that will be decrypted locally after the session by the prover
+    pub max_deferred_size: Option<usize>,
 }
 
 /// Request query of the /notarize API
@@ -47,7 +49,8 @@ pub enum ClientType {
 #[derive(Clone, Debug)]
 pub struct SessionData {
     pub max_sent_data: Option<usize>,
-    pub max_recv_data: Option<usize>,
+    pub max_recv_data_online: Option<usize>,
+    pub max_deferred_size: Option<usize>,
 }
 
 /// Global data that needs to be shared with the axum handlers

--- a/crates/notary/server/src/service/tcp.rs
+++ b/crates/notary/server/src/service/tcp.rs
@@ -84,7 +84,8 @@ pub async fn tcp_notarize(
     notary_globals: NotaryGlobals,
     session_id: String,
     max_sent_data: Option<usize>,
-    max_recv_data: Option<usize>,
+    max_recv_data_online: Option<usize>,
+    max_deferred_size: Option<usize>,
 ) {
     debug!(?session_id, "Upgraded to tcp connection");
     match notary_service(
@@ -92,7 +93,8 @@ pub async fn tcp_notarize(
         &notary_globals.notary_signing_key,
         &session_id,
         max_sent_data,
-        max_recv_data,
+        max_recv_data_online,
+        max_deferred_size,
     )
     .await
     {

--- a/crates/notary/server/src/service/websocket.rs
+++ b/crates/notary/server/src/service/websocket.rs
@@ -12,7 +12,8 @@ pub async fn websocket_notarize(
     notary_globals: NotaryGlobals,
     session_id: String,
     max_sent_data: Option<usize>,
-    max_recv_data: Option<usize>,
+    max_recv_data_online: Option<usize>,
+    max_deferred_size: Option<usize>,
 ) {
     debug!(?session_id, "Upgraded to websocket connection");
     // Wrap the websocket in WsStream so that we have AsyncRead and AsyncWrite implemented
@@ -22,7 +23,8 @@ pub async fn websocket_notarize(
         &notary_globals.notary_signing_key,
         &session_id,
         max_sent_data,
-        max_recv_data,
+        max_recv_data_online,
+        max_deferred_size,
     )
     .await
     {

--- a/crates/notary/tests-integration/Cargo.toml
+++ b/crates/notary/tests-integration/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tests-integration"
+name = "notary-tests-integration"
 version = "0.0.0"
 edition = "2021"
 publish = false

--- a/crates/notary/tests-integration/tests/notary.rs
+++ b/crates/notary/tests-integration/tests/notary.rs
@@ -104,7 +104,8 @@ async fn tcp_prover(notary_config: NotaryServerProperties) -> (NotaryConnection,
 
     let notarization_request = NotarizationRequest::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_recv_data_online(MAX_RECV_DATA)
+        .max_deferred_size(0)
         .build()
         .unwrap();
 
@@ -137,7 +138,8 @@ async fn tls_prover(notary_config: NotaryServerProperties) -> (NotaryConnection,
 
     let notarization_request = NotarizationRequest::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_recv_data_online(MAX_RECV_DATA)
+        .max_deferred_size(0)
         .build()
         .unwrap();
 
@@ -179,8 +181,10 @@ async fn test_tcp_prover<S: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
     let prover_config = ProverConfig::builder()
         .id(session_id)
         .server_dns(SERVER_DOMAIN)
+        .defer_decryption_from_start(false)
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_recv_data_online(MAX_RECV_DATA)
+        .max_deferred_size(0)
         .root_cert_store(root_cert_store)
         .build()
         .unwrap();
@@ -276,7 +280,8 @@ async fn test_websocket_prover() {
     let payload = serde_json::to_string(&NotarizationSessionRequest {
         client_type: notary_server::ClientType::Websocket,
         max_sent_data: Some(MAX_SENT_DATA),
-        max_recv_data: Some(MAX_RECV_DATA),
+        max_recv_data_online: Some(MAX_RECV_DATA),
+        max_deferred_size: Some(0),
     })
     .unwrap();
 
@@ -354,9 +359,11 @@ async fn test_websocket_prover() {
     let prover_config = ProverConfig::builder()
         .id(notarization_response.session_id)
         .server_dns(SERVER_DOMAIN)
+        .defer_decryption_from_start(false)
         .root_cert_store(root_store)
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_recv_data_online(MAX_RECV_DATA)
+        .max_deferred_size(0)
         .build()
         .unwrap();
 

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dev-dependencies]
 tlsn-core = { workspace = true }
+tlsn-common = { workspace = true }
 tlsn-prover = { workspace = true }
 tlsn-server-fixture = { workspace = true }
 tlsn-tls-core = { workspace = true }

--- a/crates/tests-integration/tests/defer_decryption.rs
+++ b/crates/tests-integration/tests/defer_decryption.rs
@@ -40,11 +40,7 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
     .unwrap();
 
     let (mut tls_connection, prover_fut) = prover.connect(client_socket.compat()).await.unwrap();
-    let prover_ctrl = prover_fut.control();
     let prover_task = tokio::spawn(prover_fut);
-
-    // Defer decryption until after the server closes the connection.
-    prover_ctrl.defer_decryption().await.unwrap();
 
     tls_connection
         .write_all(b"GET / HTTP/1.1\r\nConnection: close\r\n\r\n")

--- a/crates/tests-integration/tests/verify.rs
+++ b/crates/tests-integration/tests/verify.rs
@@ -2,6 +2,7 @@ use http_body_util::{BodyExt as _, Empty};
 use hyper::{body::Bytes, Request, StatusCode};
 use hyper_util::rt::TokioIo;
 use tls_core::{anchors::RootCertStore, verify::WebPkiVerifier};
+use tlsn_common::config::DEFAULT_MAX_RECV_LIMIT;
 use tlsn_core::{proof::SessionInfo, Direction, RedactedTranscript};
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tlsn_server_fixture::{CA_CERT_DER, SERVER_DOMAIN};
@@ -46,6 +47,9 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
             .id("test")
             .server_dns(SERVER_DOMAIN)
             .root_cert_store(root_store)
+            .defer_decryption_from_start(false)
+            .max_recv_data_online(DEFAULT_MAX_RECV_LIMIT)
+            .max_deferred_size(0)
             .build()
             .unwrap(),
     )
@@ -105,6 +109,8 @@ async fn verifier<T: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>(
 
     let verifier_config = VerifierConfig::builder()
         .id("test")
+        .max_recv_data_online(DEFAULT_MAX_RECV_LIMIT)
+        .max_deferred_size(0)
         .cert_verifier(WebPkiVerifier::new(root_store, None))
         .build()
         .unwrap();

--- a/crates/tls/mpc/src/follower.rs
+++ b/crates/tls/mpc/src/follower.rs
@@ -148,11 +148,13 @@ impl MpcTlsFollower {
         self.ke.preprocess().await?;
         self.prf.preprocess().await?;
 
+        let preprocess_encrypt = self.config.common().tx_config().max_online_size();
+        let preprocess_decrypt = self.config.common().rx_config().max_online_size()
+            + self.config.common().rx_config().max_deferred_size();
+
         futures::try_join!(
-            self.encrypter
-                .preprocess(self.config.common().tx_config().max_size()),
-            // For now we just preprocess enough for the handshake
-            self.decrypter.preprocess(256),
+            self.encrypter.preprocess(preprocess_encrypt),
+            self.decrypter.preprocess(preprocess_decrypt),
         )?;
 
         self.prf.set_client_random(None).await?;
@@ -212,7 +214,7 @@ impl MpcTlsFollower {
         match direction {
             Direction::Sent => {
                 let new_len = self.encrypter.sent_bytes() + len;
-                let max_size = self.config.common().tx_config().max_size();
+                let max_size = self.config.common().tx_config().max_online_size();
                 if new_len > max_size {
                     return Err(MpcTlsError::new(
                         Kind::Config,
@@ -225,7 +227,8 @@ impl MpcTlsFollower {
             }
             Direction::Recv => {
                 let new_len = self.decrypter.recv_bytes() + len;
-                let max_size = self.config.common().rx_config().max_size();
+                let max_size = self.config.common().rx_config().max_online_size()
+                    + self.config.common().rx_config().max_deferred_size();
                 if new_len > max_size {
                     return Err(MpcTlsError::new(
                         Kind::Config,

--- a/crates/tls/mpc/tests/test.rs
+++ b/crates/tls/mpc/tests/test.rs
@@ -115,6 +115,7 @@ async fn leader(config: MpcTlsCommonConfig, mux: TestFramedMux) {
     let mut leader = MpcTlsLeader::new(
         MpcTlsLeaderConfig::builder()
             .common(config)
+            .defer_decryption_from_start(false)
             .build()
             .unwrap(),
         Box::new(StreamExt::compat_stream(

--- a/crates/verifier/src/tls/config.rs
+++ b/crates/verifier/src/tls/config.rs
@@ -18,9 +18,12 @@ pub struct VerifierConfig {
     /// Maximum number of bytes that can be sent.
     #[builder(default = "DEFAULT_MAX_SENT_LIMIT")]
     max_sent_data: usize,
-    /// Maximum number of bytes that can be received.
+    /// Maximum number of bytes that can be decrypted online.
+    #[builder(default = "0")]
+    max_recv_data_online: usize,
+    /// Maximum number of bytes that will be decrypted after the TLS connection is closed.
     #[builder(default = "DEFAULT_MAX_RECV_LIMIT")]
-    max_recv_data: usize,
+    max_deferred_size: usize,
     #[builder(
         pattern = "owned",
         setter(strip_option),
@@ -34,7 +37,8 @@ impl Debug for VerifierConfig {
         f.debug_struct("VerifierConfig")
             .field("id", &self.id)
             .field("max_sent_data", &self.max_sent_data)
-            .field("max_recv_data", &self.max_recv_data)
+            .field("max_recv_data_online", &self.max_recv_data_online)
+            .field("max_deferred_size", &self.max_deferred_size)
             .field("cert_verifier", &"_")
             .finish()
     }
@@ -56,9 +60,14 @@ impl VerifierConfig {
         self.max_sent_data
     }
 
-    /// Returns the maximum number of bytes that can be received.
-    pub fn max_recv_data(&self) -> usize {
-        self.max_recv_data
+    /// Returns the maximum number of bytes that can be decrypted online.
+    pub fn max_recv_data_online(&self) -> usize {
+        self.max_recv_data_online
+    }
+
+    /// Returns the maximum number of bytes that will be decrypted after the TLS connection is closed.
+    pub fn max_deferred_size(&self) -> usize {
+        self.max_deferred_size
     }
 
     /// Returns the certificate verifier.
@@ -97,13 +106,14 @@ impl VerifierConfig {
                     .id(format!("{}/mpc_tls", &self.id))
                     .tx_config(
                         TranscriptConfig::default_tx()
-                            .max_size(self.max_sent_data)
+                            .max_online_size(self.max_sent_data)
                             .build()
                             .unwrap(),
                     )
                     .rx_config(
                         TranscriptConfig::default_rx()
-                            .max_size(self.max_recv_data)
+                            .max_online_size(self.max_recv_data_online)
+                            .max_deferred_size(self.max_deferred_size)
                             .build()
                             .unwrap(),
                     )
@@ -116,10 +126,20 @@ impl VerifierConfig {
     }
 
     pub(crate) fn ot_sender_setup_count(&self) -> usize {
-        ot_send_estimate(Role::Verifier, self.max_sent_data, self.max_recv_data)
+        ot_send_estimate(
+            Role::Verifier,
+            self.max_sent_data,
+            self.max_recv_data_online,
+            self.max_deferred_size,
+        )
     }
 
     pub(crate) fn ot_receiver_setup_count(&self) -> usize {
-        ot_recv_estimate(Role::Verifier, self.max_sent_data, self.max_recv_data)
+        ot_recv_estimate(
+            Role::Verifier,
+            self.max_sent_data,
+            self.max_recv_data_online,
+            self.max_deferred_size,
+        )
     }
 }

--- a/crates/wasm/src/prover/config.rs
+++ b/crates/wasm/src/prover/config.rs
@@ -7,7 +7,9 @@ pub struct ProverConfig {
     pub id: String,
     pub server_dns: String,
     pub max_sent_data: Option<usize>,
-    pub max_recv_data: Option<usize>,
+    pub max_recv_data_online: Option<usize>,
+    pub max_deferred_size: Option<usize>,
+    pub defer_decryption_from_start: Option<bool>,
 }
 
 impl From<ProverConfig> for tlsn_prover::tls::ProverConfig {
@@ -20,8 +22,16 @@ impl From<ProverConfig> for tlsn_prover::tls::ProverConfig {
             builder.max_sent_data(value);
         }
 
-        if let Some(value) = value.max_recv_data {
-            builder.max_recv_data(value);
+        if let Some(value) = value.max_recv_data_online {
+            builder.max_recv_data_online(value);
+        }
+
+        if let Some(value) = value.max_deferred_size {
+            builder.max_deferred_size(value);
+        }
+
+        if let Some(value) = value.defer_decryption_from_start {
+            builder.defer_decryption_from_start(value);
         }
 
         builder.build().unwrap()

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -83,15 +83,11 @@ impl JsProver {
         info!("connected to server");
 
         let (tls_conn, prover_fut) = prover.connect(server_conn.into_io()).await?;
-        let prover_ctrl = prover_fut.control();
 
         info!("sending request");
 
         let (response, prover) = futures::try_join!(
-            async move {
-                prover_ctrl.defer_decryption().await?;
-                send_request(tls_conn, request).await
-            },
+            send_request(tls_conn, request),
             prover_fut.map_err(Into::into),
         )?;
 

--- a/crates/wasm/src/tests.rs
+++ b/crates/wasm/src/tests.rs
@@ -29,7 +29,7 @@ pub async fn test_prove() -> Result<(), JsValue> {
             .server_dns(SERVER_DOMAIN)
             .root_cert_store(root_store)
             .max_sent_data(1024)
-            .max_recv_data(1024)
+            .max_deferred_size(1024)
             .build()
             .unwrap(),
     );
@@ -77,7 +77,7 @@ pub async fn test_notarize() -> Result<(), JsValue> {
             .server_dns(SERVER_DOMAIN)
             .root_cert_store(root_store)
             .max_sent_data(1024)
-            .max_recv_data(1024)
+            .max_deferred_size(1024)
             .build()
             .unwrap(),
     );
@@ -124,7 +124,7 @@ pub async fn test_verifier() -> Result<(), JsValue> {
     let config = VerifierConfig::builder()
         .id("test")
         .max_sent_data(1024)
-        .max_recv_data(1024)
+        .max_deferred_size(1024)
         .cert_verifier(WebPkiVerifier::new(root_store, None))
         .build()
         .unwrap();

--- a/crates/wasm/src/verifier/config.rs
+++ b/crates/wasm/src/verifier/config.rs
@@ -6,7 +6,8 @@ use tsify_next::Tsify;
 pub struct VerifierConfig {
     pub id: String,
     pub max_sent_data: Option<usize>,
-    pub max_received_data: Option<usize>,
+    pub max_received_data_online: Option<usize>,
+    pub max_deferred_size: Option<usize>,
 }
 
 impl From<VerifierConfig> for tlsn_verifier::tls::VerifierConfig {
@@ -17,8 +18,12 @@ impl From<VerifierConfig> for tlsn_verifier::tls::VerifierConfig {
             builder = builder.max_sent_data(value);
         }
 
-        if let Some(value) = value.max_received_data {
-            builder = builder.max_recv_data(value);
+        if let Some(value) = value.max_received_data_online {
+            builder = builder.max_recv_data_online(value);
+        }
+
+        if let Some(value) = value.max_deferred_size {
+            builder = builder.max_deferred_size(value)
         }
 
         builder.id(value.id).build().unwrap()


### PR DESCRIPTION
This PR enables deferred decryption per default. It exposes more fine-grained control over what size is decrypted locally after the TLS connection and what is decrypted online.