### PR TITLE
refactor: use public key pem instead of bytes

### DIFF
--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -105,7 +105,7 @@ pub enum KeyType {
 #[tsify(from_wasm_abi)]
 pub struct NotaryPublicKey {
     typ: KeyType,
-    key: Vec<u8>,
+    key: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -184,7 +184,7 @@ impl TlsProof {
         };
 
         let key = tlsn_core::NotaryPublicKey::P256(
-            p256::PublicKey::from_public_key_pem(&String::from_utf8(key).expect("Found invalid UTF-8"))
+            p256::PublicKey::from_public_key_pem(&key)
                 .map_err(|_| JsError::new("invalid public key"))?,
         );
 


### PR DESCRIPTION
@sinui0 @th4s what do you think about passing in the pem string directly to the verify method?

I've tried lots of different variation of decoding pem into byte array on JS side, but all of them failed and gave me the error `Invalid public key` in wasm 😞 

For reference, i've tried:
- [ec-key](https://www.npmjs.com/package/ec-key#-tobuffer-format-)
- [elliptic](https://www.npmjs.com/package/elliptic)
- decoding pem to base64 then convert to bytes
- decoding pem to base64, then encode to hex, then convert to bytes...



