### PR TITLE
Remove unnecessary dependency from notary-client crate

### DIFF
--- a/crates/notary/client/Cargo.toml
+++ b/crates/notary/client/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 notary-server = { workspace = true }
-tlsn-common = { workspace = true }
 
 derive_builder = { workspace = true }
 futures = { workspace = true }


### PR DESCRIPTION
Removed `tlsn-common` as a dependency from the `notary-client` crate since it wasn't being used. It was likely a leftover from the v7 refactor.