### PR TITLE
Make logging format configurable

### DIFF
--- a/crates/notary/server/Cargo.toml
+++ b/crates/notary/server/Cargo.toml
@@ -45,7 +45,7 @@ tower-http = { version = "0.5", features = ["cors"] }
 tower-service = { version = "0.3" }
 tower-util = { version = "0.3.1" }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
 ws_stream_tungstenite = { workspace = true, features = ["tokio_io"] }
 zeroize = { workspace = true }

--- a/crates/notary/server/src/config.rs
+++ b/crates/notary/server/src/config.rs
@@ -75,4 +75,15 @@ pub struct LoggingProperties {
     /// Custom filtering logic, refer to the syntax here https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax
     /// This will override the default filtering logic above
     pub filter: Option<String>,
+    /// Log format. Available options are "compact" and "json". Default is "compact"
+    #[serde(default)]
+    pub format: LogFormat,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum LogFormat {
+    #[default]
+    Compact,
+    Json,
 }


### PR DESCRIPTION
Log collector tools want to consume logs in JSON format. This PR adds support for it.
You can now set logging.format to json in toml config file in notary server and instead of this:
```
2025-03-10T10:34:03.339984Z DEBUG main ThreadId(01) run_server: notary_server::server: Loading notary server's signing key
2025-03-10T10:34:03.343506Z DEBUG main ThreadId(01) run_server: notary_server::server: Successfully loaded notary server's signing key!
2025-03-10T10:34:03.344714Z DEBUG main ThreadId(01) run_server: notary_server::server: Skipping TLS setup as it is turned off.
2025-03-10T10:34:03.344732Z DEBUG main ThreadId(01) run_server: notary_server::server: Skipping authorization as it is turned off.
2025-03-10T10:34:03.344862Z  INFO main ThreadId(01) run_server: notary_server::server: Listening for TCP traffic at 0.0.0.0:7047
```

get this:
```
{"timestamp":"2025-03-10T10:33:52.767048Z","level":"DEBUG","fields":{"message":"Loading notary server's signing key"},"target":"notary_server::server","span":{"name":"run_server"},"spans":[{"name":"run_server"}],"threadName":"main","threadId":"ThreadId(1)"}
{"timestamp":"2025-03-10T10:33:52.770139Z","level":"DEBUG","fields":{"message":"Successfully loaded notary server's signing key!"},"target":"notary_server::server","span":{"name":"run_server"},"spans":[{"name":"run_server"}],"threadName":"main","threadId":"ThreadId(1)"}
{"timestamp":"2025-03-10T10:33:52.771363Z","level":"DEBUG","fields":{"message":"Skipping TLS setup as it is turned off."},"target":"notary_server::server","span":{"name":"run_server"},"spans":[{"name":"run_server"}],"threadName":"main","threadId":"ThreadId(1)"}
{"timestamp":"2025-03-10T10:33:52.771387Z","level":"DEBUG","fields":{"message":"Skipping authorization as it is turned off."},"target":"notary_server::server","span":{"name":"run_server"},"spans":[{"name":"run_server"}],"threadName":"main","threadId":"ThreadId(1)"}
{"timestamp":"2025-03-10T10:33:52.771525Z","level":"INFO","fields":{"message":"Listening for TCP traffic at 0.0.0.0:7047"},"target":"notary_server::server","span":{"name":"run_server"},"spans":[{"name":"run_server"}],"threadName":"main","threadId":"ThreadId(1)"}
```