### PR TITLE
notary-server: fix paths

### DIFF
--- a/crates/notary/server/Cargo.toml
+++ b/crates/notary/server/Cargo.toml
@@ -10,7 +10,7 @@ tee_quote = [
 	"dep:rand_chacha", 
 	"dep:once_cell",
 	"dep:simple_asn1",
-        "dep:pem",
+	"dep:pem",
 	"dep:lazy_static",
 ]
 

--- a/crates/notary/server/config/config.yaml
+++ b/crates/notary/server/config/config.yaml
@@ -3,12 +3,26 @@ server:
   host: "0.0.0.0"
   port: 7047
   html_info: |
-    <h1>Notary Server {version}!</h1>
-    <ul>
-    <li>git commit hash: <a href="https://github.com/tlsnotary/tlsn/commit/{git_commit_hash}">{git_commit_hash}</a></li>
-    <li>public key: <pre>{public_key}</pre></li>
-    </ul>
-    <a href="healthcheck">health check</a> - <a href="info">info</a><br/>
+    <head>
+      <meta charset="UTF-8">
+      <meta name="author" content="tlsnotary">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+      <svg width="86" height="88" viewBox="0 0 86 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M25.5484 0.708986C25.5484 0.17436 26.1196 -0.167376 26.5923 0.0844205L33.6891 3.86446C33.9202 3.98756 34.0645 4.22766 34.0645 4.48902V9.44049H37.6129C38.0048 9.44049 38.3226 9.75747 38.3226 10.1485V21.4766L36.1936 20.0606V11.5645H34.0645V80.9919C34.0645 81.1134 34.0332 81.2328 33.9735 81.3388L30.4251 87.6388C30.1539 88.1204 29.459 88.1204 29.1878 87.6388L25.6394 81.3388C25.5797 81.2328 25.5484 81.1134 25.5484 80.9919V0.708986Z" fill="#243F5F"/>
+        <path d="M21.2903 25.7246V76.7012H12.7742V34.2207H0V25.7246H21.2903Z" fill="#243F5F"/>
+        <path d="M63.871 76.7012H72.3871V34.2207H76.6452V76.7012H85.1613V25.7246H63.871V76.7012Z" fill="#243F5F"/>
+        <path d="M38.3226 25.7246H59.6129V34.2207H46.8387V46.9649H59.6129V76.7012H38.3226V68.2051H51.0968V55.4609H38.3226V25.7246Z" fill="#243F5F"/>
+      </svg>
+      <h1>Notary Server {version}!</h1>
+      <ul>
+        <li>public key: <pre>{public_key}</pre></li>
+        <li>git commit hash: <a href="https://github.com/tlsnotary/tlsn/commit/{git_commit_hash}">{git_commit_hash}</a></li>
+        <li><a href="healthcheck">health check</a></li>
+        <li><a href="info">info</a></li>
+      </ul>
+    </body>
 
 notarization:
   max_sent_data: 4096

--- a/crates/notary/server/config/config.yaml
+++ b/crates/notary/server/config/config.yaml
@@ -8,7 +8,7 @@ server:
     <li>git commit hash: <a href="https://github.com/tlsnotary/tlsn/commit/{git_commit_hash}">{git_commit_hash}</a></li>
     <li>public key: <pre>{public_key}</pre></li>
     </ul>
-    <a href="/healthcheck">health check</a> - <a href="/info">info</a><br/>
+    <a href="healthcheck">health check</a> - <a href="info">info</a><br/>
 
 notarization:
   max_sent_data: 4096

--- a/crates/notary/server/tee/config/config.yaml
+++ b/crates/notary/server/tee/config/config.yaml
@@ -1,27 +1,28 @@
 server:
-  name: "notary.codes"
+  name: "notary-server"
   host: "0.0.0.0"
   port: 7047
   html_info: |
     <head>
-    <meta charset="UTF-8">
-    <meta name="description" content="mpc-tls">
-    <meta name="keywords" content="tlsnotary, mpc, free">
-    <meta name="author" content="notary">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta charset="UTF-8">
+      <meta name="author" content="tlsnotary">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
     </head>
     <body>
