### PR TITLE
fix(wasm): remove presentation verify from test

### DIFF
--- a/crates/wasm/src/tests.rs
+++ b/crates/wasm/src/tests.rs
@@ -147,9 +147,7 @@ pub async fn test_notarize() -> Result<(), JsValue> {
         },
     )?;
 
-    let presentation = Presentation::deserialize(presentation.serialize())?;
-
-    let _ = presentation.verify()?;
+    let _ = Presentation::deserialize(presentation.serialize())?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #615 

We will want to add this back in, but first we have to work out a good solution for customizing the crypto provider through the wasm bindings.