### PR TITLE
chore: removed unused deps

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -15,7 +15,6 @@ tlsn-utils = { workspace = true }
 mpz-core = { workspace = true }
 mpz-common = { workspace = true }
 mpz-memory-core = { workspace = true }
-mpz-ot = { workspace = true }
 mpz-vm-core = { workspace = true }
 mpz-zk = { workspace = true }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,10 +17,6 @@ tlsn-data-fixtures = { workspace = true, optional = true }
 tlsn-tls-core = { workspace = true, features = ["serde"] }
 tlsn-utils = { workspace = true }
 
-mpz-core = { workspace = true }
-mpz-garble-core = { workspace = true }
-mpz-circuits = { workspace = true }
-
 bcs = { workspace = true }
 bimap = { version = "0.6", features = ["serde"] }
 blake3 = { workspace = true }


### PR DESCRIPTION
This PR removes `mpz` dependencies from `tlsn-core` (yay), and one unused one from `tlsn-common`