### PR TITLE
Codecov yaml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+github_checks:
+  annotations: false
+comment: false


### PR DESCRIPTION
Disable coverage annotations and comments in GitHub with a `codecov.yml` file