### PR TITLE
Fix/core validation

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,8 +40,9 @@ web-time = { workspace = true }
 webpki-roots = { workspace = true }
 
 [dev-dependencies]
-rstest = { workspace = true }
+bincode = { workspace = true }
 hex = { workspace = true }
+rstest = { workspace = true }
 tlsn-data-fixtures = { workspace = true }
 
 [[test]]

--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -314,11 +314,11 @@ impl ServerCertData {
             return Err(CertificateVerificationError::InvalidServerEphemeralKey);
         }
 
-        // Verify server name
+        // Verify server name.
         let server_name = tls_core::dns::ServerName::try_from(server_name.as_ref())
             .map_err(|_| CertificateVerificationError::InvalidIdentity(server_name.clone()))?;
 
-        // Verify server certificate
+        // Verify server certificate.
         let cert_chain = self
             .certs
             .clone()

--- a/crates/core/src/merkle.rs
+++ b/crates/core/src/merkle.rs
@@ -129,10 +129,16 @@ impl MerkleTree {
     /// # Panics
     ///
     /// - If the provided indices are not unique and sorted.
+    /// - If the provided indices are out of bounds.
     pub(crate) fn proof(&self, indices: &[usize]) -> MerkleProof {
         assert!(
             indices.windows(2).all(|w| w[0] < w[1]),
             "indices must be unique and sorted"
+        );
+
+        assert!(
+            *indices.last().unwrap() < self.tree.leaves_len(),
+            "one or more provided indices are out of bounds"
         );
 
         MerkleProof {

--- a/crates/core/src/merkle.rs
+++ b/crates/core/src/merkle.rs
@@ -235,6 +235,21 @@ mod test {
     #[case::blake3(Blake3::default())]
     #[case::keccak(Keccak256::default())]
     #[should_panic]
+    fn test_proof_fail_index_out_of_bounds<H: HashAlgorithm>(#[case] hasher: H) {
+        let mut tree = MerkleTree::new(hasher.id());
+
+        let leaves = leaves(&hasher, [T(0), T(1), T(2), T(3), T(4)]);
+
+        tree.insert(&hasher, leaves.clone());
+
+        _ = tree.proof(&[2, 3, 4, 6]);
+    }
+
+    #[rstest]
+    #[case::sha2(Sha256::default())]
+    #[case::blake3(Blake3::default())]
+    #[case::keccak(Keccak256::default())]
+    #[should_panic]
     fn test_proof_fail_length_duplicates<H: HashAlgorithm>(#[case] hasher: H) {
         let mut tree = MerkleTree::new(hasher.id());
 

--- a/crates/core/src/transcript/commit.rs
+++ b/crates/core/src/transcript/commit.rs
@@ -10,6 +10,15 @@ use crate::{
     transcript::{Direction, Idx, Transcript},
 };
 
+/// The maximum allowed total bytelength of committed data for a single
+/// commitment kind. Used to prevent DoS during verification. (May cause the
+/// verifier to hash up to a max of 1GB * 128 = 128GB of data for certain kinds
+/// of encoding commitments.)
+///
+/// This value must not exceed bcs's MAX_SEQUENCE_LENGTH limit (which is (1 <<
+/// 31) - 1 by default)
+pub(crate) const MAX_TOTAL_COMMITTED_DATA: usize = 1_000_000_000;
+
 /// Kind of transcript commitment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TranscriptCommitmentKind {

--- a/crates/core/src/transcript/encoding.rs
+++ b/crates/core/src/transcript/encoding.rs
@@ -17,15 +17,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::hash::{impl_domain_separator, TypedHash};
 
-/// The maximum allowed total bytelength of committed data for a single
-/// commitment kind. Used to prevent DoS during verification. (May cause the
-/// verifier to hash up to a max of 1GB * 128 = 128GB of data for certain kinds
-/// of encoding commitments.)
-///
-/// This value must not exceed bcs's MAX_SEQUENCE_LENGTH limit (which is (1 <<
-/// 31) - 1 by default)
-const MAX_TOTAL_COMMITTED_DATA: usize = 1_000_000_000;
-
 /// Transcript encoding commitment.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EncodingCommitment {

--- a/crates/core/src/transcript/encoding/proof.rs
+++ b/crates/core/src/transcript/encoding/proof.rs
@@ -7,9 +7,8 @@ use crate::{
     hash::{Blinded, Blinder, HashAlgorithmExt, HashProviderError},
     merkle::{MerkleError, MerkleProof},
     transcript::{
-        encoding::{
-            new_encoder, tree::EncodingLeaf, Encoder, EncodingCommitment, MAX_TOTAL_COMMITTED_DATA,
-        },
+        commit::MAX_TOTAL_COMMITTED_DATA,
+        encoding::{new_encoder, tree::EncodingLeaf, Encoder, EncodingCommitment},
         Direction, PartialTranscript, Subsequence,
     },
     CryptoProvider,

--- a/crates/verifier/src/verify.rs
+++ b/crates/verifier/src/verify.rs
@@ -94,7 +94,7 @@ impl Verifier<VerifyState> {
             data,
         } = mux_fut
             .poll_with(async {
-                // Finalize all MPC
+                // Finalize all MPC.
                 ot_send.reveal(&mut ctx).await?;
 
                 vm.finalize().await?;


### PR DESCRIPTION
This PR adds validation to some of the core types.

Also renames `tree_len` to `leaf_count` since "tree length" is too ambiguous.  