### PR TITLE
fix: allow deprecated ring

### DIFF
--- a/crates/tls/client/src/client/tls12.rs
+++ b/crates/tls/client/src/client/tls12.rs
@@ -16,6 +16,7 @@ use crate::{
     verify,
 };
 use async_trait::async_trait;
+#[allow(deprecated)]
 use ring::constant_time;
 use std::sync::Arc;
 use tls_core::{
@@ -1100,6 +1101,7 @@ impl State<ClientConnectionData> for ExpectFinished {
 
         // Constant-time verification of this is relatively unimportant: they only
         // get one chance.  But it can't hurt.
+        #[allow(deprecated)]
         let _fin_verified =
             match constant_time::verify_slices_are_equal(&expect_verify_data, &finished.0) {
                 Ok(()) => verify::FinishedMessageVerified::assertion(),

--- a/crates/tls/client/src/client/tls13.rs
+++ b/crates/tls/client/src/client/tls13.rs
@@ -14,6 +14,8 @@ use crate::{
     msgs::persist,
     sign, verify, KeyLog,
 };
+#[allow(deprecated)]
+use ring::constant_time;
 use tls_core::{
     key::PublicKey,
     msgs::{
@@ -33,8 +35,6 @@ use tls_core::{
     },
     suites::Tls13CipherSuite,
 };
-
-use ring::constant_time;
 
 use crate::sign::{CertifiedKey, Signer};
 use async_trait::async_trait;
@@ -771,6 +771,7 @@ impl State<ClientConnectionData> for ExpectFinished {
             .get_server_finished_vd(handshake_hash.as_ref().to_vec())
             .await?;
 
+        #[allow(deprecated)]
         let fin = match constant_time::verify_slices_are_equal(
             expect_verify_data.as_ref(),
             &finished.0,


### PR DESCRIPTION
This PR allows use of deprecated items from ring as we won't be upgrading.