### PR TITLE
fix: compute recv record count from max_recv

### DIFF
--- a/crates/mpc-tls/src/config.rs
+++ b/crates/mpc-tls/src/config.rs
@@ -47,10 +47,9 @@ impl ConfigBuilder {
             + self
                 .max_sent
                 .ok_or(ConfigBuilderError::UninitializedField("max_sent"))?;
-        let max_recv_online = MIN_RECV
-            + self
-                .max_recv_online
-                .ok_or(ConfigBuilderError::UninitializedField("max_recv_online"))?;
+        let mut max_recv_online = self
+            .max_recv_online
+            .ok_or(ConfigBuilderError::UninitializedField("max_recv_online"))?;
         let max_recv = self
             .max_recv
             .ok_or(ConfigBuilderError::UninitializedField("max_recv"))?;
@@ -60,6 +59,8 @@ impl ConfigBuilder {
                 "max_recv_online must be less than or equal to max_recv".to_string(),
             ));
         }
+
+        max_recv_online += MIN_RECV;
 
         let max_sent_records = self
             .max_sent_records

--- a/crates/mpc-tls/tests/test.rs
+++ b/crates/mpc-tls/tests/test.rs
@@ -28,6 +28,7 @@ async fn mpc_tls_test() {
         .defer_decryption(false)
         .max_sent(1 << 13)
         .max_recv_online(1 << 13)
+        .max_recv(1 << 13)
         .build()
         .unwrap();
 

--- a/crates/prover/src/config.rs
+++ b/crates/prover/src/config.rs
@@ -53,6 +53,7 @@ impl ProverConfig {
             .defer_decryption(self.defer_decryption_from_start)
             .max_sent(self.protocol_config.max_sent_data())
             .max_recv_online(self.protocol_config.max_recv_data_online())
+            .max_recv(self.protocol_config.max_recv_data())
             .build()
             .unwrap()
     }

--- a/crates/verifier/src/config.rs
+++ b/crates/verifier/src/config.rs
@@ -46,6 +46,7 @@ impl VerifierConfig {
         Config::builder()
             .max_sent(protocol_config.max_sent_data())
             .max_recv_online(protocol_config.max_recv_data_online())
+            .max_recv(protocol_config.max_recv_data())
             .build()
             .unwrap()
     }


### PR DESCRIPTION
This PR partially addresses #738 

Right now the count is derived from `max_recv_online`, which is incorrect. We have to preprocess J0s for `max_recv`.