-    <svg width="86" height="88" viewBox="0 0 86 88" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M25.5484 0.708986C25.5484 0.17436 26.1196 -0.167376 26.5923 0.0844205L33.6891 3.86446C33.9202 3.98756 34.0645 4.22766 34.0645 4.48902V9.44049H37.6129C38.0048 9.44049 38.3226 9.75747 38.3226 10.1485V21.4766L36.1936 20.0606V11.5645H34.0645V80.9919C34.0645 81.1134 34.0332 81.2328 33.9735 81.3388L30.4251 87.6388C30.1539 88.1204 29.459 88.1204 29.1878 87.6388L25.6394 81.3388C25.5797 81.2328 25.5484 81.1134 25.5484 80.9919V0.708986Z" fill="#243F5F"/>
-    <path d="M21.2903 25.7246V76.7012H12.7742V34.2207H0V25.7246H21.2903Z" fill="#243F5F"/>
-    <path d="M63.871 76.7012H72.3871V34.2207H76.6452V76.7012H85.1613V25.7246H63.871V76.7012Z" fill="#243F5F"/>
-    <path d="M38.3226 25.7246H59.6129V34.2207H46.8387V46.9649H59.6129V76.7012H38.3226V68.2051H51.0968V55.4609H38.3226V25.7246Z" fill="#243F5F"/>
-    </svg>
-    <h1>notary server :: at your service</h1>
-    <h3>tlsnotary {version}</h3>
-    <blink>{public_key}</blink>
-    <h4>remote attestation</h4>
-    <a href="/v{version}/info">available here</a>
+      <svg width="86" height="88" viewBox="0 0 86 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M25.5484 0.708986C25.5484 0.17436 26.1196 -0.167376 26.5923 0.0844205L33.6891 3.86446C33.9202 3.98756 34.0645 4.22766 34.0645 4.48902V9.44049H37.6129C38.0048 9.44049 38.3226 9.75747 38.3226 10.1485V21.4766L36.1936 20.0606V11.5645H34.0645V80.9919C34.0645 81.1134 34.0332 81.2328 33.9735 81.3388L30.4251 87.6388C30.1539 88.1204 29.459 88.1204 29.1878 87.6388L25.6394 81.3388C25.5797 81.2328 25.5484 81.1134 25.5484 80.9919V0.708986Z" fill="#243F5F"/>
+        <path d="M21.2903 25.7246V76.7012H12.7742V34.2207H0V25.7246H21.2903Z" fill="#243F5F"/>
+        <path d="M63.871 76.7012H72.3871V34.2207H76.6452V76.7012H85.1613V25.7246H63.871V76.7012Z" fill="#243F5F"/>
+        <path d="M38.3226 25.7246H59.6129V34.2207H46.8387V46.9649H59.6129V76.7012H38.3226V68.2051H51.0968V55.4609H38.3226V25.7246Z" fill="#243F5F"/>
+      </svg>
+      <h1>Notary Server {version}!</h1>
+      <ul>
+        <li>public key: <pre>{public_key}</pre></li>
+        <li>git commit hash: <a href="https://github.com/tlsnotary/tlsn/commit/{git_commit_hash}">{git_commit_hash}</a></li>
+        <li><a href="/v{version}/info">remote attestation</a></li>
+        <li><a href="healthcheck">health check</a></li>
+        <li><a href="info">info</a></li>
+      </ul>
     </body>
 
 notarization:

--- a/crates/notary/server/tee/config/config.yaml
+++ b/crates/notary/server/tee/config/config.yaml
@@ -19,9 +19,8 @@ server:
       <ul>
         <li>public key: <pre>{public_key}</pre></li>
         <li>git commit hash: <a href="https://github.com/tlsnotary/tlsn/commit/{git_commit_hash}">{git_commit_hash}</a></li>
-        <li><a href="/v{version}/info">remote attestation</a></li>
         <li><a href="healthcheck">health check</a></li>
-        <li><a href="info">info</a></li>
+        <li><a href="info">info</a> (includes the remote attestation)</li>
       </ul>
     </body>
 


### PR DESCRIPTION
this pr modifies the info and health endpoints to use relative paths which are compatible with the standalone notary-server and hosted versions behind reverse proxies