### PR TITLE
Fix wasm build failure

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -44,7 +44,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["time"] }
 tracing-web = { version = "0.1" }
 tsify-next = { version = "0.5", default-features = false, features = ["js"] }
-wasm-bindgen = { version = "0.2" }
+wasm-bindgen = { version = "=0.2.92" }
 wasm-bindgen-futures = { version = "0.4" }
 # Use the patched ws_stream_wasm to fix the issue https://github.com/najamelan/ws_stream_wasm/issues/12#issuecomment-1711902958
 ws_stream_wasm = { git = "https://github.com/tlsnotary/ws_stream_wasm", rev = "2ed12aad9f0236e5321f577672f309920b2aef51" }


### PR DESCRIPTION
This PR fixes our currently failing wasm build and closes #564. The fix is to set a specific wasm-bindgen version.