### PR TITLE
Remove clippy::blocks_in_conditions

### DIFF
--- a/crates/components/aead/src/aes_gcm/mod.rs
+++ b/crates/components/aead/src/aes_gcm/mod.rs
@@ -60,7 +60,6 @@ impl<Ctx: Context> MpcAesGcm<Ctx> {
 }
 
 #[async_trait]
-#[allow(clippy::blocks_in_conditions)]
 impl<Ctx: Context> Aead for MpcAesGcm<Ctx> {
     type Error = AesGcmError;
 

--- a/crates/components/block-cipher/src/cipher.rs
+++ b/crates/components/block-cipher/src/cipher.rs
@@ -118,7 +118,6 @@ where
 }
 
 #[async_trait]
-#[allow(clippy::blocks_in_conditions)]
 impl<C, E> BlockCipher<C> for MpcBlockCipher<C, E>
 where
     C: BlockCipherCircuit,

--- a/crates/components/hmac-sha256/src/prf.rs
+++ b/crates/components/hmac-sha256/src/prf.rs
@@ -222,7 +222,6 @@ where
 }
 
 #[async_trait]
-#[allow(clippy::blocks_in_conditions)]
 impl<E> Prf for MpcPrf<E>
 where
     E: Memory + Load + Execute + Decode + Send,

--- a/crates/components/key-exchange/src/exchange.rs
+++ b/crates/components/key-exchange/src/exchange.rs
@@ -200,7 +200,6 @@ where
 }
 
 #[async_trait]
-#[allow(clippy::blocks_in_conditions)]
 impl<Ctx, C0, C1, E> KeyExchange for MpcKeyExchange<Ctx, C0, C1, E>
 where
     Ctx: Context,

--- a/crates/components/stream-cipher/src/stream_cipher.rs
+++ b/crates/components/stream-cipher/src/stream_cipher.rs
@@ -260,7 +260,6 @@ where
 }
 
 #[async_trait]
-#[allow(clippy::blocks_in_conditions)]
 impl<C, E> StreamCipher<C> for MpcStreamCipher<C, E>
 where
     C: CtrCircuit,

--- a/crates/components/universal-hash/src/ghash/ghash_inner/mod.rs
+++ b/crates/components/universal-hash/src/ghash/ghash_inner/mod.rs
@@ -89,7 +89,6 @@ impl<C, Ctx> Debug for Ghash<C, Ctx> {
 }
 
 #[async_trait]
-#[allow(clippy::blocks_in_conditions)]
 impl<Ctx, C> UniversalHash for Ghash<C, Ctx>
 where
     Ctx: Context,


### PR DESCRIPTION
The bug in clippy is fixed in rust 1.81, so these are not needed any more