### PR TITLE
Make defer-decryption default

### DIFF
--- a/crates/benches/bin/prover.rs
+++ b/crates/benches/bin/prover.rs
@@ -120,12 +120,13 @@ async fn run_instance<S: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>
     let protocol_config = if defer_decryption {
         ProtocolConfig::builder()
             .max_sent_data(upload_size + 256)
-            .max_deferred_size(download_size + 256)
+            .max_recv_data(download_size + 256)
             .build()
             .unwrap()
     } else {
         ProtocolConfig::builder()
             .max_sent_data(upload_size + 256)
+            .max_recv_data(download_size + 256)
             .max_recv_data_online(download_size + 256)
             .build()
             .unwrap()

--- a/crates/benches/bin/prover.rs
+++ b/crates/benches/bin/prover.rs
@@ -127,7 +127,6 @@ async fn run_instance<S: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>
         ProtocolConfig::builder()
             .max_sent_data(upload_size + 256)
             .max_recv_data_online(download_size + 256)
-            .max_deferred_size(0)
             .build()
             .unwrap()
     };

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -41,7 +41,7 @@ pub struct ProtocolConfig {
     max_recv_data_online: usize,
     /// Maximum number of bytes for which the decryption can be deferred until after the MPC-TLS
     /// connection is closed.
-    #[builder(default = "0")]
+    #[builder(default = "self.default_max_deferred_size()")]
     max_deferred_size: usize,
     /// Version that is being run by prover/verifier.
     #[builder(setter(skip), default = "VERSION.clone()")]
@@ -67,6 +67,14 @@ impl ProtocolConfigBuilder {
         }
 
         Ok(())
+    }
+
+    fn default_max_deferred_size(&self) -> usize {
+        if self.max_recv_data_online.is_none() {
+            return DEFAULT_MAX_RECV_LIMIT;
+        }
+
+        0
     }
 }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -34,10 +34,12 @@ pub struct ProtocolConfig {
     /// Maximum number of bytes that can be sent.
     #[builder(default = "DEFAULT_MAX_SENT_LIMIT")]
     max_sent_data: usize,
-    /// Maximum number of bytes that can be decrypted online.
+    /// Maximum number of bytes that can be decrypted online, i.e. while the MPC-TLS connection is
+    /// active.
     #[builder(default = "0")]
     max_recv_data_online: usize,
-    /// Maximum number of bytes that will be decrypted after the TLS connection is closed.
+    /// Maximum number of bytes for which the decryption can be deferred until after the MPC-TLS
+    /// connection is closed.
     #[builder(default = "DEFAULT_MAX_RECV_LIMIT")]
     max_deferred_size: usize,
     /// Version that is being run by prover/verifier.
@@ -67,7 +69,8 @@ impl ProtocolConfig {
         self.max_recv_data_online
     }
 
-    /// Returns the maximum number of bytes that will be decrypted after the TLS connection is closed.
+    /// Returns the maximum number of bytes for which the decryption can be deferred until after
+    /// the MPC-TLS connection is closed.
     pub fn max_deferred_size(&self) -> usize {
         self.max_deferred_size
     }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -294,6 +294,7 @@ mod test {
         let peer_config = ProtocolConfig::builder()
             .max_sent_data(max_sent_data)
             .max_recv_data_online(max_recv_data)
+            .max_deferred_size(0)
             .build()
             .unwrap();
 
@@ -312,6 +313,7 @@ mod test {
         let peer_config = ProtocolConfig::builder()
             .max_sent_data(max_sent_data)
             .max_recv_data_online(max_recv_data)
+            .max_deferred_size(0)
             .build()
             .unwrap();
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -30,7 +30,6 @@ static VERSION: Lazy<Version> = Lazy::new(|| {
 
 /// Protocol configuration to be set up initially by prover and verifier.
 #[derive(derive_builder::Builder, Clone, Debug, Deserialize, Serialize)]
-#[builder(build_fn(validate = "Self::validate"))]
 pub struct ProtocolConfig {
     /// Maximum number of bytes that can be sent.
     #[builder(default = "DEFAULT_MAX_SENT_LIMIT")]
@@ -49,26 +48,6 @@ pub struct ProtocolConfig {
 }
 
 impl ProtocolConfigBuilder {
-    fn validate(&self) -> Result<(), String> {
-        let is_max_recv_data_online_zero = self.max_recv_data_online.is_none()
-            || self
-                .max_recv_data_online
-                .expect("Should be able to unwrap max_recv_data_online due to short-circuit")
-                == 0;
-
-        let is_max_deferred_size_zero = self.max_deferred_size.is_none()
-            || self
-                .max_deferred_size
-                .expect("Should be able to unwrap max_deferred_size due to short-circuit")
-                == 0;
-
-        if is_max_recv_data_online_zero && is_max_deferred_size_zero {
-            return Err("Cannot create protocol config with both max_deferred_size and max_recv_data_online equal to zero".to_string());
-        }
-
-        Ok(())
-    }
-
     fn default_max_deferred_size(&self) -> usize {
         if self.max_recv_data_online.is_none() {
             return DEFAULT_MAX_RECV_LIMIT;

--- a/crates/examples/discord/discord_dm.rs
+++ b/crates/examples/discord/discord_dm.rs
@@ -21,10 +21,6 @@ const SERVER_DOMAIN: &str = "discord.com";
 const NOTARY_HOST: &str = "127.0.0.1";
 const NOTARY_PORT: u16 = 7047;
 
-// P/S: If the following limits are increased, please ensure max-transcript-size of
-// the notary server's config (../../notary/server) is increased too, where
-// max-transcript-size = MAX_SENT_DATA + MAX_RECV_DATA
-//
 // Maximum number of bytes that can be sent from prover to server
 const MAX_SENT_DATA: usize = 1 << 12;
 // Maximum number of bytes that can be received by prover from server

--- a/crates/examples/discord/discord_dm.rs
+++ b/crates/examples/discord/discord_dm.rs
@@ -69,7 +69,7 @@ async fn main() {
     // Set up protocol configuration for prover.
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_deferred_size(MAX_RECV_DATA)
         .build()
         .unwrap();
 

--- a/crates/examples/discord/discord_dm.rs
+++ b/crates/examples/discord/discord_dm.rs
@@ -69,7 +69,7 @@ async fn main() {
     // Set up protocol configuration for prover.
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_deferred_size(MAX_RECV_DATA)
+        .max_recv_data(MAX_RECV_DATA)
         .build()
         .unwrap();
 

--- a/crates/examples/interactive/interactive.rs
+++ b/crates/examples/interactive/interactive.rs
@@ -69,9 +69,6 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
     let (mpc_tls_connection, prover_fut) =
         prover.connect(tls_client_socket.compat()).await.unwrap();
 
-    // Grab a controller for the Prover so we can enable deferred decryption.
-    let ctrl = prover_fut.control();
-
     // Wrap the connection in a TokioIo compatibility layer to use it with hyper.
     let mpc_tls_connection = TokioIo::new(mpc_tls_connection.compat());
 
@@ -86,10 +83,6 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
 
     // Spawn the connection to run in the background.
     tokio::spawn(connection);
-
-    // Enable deferred decryption. This speeds up the proving time, but doesn't
-    // let us see the decrypted data until after the connection is closed.
-    ctrl.defer_decryption().await.unwrap();
 
     // MPC-TLS: Send Request and wait for Response.
     let request = Request::builder()

--- a/crates/examples/interactive/interactive.rs
+++ b/crates/examples/interactive/interactive.rs
@@ -1,7 +1,7 @@
 use http_body_util::Empty;
 use hyper::{body::Bytes, Request, StatusCode, Uri};
 use hyper_util::rt::TokioIo;
-use tlsn_common::config::ProtocolConfig;
+use tlsn_common::config::{ProtocolConfig, ProtocolConfigValidator};
 use tlsn_core::{proof::SessionInfo, Direction, RedactedTranscript};
 use tlsn_prover::tls::{state::Prove, Prover, ProverConfig};
 use tlsn_verifier::tls::{Verifier, VerifierConfig};
@@ -12,10 +12,6 @@ use tracing::instrument;
 const SECRET: &str = "TLSNotary's private key 🤡";
 const SERVER_DOMAIN: &str = "example.com";
 
-// P/S: If the following limits are increased, please ensure max-transcript-size of
-// the notary server's config (../../notary/server) is increased too, where
-// max-transcript-size = MAX_SENT_DATA + MAX_RECV_DATA
-//
 // Maximum number of bytes that can be sent from prover to server
 const MAX_SENT_DATA: usize = 1 << 12;
 // Maximum number of bytes that can be received by prover from server
@@ -130,7 +126,17 @@ async fn verifier<T: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>(
     id: &str,
 ) -> (RedactedTranscript, RedactedTranscript, SessionInfo) {
     // Setup Verifier.
-    let verifier_config = VerifierConfig::builder().id(id).build().unwrap();
+    let config_validator = ProtocolConfigValidator::builder()
+        .max_sent_data(MAX_SENT_DATA)
+        .max_recv_data(MAX_RECV_DATA)
+        .build()
+        .unwrap();
+
+    let verifier_config = VerifierConfig::builder()
+        .id(id)
+        .protocol_config_validator(config_validator)
+        .build()
+        .unwrap();
     let verifier = Verifier::new(verifier_config);
 
     // Verify MPC-TLS and wait for (redacted) data.

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -1,6 +1,12 @@
 use elliptic_curve::pkcs8::DecodePrivateKey;
 use futures::{AsyncRead, AsyncWrite};
+use tlsn_common::config::ProtocolConfigValidator;
 use tlsn_verifier::tls::{Verifier, VerifierConfig};
+
+// Maximum number of bytes that can be sent from prover to server
+const MAX_SENT_DATA: usize = 1 << 12;
+// Maximum number of bytes that can be received by prover from server
+const MAX_RECV_DATA: usize = 1 << 14;
 
 /// Runs a simple Notary with the provided connection to the Prover.
 pub async fn run_notary<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(conn: T) {
@@ -11,9 +17,19 @@ pub async fn run_notary<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(conn
     .unwrap();
     let signing_key = p256::ecdsa::SigningKey::from_pkcs8_pem(signing_key_str).unwrap();
 
-    // Setup default config. Normally a different ID would be generated
+    // Setup the config. Normally a different ID would be generated
     // for each notarization.
-    let config = VerifierConfig::builder().id("example").build().unwrap();
+    let config_validator = ProtocolConfigValidator::builder()
+        .max_sent_data(MAX_SENT_DATA)
+        .max_recv_data(MAX_RECV_DATA)
+        .build()
+        .unwrap();
+
+    let config = VerifierConfig::builder()
+        .id("example")
+        .protocol_config_validator(config_validator)
+        .build()
+        .unwrap();
 
     Verifier::new(config)
         .notarize::<_, p256::ecdsa::Signature>(conn, &signing_key)

--- a/crates/examples/twitter/twitter_dm.rs
+++ b/crates/examples/twitter/twitter_dm.rs
@@ -54,7 +54,11 @@ async fn main() {
         .unwrap();
 
     // Send requests for configuration and notarization to the notary server.
-    let notarization_request = NotarizationRequest::builder().build().unwrap();
+    let notarization_request = NotarizationRequest::builder()
+        .max_sent_data(MAX_SENT_DATA)
+        .max_recv_data(MAX_RECV_DATA)
+        .build()
+        .unwrap();
 
     let Accepted {
         io: notary_connection,

--- a/crates/examples/twitter/twitter_dm.rs
+++ b/crates/examples/twitter/twitter_dm.rs
@@ -23,10 +23,6 @@ const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KH
 const NOTARY_HOST: &str = "127.0.0.1";
 const NOTARY_PORT: u16 = 7047;
 
-// P/S: If the following limits are increased, please ensure max-transcript-size of
-// the notary server's config (../../notary/server) is increased too, where
-// max-transcript-size = MAX_SENT_DATA + MAX_RECV_DATA
-//
 // Maximum number of bytes that can be sent from prover to server
 const MAX_SENT_DATA: usize = 1 << 12;
 // Maximum number of bytes that can be received by prover from server

--- a/crates/examples/twitter/twitter_dm.rs
+++ b/crates/examples/twitter/twitter_dm.rs
@@ -77,9 +77,6 @@ async fn main() {
     let (tls_connection, prover_fut) = prover.connect(client_socket.compat()).await.unwrap();
     let tls_connection = TokioIo::new(tls_connection.compat());
 
-    // Grab a control handle to the Prover
-    let prover_ctrl = prover_fut.control();
-
     // Spawn the Prover to be run concurrently
     let prover_task = tokio::spawn(prover_fut);
 
@@ -114,10 +111,6 @@ async fn main() {
         .unwrap();
 
     debug!("Sending request");
-
-    // Because we don't need to decrypt the response right away, we can defer decryption
-    // until after the connection is closed. This will speed up the proving process!
-    prover_ctrl.defer_decryption().await.unwrap();
 
     let response = request_sender.send_request(request).await.unwrap();
 

--- a/crates/examples/twitter/twitter_dm.rs
+++ b/crates/examples/twitter/twitter_dm.rs
@@ -7,6 +7,7 @@ use hyper::{body::Bytes, Request, StatusCode};
 use hyper_util::rt::TokioIo;
 use notary_client::{Accepted, NotarizationRequest, NotaryClient};
 use std::{env, str};
+use tlsn_common::config::ProtocolConfig;
 use tlsn_core::{commitment::CommitmentKind, proof::TlsProof};
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tokio::io::AsyncWriteExt as _;
@@ -21,6 +22,15 @@ const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KH
 // Setting of the notary server — make sure these are the same with the config in ../../notary/server
 const NOTARY_HOST: &str = "127.0.0.1";
 const NOTARY_PORT: u16 = 7047;
+
+// P/S: If the following limits are increased, please ensure max-transcript-size of
+// the notary server's config (../../notary/server) is increased too, where
+// max-transcript-size = MAX_SENT_DATA + MAX_RECV_DATA
+//
+// Maximum number of bytes that can be sent from prover to server
+const MAX_SENT_DATA: usize = 1 << 12;
+// Maximum number of bytes that can be received by prover from server
+const MAX_RECV_DATA: usize = 1 << 14;
 
 #[tokio::main]
 async fn main() {
@@ -59,6 +69,13 @@ async fn main() {
     let prover_config = ProverConfig::builder()
         .id(session_id)
         .server_dns(SERVER_DOMAIN)
+        .protocol_config(
+            ProtocolConfig::builder()
+                .max_sent_data(MAX_SENT_DATA)
+                .max_recv_data(MAX_RECV_DATA)
+                .build()
+                .unwrap(),
+        )
         .build()
         .unwrap();
 

--- a/crates/notary/client/src/client.rs
+++ b/crates/notary/client/src/client.rs
@@ -12,7 +12,6 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tlsn_common::config::{DEFAULT_MAX_RECV_LIMIT, DEFAULT_MAX_SENT_LIMIT};
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     net::TcpStream,
@@ -30,10 +29,8 @@ use crate::error::{ClientError, ErrorKind};
 #[derive(Debug, Clone, derive_builder::Builder)]
 pub struct NotarizationRequest {
     /// Maximum number of bytes that can be sent.
-    #[builder(default = "DEFAULT_MAX_SENT_LIMIT")]
     max_sent_data: usize,
     /// Maximum number of bytes that can be received.
-    #[builder(default = "DEFAULT_MAX_RECV_LIMIT")]
     max_recv_data: usize,
 }
 

--- a/crates/notary/tests-integration/tests/notary.rs
+++ b/crates/notary/tests-integration/tests/notary.rs
@@ -180,7 +180,7 @@ async fn test_tcp_prover<S: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_deferred_size(MAX_RECV_DATA)
         .build()
         .unwrap();
 
@@ -361,7 +361,7 @@ async fn test_websocket_prover() {
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_recv_data(MAX_RECV_DATA)
+        .max_deferred_size(MAX_RECV_DATA)
         .build()
         .unwrap();
 

--- a/crates/notary/tests-integration/tests/notary.rs
+++ b/crates/notary/tests-integration/tests/notary.rs
@@ -180,7 +180,7 @@ async fn test_tcp_prover<S: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_deferred_size(MAX_RECV_DATA)
+        .max_recv_data(MAX_RECV_DATA)
         .build()
         .unwrap();
 
@@ -361,7 +361,7 @@ async fn test_websocket_prover() {
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(MAX_SENT_DATA)
-        .max_deferred_size(MAX_RECV_DATA)
+        .max_recv_data(MAX_RECV_DATA)
         .build()
         .unwrap();
 

--- a/crates/prover/src/tls/config.rs
+++ b/crates/prover/src/tls/config.rs
@@ -67,7 +67,10 @@ impl ProverConfig {
                     .rx_config(
                         TranscriptConfig::default_rx()
                             .max_online_size(self.protocol_config.max_recv_data_online())
-                            .max_offline_size(self.protocol_config.max_deferred_size())
+                            .max_offline_size(
+                                self.protocol_config.max_recv_data()
+                                    - self.protocol_config.max_recv_data_online(),
+                            )
                             .build()
                             .unwrap(),
                     )

--- a/crates/prover/src/tls/config.rs
+++ b/crates/prover/src/tls/config.rs
@@ -18,15 +18,10 @@ pub struct ProverConfig {
     /// Protocol configuration to be checked with the verifier.
     #[builder(default)]
     protocol_config: ProtocolConfig,
-    /// Defers the decryption from the start of the connection until after the connection is closed.
+    /// Whether the `deferred decryption` feature is toggled on from the start of the MPC-TLS
+    /// connection.
     ///
-    /// Decryption of server responses will be deferred until after the TLS connection is closed.
-    /// This is useful if you either have only one request/response cycle of if you have several
-    /// such cycles but the content of the request never depends on the content of the previous
-    /// response.
-    ///
-    /// This allows to decrypt responses locally without MPC, so this option saves bandwidth
-    /// and performance.
+    /// See `defer_decryption_from_start` in [tls_mpc::MpcTlsLeaderConfig].
     #[builder(default = "true")]
     defer_decryption_from_start: bool,
 }
@@ -52,7 +47,8 @@ impl ProverConfig {
         &self.protocol_config
     }
 
-    /// Returns if deferred decryption is used from the start of the connection.
+    /// Returns whether the `deferred decryption` feature is toggled on from the start of the MPC-TLS
+    /// connection.
     pub fn defer_decryption_from_start(&self) -> bool {
         self.defer_decryption_from_start
     }
@@ -71,7 +67,7 @@ impl ProverConfig {
                     .rx_config(
                         TranscriptConfig::default_rx()
                             .max_online_size(self.protocol_config.max_recv_data_online())
-                            .max_deferred_size(self.protocol_config.max_deferred_size())
+                            .max_offline_size(self.protocol_config.max_deferred_size())
                             .build()
                             .unwrap(),
                     )

--- a/crates/tests-integration/Cargo.toml
+++ b/crates/tests-integration/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dev-dependencies]
 tlsn-core = { workspace = true }
+tlsn-common = { workspace = true }
 tlsn-prover = { workspace = true }
 tlsn-server-fixture = { workspace = true }
 tlsn-server-fixture-certs = { workspace = true }

--- a/crates/tests-integration/tests/defer_decryption.rs
+++ b/crates/tests-integration/tests/defer_decryption.rs
@@ -1,3 +1,4 @@
+use tlsn_common::config::ProtocolConfig;
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tlsn_server_fixture::bind;
 use tlsn_server_fixture_certs::{CA_CERT_DER, SERVER_DOMAIN};
@@ -7,6 +8,11 @@ use futures::{AsyncReadExt, AsyncWriteExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::instrument;
+
+// Maximum number of bytes that can be sent from prover to server
+const MAX_SENT_DATA: usize = 1 << 12;
+// Maximum number of bytes that can be received by prover from server
+const MAX_RECV_DATA: usize = 1 << 14;
 
 #[tokio::test]
 #[ignore]
@@ -33,6 +39,13 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
         ProverConfig::builder()
             .id("test")
             .server_dns(SERVER_DOMAIN)
+            .protocol_config(
+                ProtocolConfig::builder()
+                    .max_sent_data(MAX_SENT_DATA)
+                    .max_recv_data(MAX_RECV_DATA)
+                    .build()
+                    .unwrap(),
+            )
             .root_cert_store(root_store)
             .build()
             .unwrap(),

--- a/crates/tests-integration/tests/defer_decryption.rs
+++ b/crates/tests-integration/tests/defer_decryption.rs
@@ -42,11 +42,7 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
     .unwrap();
 
     let (mut tls_connection, prover_fut) = prover.connect(client_socket.compat()).await.unwrap();
-    let prover_ctrl = prover_fut.control();
     let prover_task = tokio::spawn(prover_fut);
-
-    // Defer decryption until after the server closes the connection.
-    prover_ctrl.defer_decryption().await.unwrap();
 
     tls_connection
         .write_all(b"GET / HTTP/1.1\r\nConnection: close\r\n\r\n")

--- a/crates/tests-integration/tests/defer_decryption.rs
+++ b/crates/tests-integration/tests/defer_decryption.rs
@@ -1,4 +1,4 @@
-use tlsn_common::config::ProtocolConfig;
+use tlsn_common::config::{ProtocolConfig, ProtocolConfigValidator};
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tlsn_server_fixture::bind;
 use tlsn_server_fixture_certs::{CA_CERT_DER, SERVER_DOMAIN};
@@ -83,7 +83,19 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
 
 #[instrument(skip(socket))]
 async fn notary<T: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>(socket: T) {
-    let verifier = Verifier::new(VerifierConfig::builder().id("test").build().unwrap());
+    let config_validator = ProtocolConfigValidator::builder()
+        .max_sent_data(MAX_SENT_DATA)
+        .max_recv_data(MAX_RECV_DATA)
+        .build()
+        .unwrap();
+
+    let verifier = Verifier::new(
+        VerifierConfig::builder()
+            .id("test")
+            .protocol_config_validator(config_validator)
+            .build()
+            .unwrap(),
+    );
     let signing_key = p256::ecdsa::SigningKey::from_bytes(&[1u8; 32].into()).unwrap();
 
     _ = verifier

--- a/crates/tests-integration/tests/notarize.rs
+++ b/crates/tests-integration/tests/notarize.rs
@@ -34,7 +34,6 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
 
     let protocol_config = ProtocolConfig::builder()
         .max_recv_data_online(DEFAULT_MAX_RECV_LIMIT)
-        .max_deferred_size(0)
         .build()
         .unwrap();
 

--- a/crates/tests-integration/tests/notarize.rs
+++ b/crates/tests-integration/tests/notarize.rs
@@ -1,3 +1,4 @@
+use tlsn_common::config::{ProtocolConfig, DEFAULT_MAX_RECV_LIMIT};
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tlsn_server_fixture::bind;
 use tlsn_server_fixture_certs::{CA_CERT_DER, SERVER_DOMAIN};
@@ -31,11 +32,19 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
         .add(&tls_core::key::Certificate(CA_CERT_DER.to_vec()))
         .unwrap();
 
+    let protocol_config = ProtocolConfig::builder()
+        .max_recv_data_online(DEFAULT_MAX_RECV_LIMIT)
+        .max_deferred_size(0)
+        .build()
+        .unwrap();
+
     let prover = Prover::new(
         ProverConfig::builder()
             .id("test")
             .server_dns(SERVER_DOMAIN)
             .root_cert_store(root_store)
+            .defer_decryption_from_start(false)
+            .protocol_config(protocol_config)
             .build()
             .unwrap(),
     )

--- a/crates/tests-integration/tests/notarize.rs
+++ b/crates/tests-integration/tests/notarize.rs
@@ -1,4 +1,4 @@
-use tlsn_common::config::{ProtocolConfig, DEFAULT_MAX_RECV_LIMIT};
+use tlsn_common::config::ProtocolConfig;
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tlsn_server_fixture::bind;
 use tlsn_server_fixture_certs::{CA_CERT_DER, SERVER_DOMAIN};
@@ -10,6 +10,11 @@ use hyper_util::rt::TokioIo;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tracing::instrument;
+
+// Maximum number of bytes that can be sent from prover to server
+const MAX_SENT_DATA: usize = 1 << 12;
+// Maximum number of bytes that can be received by prover from server
+const MAX_RECV_DATA: usize = 1 << 14;
 
 #[tokio::test]
 #[ignore]
@@ -33,7 +38,9 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
         .unwrap();
 
     let protocol_config = ProtocolConfig::builder()
-        .max_recv_data_online(DEFAULT_MAX_RECV_LIMIT)
+        .max_recv_data(MAX_SENT_DATA)
+        .max_recv_data(MAX_RECV_DATA)
+        .max_recv_data_online(MAX_RECV_DATA)
         .build()
         .unwrap();
 

--- a/crates/tests-integration/tests/notarize.rs
+++ b/crates/tests-integration/tests/notarize.rs
@@ -38,7 +38,7 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
         .unwrap();
 
     let protocol_config = ProtocolConfig::builder()
-        .max_recv_data(MAX_SENT_DATA)
+        .max_sent_data(MAX_SENT_DATA)
         .max_recv_data(MAX_RECV_DATA)
         .max_recv_data_online(MAX_RECV_DATA)
         .build()

--- a/crates/tests-integration/tests/verify.rs
+++ b/crates/tests-integration/tests/verify.rs
@@ -46,7 +46,6 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
 
     let protocol_config = ProtocolConfig::builder()
         .max_recv_data_online(DEFAULT_MAX_RECV_LIMIT)
-        .max_deferred_size(0)
         .build()
         .unwrap();
 

--- a/crates/tests-integration/tests/verify.rs
+++ b/crates/tests-integration/tests/verify.rs
@@ -1,5 +1,5 @@
 use tls_core::{anchors::RootCertStore, verify::WebPkiVerifier};
-use tlsn_common::config::ProtocolConfig;
+use tlsn_common::config::{ProtocolConfig, ProtocolConfigValidator};
 use tlsn_core::{proof::SessionInfo, Direction, RedactedTranscript};
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tlsn_server_fixture::bind;
@@ -120,8 +120,15 @@ async fn verifier<T: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>(
         .add(&tls_core::key::Certificate(CA_CERT_DER.to_vec()))
         .unwrap();
 
+    let config_validator = ProtocolConfigValidator::builder()
+        .max_sent_data(MAX_SENT_DATA)
+        .max_recv_data(MAX_RECV_DATA)
+        .build()
+        .unwrap();
+
     let verifier_config = VerifierConfig::builder()
         .id("test")
+        .protocol_config_validator(config_validator)
         .cert_verifier(WebPkiVerifier::new(root_store, None))
         .build()
         .unwrap();

--- a/crates/tests-integration/tests/verify.rs
+++ b/crates/tests-integration/tests/verify.rs
@@ -1,4 +1,5 @@
 use tls_core::{anchors::RootCertStore, verify::WebPkiVerifier};
+use tlsn_common::config::{ProtocolConfig, DEFAULT_MAX_RECV_LIMIT};
 use tlsn_core::{proof::SessionInfo, Direction, RedactedTranscript};
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tlsn_server_fixture::bind;
@@ -43,11 +44,19 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
         .add(&tls_core::key::Certificate(CA_CERT_DER.to_vec()))
         .unwrap();
 
+    let protocol_config = ProtocolConfig::builder()
+        .max_recv_data_online(DEFAULT_MAX_RECV_LIMIT)
+        .max_deferred_size(0)
+        .build()
+        .unwrap();
+
     let prover = Prover::new(
         ProverConfig::builder()
             .id("test")
             .server_dns(SERVER_DOMAIN)
             .root_cert_store(root_store)
+            .defer_decryption_from_start(false)
+            .protocol_config(protocol_config)
             .build()
             .unwrap(),
     )

--- a/crates/tests-integration/tests/verify.rs
+++ b/crates/tests-integration/tests/verify.rs
@@ -1,5 +1,5 @@
 use tls_core::{anchors::RootCertStore, verify::WebPkiVerifier};
-use tlsn_common::config::{ProtocolConfig, DEFAULT_MAX_RECV_LIMIT};
+use tlsn_common::config::ProtocolConfig;
 use tlsn_core::{proof::SessionInfo, Direction, RedactedTranscript};
 use tlsn_prover::tls::{Prover, ProverConfig};
 use tlsn_server_fixture::bind;
@@ -13,6 +13,11 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tracing::instrument;
 use utils::range::RangeSet;
+
+// Maximum number of bytes that can be sent from prover to server
+const MAX_SENT_DATA: usize = 1 << 12;
+// Maximum number of bytes that can be received by prover from server
+const MAX_RECV_DATA: usize = 1 << 14;
 
 #[tokio::test]
 #[ignore]
@@ -45,7 +50,9 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
         .unwrap();
 
     let protocol_config = ProtocolConfig::builder()
-        .max_recv_data_online(DEFAULT_MAX_RECV_LIMIT)
+        .max_sent_data(MAX_SENT_DATA)
+        .max_recv_data(MAX_RECV_DATA)
+        .max_recv_data_online(MAX_RECV_DATA)
         .build()
         .unwrap();
 

--- a/crates/tls/mpc/src/follower.rs
+++ b/crates/tls/mpc/src/follower.rs
@@ -150,7 +150,7 @@ impl MpcTlsFollower {
 
         let preprocess_encrypt = self.config.common().tx_config().max_online_size();
         let preprocess_decrypt = self.config.common().rx_config().max_online_size()
-            + self.config.common().rx_config().max_deferred_size();
+            + self.config.common().rx_config().max_offline_size();
 
         futures::try_join!(
             self.encrypter.preprocess(preprocess_encrypt),
@@ -228,7 +228,7 @@ impl MpcTlsFollower {
             Direction::Recv => {
                 let new_len = self.decrypter.recv_bytes() + len;
                 let max_size = self.config.common().rx_config().max_online_size()
-                    + self.config.common().rx_config().max_deferred_size();
+                    + self.config.common().rx_config().max_offline_size();
                 if new_len > max_size {
                     return Err(MpcTlsError::new(
                         Kind::Config,

--- a/crates/tls/mpc/src/follower.rs
+++ b/crates/tls/mpc/src/follower.rs
@@ -148,11 +148,13 @@ impl MpcTlsFollower {
         self.ke.preprocess().await?;
         self.prf.preprocess().await?;
 
+        let preprocess_encrypt = self.config.common().tx_config().max_online_size();
+        let preprocess_decrypt = self.config.common().rx_config().max_online_size()
+            + self.config.common().rx_config().max_deferred_size();
+
         futures::try_join!(
-            self.encrypter
-                .preprocess(self.config.common().tx_config().max_size()),
-            // For now we just preprocess enough for the handshake
-            self.decrypter.preprocess(256),
+            self.encrypter.preprocess(preprocess_encrypt),
+            self.decrypter.preprocess(preprocess_decrypt),
         )?;
 
         self.prf.set_client_random(None).await?;
@@ -212,7 +214,7 @@ impl MpcTlsFollower {
         match direction {
             Direction::Sent => {
                 let new_len = self.encrypter.sent_bytes() + len;
-                let max_size = self.config.common().tx_config().max_size();
+                let max_size = self.config.common().tx_config().max_online_size();
                 if new_len > max_size {
                     return Err(MpcTlsError::new(
                         Kind::Config,
@@ -225,7 +227,8 @@ impl MpcTlsFollower {
             }
             Direction::Recv => {
                 let new_len = self.decrypter.recv_bytes() + len;
-                let max_size = self.config.common().rx_config().max_size();
+                let max_size = self.config.common().rx_config().max_online_size()
+                    + self.config.common().rx_config().max_deferred_size();
                 if new_len > max_size {
                     return Err(MpcTlsError::new(
                         Kind::Config,

--- a/crates/tls/mpc/src/follower.rs
+++ b/crates/tls/mpc/src/follower.rs
@@ -149,8 +149,7 @@ impl MpcTlsFollower {
         self.prf.preprocess().await?;
 
         let preprocess_encrypt = self.config.common().tx_config().max_online_size();
-        let preprocess_decrypt = self.config.common().rx_config().max_online_size()
-            + self.config.common().rx_config().max_offline_size();
+        let preprocess_decrypt = self.config.common().rx_config().max_online_size();
 
         futures::try_join!(
             self.encrypter.preprocess(preprocess_encrypt),

--- a/crates/tls/mpc/src/leader.rs
+++ b/crates/tls/mpc/src/leader.rs
@@ -136,8 +136,7 @@ impl MpcTlsLeader {
         self.prf.preprocess().await?;
 
         let preprocess_encrypt = self.config.common().tx_config().max_online_size();
-        let preprocess_decrypt = self.config.common().rx_config().max_online_size()
-            + self.config.common().rx_config().max_offline_size();
+        let preprocess_decrypt = self.config.common().rx_config().max_online_size();
 
         futures::try_join!(
             self.encrypter.preprocess(preprocess_encrypt),

--- a/crates/tls/mpc/src/leader.rs
+++ b/crates/tls/mpc/src/leader.rs
@@ -137,7 +137,7 @@ impl MpcTlsLeader {
 
         let preprocess_encrypt = self.config.common().tx_config().max_online_size();
         let preprocess_decrypt = self.config.common().rx_config().max_online_size()
-            + self.config.common().rx_config().max_deferred_size();
+            + self.config.common().rx_config().max_offline_size();
 
         futures::try_join!(
             self.encrypter.preprocess(preprocess_encrypt),
@@ -195,7 +195,7 @@ impl MpcTlsLeader {
             Direction::Recv => {
                 let new_len = self.decrypter.recv_bytes() + len;
                 let max_size = self.config.common().rx_config().max_online_size()
-                    + self.config.common().rx_config().max_deferred_size();
+                    + self.config.common().rx_config().max_offline_size();
                 if new_len > max_size {
                     return Err(MpcTlsError::new(
                         Kind::Config,

--- a/crates/tls/mpc/tests/test.rs
+++ b/crates/tls/mpc/tests/test.rs
@@ -115,6 +115,7 @@ async fn leader(config: MpcTlsCommonConfig, mux: TestFramedMux) {
     let mut leader = MpcTlsLeader::new(
         MpcTlsLeaderConfig::builder()
             .common(config)
+            .defer_decryption_from_start(false)
             .build()
             .unwrap(),
         Box::new(StreamExt::compat_stream(

--- a/crates/verifier/src/tls/config.rs
+++ b/crates/verifier/src/tls/config.rs
@@ -101,7 +101,7 @@ impl VerifierConfig {
                     .rx_config(
                         TranscriptConfig::default_rx()
                             .max_online_size(protocol_config.max_recv_data_online())
-                            .max_deferred_size(protocol_config.max_deferred_size())
+                            .max_offline_size(protocol_config.max_deferred_size())
                             .build()
                             .unwrap(),
                     )

--- a/crates/verifier/src/tls/config.rs
+++ b/crates/verifier/src/tls/config.rs
@@ -94,13 +94,14 @@ impl VerifierConfig {
                     .id(format!("{}/mpc_tls", &self.id))
                     .tx_config(
                         TranscriptConfig::default_tx()
-                            .max_size(protocol_config.max_sent_data())
+                            .max_online_size(protocol_config.max_sent_data())
                             .build()
                             .unwrap(),
                     )
                     .rx_config(
                         TranscriptConfig::default_rx()
-                            .max_size(protocol_config.max_recv_data())
+                            .max_online_size(protocol_config.max_recv_data_online())
+                            .max_deferred_size(protocol_config.max_deferred_size())
                             .build()
                             .unwrap(),
                     )

--- a/crates/verifier/src/tls/config.rs
+++ b/crates/verifier/src/tls/config.rs
@@ -12,7 +12,6 @@ use tlsn_core::proof::default_cert_verifier;
 pub struct VerifierConfig {
     #[builder(setter(into))]
     id: String,
-    #[builder(default)]
     protocol_config_validator: ProtocolConfigValidator,
     #[builder(
         pattern = "owned",

--- a/crates/verifier/src/tls/config.rs
+++ b/crates/verifier/src/tls/config.rs
@@ -101,7 +101,10 @@ impl VerifierConfig {
                     .rx_config(
                         TranscriptConfig::default_rx()
                             .max_online_size(protocol_config.max_recv_data_online())
-                            .max_offline_size(protocol_config.max_deferred_size())
+                            .max_offline_size(
+                                protocol_config.max_recv_data()
+                                    - protocol_config.max_recv_data_online(),
+                            )
                             .build()
                             .unwrap(),
                     )

--- a/crates/wasm-test-runner/src/tlsn_fixture.rs
+++ b/crates/wasm-test-runner/src/tlsn_fixture.rs
@@ -123,7 +123,7 @@ async fn handle_prover(io: TcpStream) -> Result<()> {
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(1024)
-        .max_deferred_size(1024)
+        .max_recv_data(1024)
         .build()
         .unwrap();
 

--- a/crates/wasm-test-runner/src/tlsn_fixture.rs
+++ b/crates/wasm-test-runner/src/tlsn_fixture.rs
@@ -123,7 +123,7 @@ async fn handle_prover(io: TcpStream) -> Result<()> {
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(1024)
-        .max_recv_data(1024)
+        .max_deferred_size(1024)
         .build()
         .unwrap();
 
@@ -150,11 +150,7 @@ async fn handle_prover(io: TcpStream) -> Result<()> {
     let client_socket = TcpStream::connect((addr, port)).await.unwrap();
 
     let (mut tls_connection, prover_fut) = prover.connect(client_socket.compat()).await.unwrap();
-    let prover_ctrl = prover_fut.control();
     let prover_task = tokio::spawn(prover_fut);
-
-    // Defer decryption until after the server closes the connection.
-    prover_ctrl.defer_decryption().await.unwrap();
 
     tls_connection
         .write_all(b"GET / HTTP/1.1\r\nConnection: close\r\n\r\n")

--- a/crates/wasm/src/prover/config.rs
+++ b/crates/wasm/src/prover/config.rs
@@ -7,9 +7,9 @@ use tsify_next::Tsify;
 pub struct ProverConfig {
     pub id: String,
     pub server_dns: String,
-    pub max_sent_data: Option<usize>,
+    pub max_sent_data: usize,
     pub max_recv_data_online: Option<usize>,
-    pub max_deferred_size: Option<usize>,
+    pub max_recv_data: usize,
     pub defer_decryption_from_start: Option<bool>,
 }
 
@@ -17,17 +17,13 @@ impl From<ProverConfig> for tlsn_prover::tls::ProverConfig {
     fn from(value: ProverConfig) -> Self {
         let mut builder = ProtocolConfig::builder();
 
-        if let Some(value) = value.max_sent_data {
-            builder.max_sent_data(value);
-        }
+        builder.max_sent_data(value.max_sent_data);
 
         if let Some(value) = value.max_recv_data_online {
             builder.max_recv_data_online(value);
         }
 
-        if let Some(value) = value.max_deferred_size {
-            builder.max_deferred_size(value);
-        }
+        builder.max_recv_data(value.max_recv_data);
 
         let protocol_config = builder.build().unwrap();
 

--- a/crates/wasm/src/prover/config.rs
+++ b/crates/wasm/src/prover/config.rs
@@ -8,7 +8,9 @@ pub struct ProverConfig {
     pub id: String,
     pub server_dns: String,
     pub max_sent_data: Option<usize>,
-    pub max_recv_data: Option<usize>,
+    pub max_recv_data_online: Option<usize>,
+    pub max_deferred_size: Option<usize>,
+    pub defer_decryption_from_start: Option<bool>,
 }
 
 impl From<ProverConfig> for tlsn_prover::tls::ProverConfig {
@@ -19,17 +21,26 @@ impl From<ProverConfig> for tlsn_prover::tls::ProverConfig {
             builder.max_sent_data(value);
         }
 
-        if let Some(value) = value.max_recv_data {
-            builder.max_recv_data(value);
+        if let Some(value) = value.max_recv_data_online {
+            builder.max_recv_data_online(value);
+        }
+
+        if let Some(value) = value.max_deferred_size {
+            builder.max_deferred_size(value);
         }
 
         let protocol_config = builder.build().unwrap();
 
-        tlsn_prover::tls::ProverConfig::builder()
+        let mut builder = tlsn_prover::tls::ProverConfig::builder();
+        builder
             .id(value.id)
             .server_dns(value.server_dns)
-            .protocol_config(protocol_config)
-            .build()
-            .unwrap()
+            .protocol_config(protocol_config);
+
+        if let Some(value) = value.defer_decryption_from_start {
+            builder.defer_decryption_from_start(value);
+        }
+
+        builder.build().unwrap()
     }
 }

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -83,16 +83,12 @@ impl JsProver {
         info!("connected to server");
 
         let (tls_conn, prover_fut) = prover.connect(server_conn.into_io()).await?;
-        let prover_ctrl = prover_fut.control();
 
         info!("sending request");
 
         let (response, prover) = futures::try_join!(
-            async move {
-                prover_ctrl.defer_decryption().await?;
-                send_request(tls_conn, request).await
-            },
-            prover_fut.map_err(Into::into),
+            send_request(tls_conn, request),
+            prover_fut.map_err(Into::into)
         )?;
 
         info!("response received");

--- a/crates/wasm/src/tests.rs
+++ b/crates/wasm/src/tests.rs
@@ -24,7 +24,7 @@ pub async fn test_prove() -> Result<(), JsValue> {
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(1024)
-        .max_recv_data(1024)
+        .max_deferred_size(1024)
         .build()
         .unwrap();
 
@@ -77,7 +77,7 @@ pub async fn test_notarize() -> Result<(), JsValue> {
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(1024)
-        .max_recv_data(1024)
+        .max_deferred_size(1024)
         .build()
         .unwrap();
 

--- a/crates/wasm/src/tests.rs
+++ b/crates/wasm/src/tests.rs
@@ -24,7 +24,7 @@ pub async fn test_prove() -> Result<(), JsValue> {
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(1024)
-        .max_deferred_size(1024)
+        .max_recv_data(1024)
         .build()
         .unwrap();
 
@@ -77,7 +77,7 @@ pub async fn test_notarize() -> Result<(), JsValue> {
 
     let protocol_config = ProtocolConfig::builder()
         .max_sent_data(1024)
-        .max_deferred_size(1024)
+        .max_recv_data(1024)
         .build()
         .unwrap();
 

--- a/crates/wasm/src/verifier/config.rs
+++ b/crates/wasm/src/verifier/config.rs
@@ -6,21 +6,16 @@ use tsify_next::Tsify;
 #[tsify(from_wasm_abi)]
 pub struct VerifierConfig {
     pub id: String,
-    pub max_sent_data: Option<usize>,
-    pub max_received_data: Option<usize>,
+    pub max_sent_data: usize,
+    pub max_received_data: usize,
 }
 
 impl From<VerifierConfig> for tlsn_verifier::tls::VerifierConfig {
     fn from(value: VerifierConfig) -> Self {
         let mut builder = ProtocolConfigValidator::builder();
 
-        if let Some(value) = value.max_sent_data {
-            builder.max_sent_data(value);
-        }
-
-        if let Some(value) = value.max_received_data {
-            builder.max_recv_data(value);
-        }
+        builder.max_sent_data(value.max_sent_data);
+        builder.max_recv_data(value.max_received_data);
 
         let config_validator = builder.build().unwrap();
 


### PR DESCRIPTION
This PR makes defer-decryption default and introduces the necessary config changes.