### PR TITLE
Add `verify` for wasm `TlsProof`

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -38,7 +38,7 @@ ring = { version = "0.17", features = ["wasm32_unknown_unknown_js"] }
 serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6" }
 serde_json = { version = "1.0" }
-time = { version = "0.3", features = ["wasm-bindgen"] }
+time = { version = "0.3", features = ["wasm-bindgen", "serde"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["time"] }
 tracing-web = { version = "0.1" }


### PR DESCRIPTION
This PR adds a `verify` method for `TlsProof` in wasm.