### PR TITLE
use the latest rev of tlsn-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ tlsn-tls-client-async = { path = "crates/tls/client-async" }
 tlsn-tls-core = { path = "crates/tls/core" }
 tlsn-tls-mpc = { path = "crates/tls/mpc" }
 tlsn-universal-hash = { path = "crates/components/universal-hash" }
-tlsn-utils = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "e7b2db6" }
-tlsn-utils-aio = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "e7b2db6" }
+tlsn-utils = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "0040a00" }
+tlsn-utils-aio = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "0040a00" }
 tlsn-verifier = { path = "crates/verifier" }
 
 mpz-circuits = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "b8ae7ac" }
@@ -80,8 +80,9 @@ mpz-ot = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "b
 mpz-share-conversion = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "b8ae7ac" }
 
 serio = { version = "0.1" }
-spansy = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "e7b2db6" }
+spansy = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "0040a00" }
 uid-mux = { version = "0.1", features = ["serio"] }
+websocket-relay = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "0040a00" }
 
 aes = { version = "0.8" }
 aes-gcm = { version = "0.9" }

--- a/crates/benches/browser/native/Cargo.toml
+++ b/crates/benches/browser/native/Cargo.toml
@@ -9,7 +9,7 @@ tlsn-benches-browser-core = { workspace = true }
 tlsn-benches-library = { workspace = true }
 
 serio = { workspace = true }
-websocket-relay = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "76c9de0" }
+websocket-relay = { workspace = true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/wasm-test-runner/Cargo.toml
+++ b/crates/wasm-test-runner/Cargo.toml
@@ -13,7 +13,7 @@ tlsn-server-fixture-certs = { workspace = true }
 tlsn-tls-core = { workspace = true }
 tlsn-verifier = { workspace = true }
 
-websocket-relay = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "73a6be1" }
+websocket-relay = { workspace = true }
 
 anyhow = { workspace = true }
 axum = { workspace = true }


### PR DESCRIPTION
this PR bumps tlsn-utils (reason: websocket-relay was merged into dev)