### PR TITLE
refactor: prf interface

### DIFF
--- a/crates/components/hmac-sha256/benches/prf.rs
+++ b/crates/components/hmac-sha256/benches/prf.rs
@@ -2,8 +2,8 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use hmac_sha256::{MpcPrf, Prf, PrfConfig, Role};
-use mpz_common::executor::{mt::MTConfig, test_mt_executor};
+use hmac_sha256::{MpcPrf, PrfConfig, Role};
+use mpz_common::context::test_mt_context;
 use mpz_garble::protocol::semihonest::{Evaluator, Generator};
 use mpz_ot::ideal::cot::ideal_cot;
 use mpz_vm_core::{
@@ -31,9 +31,9 @@ async fn prf() {
     let client_random = [69u8; 32];
     let server_random: [u8; 32] = [96u8; 32];
 
-    let (mut leader_exec, mut follower_exec) = test_mt_executor(128, MTConfig::default());
-    let mut leader_ctx = leader_exec.new_thread().await.unwrap();
-    let mut follower_ctx = follower_exec.new_thread().await.unwrap();
+    let (mut leader_exec, mut follower_exec) = test_mt_context(8);
+    let mut leader_ctx = leader_exec.new_context().await.unwrap();
+    let mut follower_ctx = follower_exec.new_context().await.unwrap();
 
     let delta = Delta::random(&mut rng);
     let (ot_send, ot_recv) = ideal_cot(delta.into_inner());

--- a/crates/components/hmac-sha256/src/lib.rs
+++ b/crates/components/hmac-sha256/src/lib.rs
@@ -49,58 +49,9 @@ pub struct SessionKeys {
     pub server_iv: Array<U8, 4>,
 }
 
-/// PRF trait for computing TLS PRF.
-pub trait Prf<Vm> {
-    /// Sets up the PRF.
-    ///
-    /// # Arguments
-    ///
-    /// * `vm` - Virtual machine.
-    /// * `pms` - The pre-master secret.
-    fn setup(&mut self, vm: &mut Vm, pms: Array<U8, 32>) -> Result<PrfOutput, PrfError>;
-
-    /// Sets the client random.
-    ///
-    /// Only the leader can provide the client random.
-    ///
-    /// # Arguments
-    ///
-    /// * `vm` - Virtual machine.
-    /// * `client_random` - The client random.
-    fn set_client_random(
-        &mut self,
-        vm: &mut Vm,
-        client_random: Option<[u8; 32]>,
-    ) -> Result<(), PrfError>;
-
-    /// Sets the server random.
-    ///
-    /// # Arguments
-    ///
-    /// * `vm` - Virtual machine.
-    /// * `server_random` - The server random.
-    fn set_server_random(&mut self, vm: &mut Vm, server_random: [u8; 32]) -> Result<(), PrfError>;
-
-    /// Sets the client finished handshake hash.
-    ///
-    /// # Arguments
-    ///
-    /// * `vm` - Virtual machine.
-    /// * `handshake_hash` - The handshake transcript hash.
-    fn set_cf_hash(&mut self, vm: &mut Vm, handshake_hash: [u8; 32]) -> Result<(), PrfError>;
-
-    /// Sets the server finished handshake hash.
-    ///
-    /// # Arguments
-    ///
-    /// * `vm` - Virtual machine.
-    /// * `handshake_hash` - The handshake transcript hash.
-    fn set_sf_hash(&mut self, vm: &mut Vm, handshake_hash: [u8; 32]) -> Result<(), PrfError>;
-}
-
 #[cfg(test)]
 mod tests {
-    use mpz_common::executor::test_st_executor;
+    use mpz_common::context::test_st_context;
     use mpz_garble::protocol::semihonest::{Evaluator, Generator};
 
     use hmac_sha256_circuits::{hmac_sha256_partial, prf, session_keys};
@@ -137,7 +88,7 @@ mod tests {
         let server_random: [u8; 32] = [96u8; 32];
         let ms = compute_ms(pms, client_random, server_random);
 
-        let (mut leader_ctx, mut follower_ctx) = test_st_executor(128);
+        let (mut leader_ctx, mut follower_ctx) = test_st_context(128);
 
         let delta = Delta::random(&mut rng);
         let (ot_send, ot_recv) = ideal_cot(delta.into_inner());


### PR DESCRIPTION
This PR refactors the PRF interface to integrate changes in mpz. I've removed the `Prf` trait and instead we can just use a concrete type.