### PR TITLE
fix: set cwd to CARGO_MANIFEST_DIR in notary-server

### DIFF
--- a/crates/notary/server/src/main.rs
+++ b/crates/notary/server/src/main.rs
@@ -5,11 +5,14 @@ use tracing::debug;
 
 #[tokio::main]
 async fn main() -> Result<(), NotaryServerError> {
+    std::env::set_current_dir(env!("CARGO_MANIFEST_DIR"))
+        .map_err(|err| eyre!("Failed to set CWD: {err}"))?;
+
     // Load command line arguments
     let cli_fields: CliFields = CliFields::from_args();
 
     let settings =
-        Settings::new(&cli_fields).map_err(|err| eyre!("Failed to load settings: {}", err))?;
+        Settings::new(&cli_fields).map_err(|err| eyre!("Failed to load settings: {err}"))?;
 
     // Set up tracing for logging
     init_tracing(&settings.config).map_err(|err| eyre!("Failed to set up tracing: {err}"))?;


### PR DESCRIPTION
Fixes #763 

I took the liberty to try and address issue #763 - lemme know if the proposed fix is satisfactory for you!

---

This way, it is now possible to run the server with `cargo run` from the project root as well as from the actual crate.

tl;dr both are now possible

```
$ cd tlsn
$ cargo run --bin notary-server
```

and

```
$ cd tlsn/crates/notary/server
$ cargo run
```