### PR TITLE
chore(wasm): bump web spawn to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ tokio-util = { version = "0.7" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }
 uuid = { version = "1.4" }
-web-spawn = { version = "0.1" }
+web-spawn = { version = "0.2" }
 web-time = { version = "0.2" }
 webpki = { version = "0.22" }
 webpki-roots = { version = "0.26" }

--- a/crates/wasm-test-runner/run.sh
+++ b/crates/wasm-test-runner/run.sh
@@ -5,5 +5,5 @@ cd "$(dirname "$0")"
 
 RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--max-memory=4294967296' \
     rustup run nightly \
-    wasm-pack build ../wasm --target web --no-pack --out-dir=../wasm-test-runner/static/generated -- -Zbuild-std=panic_abort,std --features test &&
-    RUST_LOG=info cargo run --release
+    wasm-pack build ../wasm --target web --no-pack --out-dir=../wasm-test-runner/static/generated -- -Zbuild-std=panic_abort,std --features test,no-bundler &&
+    RUST_LOG=debug cargo run --release

--- a/crates/wasm-test-runner/static/worker.js
+++ b/crates/wasm-test-runner/static/worker.js
@@ -1,14 +1,12 @@
 import * as Comlink from "https://unpkg.com/comlink/dist/esm/comlink.mjs";
-import init_wasm, { initialize } from "./generated/tlsn_wasm.js";
-
-const module = await import("./generated/tlsn_wasm.js");
+import init_wasm, * as wasm from "./generated/tlsn_wasm.js";
 
 class TestWorker {
     async init() {
         try {
             console.log("initializing wasm");
             await init_wasm();
-            await initialize({ thread_count: navigator.hardwareConcurrency });
+            await wasm.initialize({ level: "Debug" }, navigator.hardwareConcurrency);
         } catch (e) {
             console.error(e);
             throw e;
@@ -17,9 +15,10 @@ class TestWorker {
 
     async run() {
         let promises = [];
-        for (const [name, func] of Object.entries(module)) {
+        for (const [name, func] of Object.entries(wasm)) {
             if (name.startsWith("test_") && (typeof func === 'function')) {
                 promises.push((async () => {
+                    console.log("running test", name);
                     const start = performance.now();
                     try {
                         await func();

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -21,6 +21,7 @@ wasm-opt = true
 [features]
 default = []
 test = []
+no-bundler = ["web-spawn/no-bundler"]
 
 [dependencies]
 tlsn-common = { path = "../common" }


### PR DESCRIPTION
This PR bumps `web-spawn` to v0.2 and also fixes the test runner.