### PR TITLE
Revert "build: Update wasm-bindgen and wasm-bindgen-rayon dependency"

### DIFF
--- a/crates/benches/browser/wasm/Cargo.toml
+++ b/crates/benches/browser/wasm/Cargo.toml
@@ -16,14 +16,14 @@ serio = { workspace = true }
 
 anyhow = { workspace = true }
 tracing = { workspace = true }
-wasm-bindgen = { version = "0.2.95" }
-wasm-bindgen-futures = { version = "0.4.37" }
+wasm-bindgen = "0.2.87"
+wasm-bindgen-futures = "0.4.37"
 web-time = { workspace = true }
 # Use the patched ws_stream_wasm to fix the issue https://github.com/najamelan/ws_stream_wasm/issues/12#issuecomment-1711902958
 ws_stream_wasm = { version = "0.7.4", git = "https://github.com/tlsnotary/ws_stream_wasm", rev = "2ed12aad9f0236e5321f577672f309920b2aef51", features = ["tokio_io"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-rayon = { version = "1.2.2", features = ["no-bundler"] }
+wasm-bindgen-rayon = { version = "1", features = ["no-bundler"] }
 
 [package.metadata.wasm-pack.profile.release]
 # Note: these wasm-pack options should match those in crates/wasm/Cargo.toml

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -42,11 +42,11 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["time"] }
 tracing-web = { version = "0.1" }
 tsify-next = { version = "0.5", default-features = false, features = ["js"] }
-wasm-bindgen = { version = "0.2.95" }
+wasm-bindgen = { version = "=0.2.92" }
 wasm-bindgen-futures = { version = "0.4" }
 # Use the patched ws_stream_wasm to fix the issue https://github.com/najamelan/ws_stream_wasm/issues/12#issuecomment-1711902958
 ws_stream_wasm = { git = "https://github.com/tlsnotary/ws_stream_wasm", rev = "2ed12aad9f0236e5321f577672f309920b2aef51" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-rayon = { version = "1.2.2" }
+wasm-bindgen-rayon = { version = "1.0" }
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
Reverts tlsnotary/tlsn#662

This PR has a problem: `workerHelpers.worker.js` is no longer generated. Reverting this change for now.
