### PR TITLE
Add `tlsn-wasm` to API docs

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -21,19 +21,13 @@ jobs:
           toolchain: stable
 
       - name: "rustdoc"
-        run: |
-            cd crates/wasm
-            ./build-docs.sh
+        run: crates/wasm/build-docs.sh
 
-      # https://dev.to/deciduously/prepare-your-rust-api-docs-for-github-pages-2n5i
-      - name: "Add index file -> tlsn_prover"
-        run: |
-          echo "<meta http-equiv=\"refresh\" content=\"0; url=tlsn_prover\">" > target/doc/index.html
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/dev' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target/doc/
+          publish_dir: target/wasm32-unknown-unknown/doc/
           # cname: rustdocs.tlsnotary.org

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -21,8 +21,9 @@ jobs:
           toolchain: stable
 
       - name: "rustdoc"
-        run: cargo doc -p tlsn-core -p tlsn-prover -p tlsn-verifier --no-deps --all-features
-        # --target-dir ${GITHUB_WORKSPACE}/docs
+        run: |
+            cd crates/wasm
+            ./build-docs.sh
 
       # https://dev.to/deciduously/prepare-your-rust-api-docs-for-github-pages-2n5i
       - name: "Add index file -> tlsn_prover"

--- a/crates/wasm/build-docs.sh
+++ b/crates/wasm/build-docs.sh
@@ -29,3 +29,7 @@ cargo +nightly doc \
     "${PACKAGE_ARGS[@]}" \
     --no-deps \
     --features "$FEATURES"
+
+# https://dev.to/deciduously/prepare-your-rust-api-docs-for-github-pages-2n5i
+echo "Add index file -> tlsn_prover"
+echo "<meta http-equiv=\"refresh\" content=\"0; url=tlsn_prover\">" >../../target/wasm32-unknown-unknown/doc/index.html

--- a/crates/wasm/build-docs.sh
+++ b/crates/wasm/build-docs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# List the packages you want to document
+PACKAGES=("tlsn-core" "tlsn-prover" "tlsn-verifier" "tlsn-wasm")
+
+# Find all features, except for the "test" features
+FEATURES=$(
+    cargo metadata --no-deps --format-version=1 |
+        jq -r --argjson names "$(printf '%s\n' "${PACKAGES[@]}" | jq -R . | jq -s .)" '
+    .packages[]
+    | select(.name as $n | $names | index($n))
+    | .features
+    | keys[]
+    | select(. != "test" and . != "rstest")
+  ' | sort -u | paste -sd, -
+)
+
+# Join package names for the `-p` args
+PACKAGE_ARGS=()
+for pkg in "${PACKAGES[@]}"; do
+    PACKAGE_ARGS+=("-p" "$pkg")
+done
+
+# Build docs using the correct config and filtered features
+cargo +nightly doc \
+    "${PACKAGE_ARGS[@]}" \
+    --no-deps \
+    --features "$FEATURES"


### PR DESCRIPTION
This PR adds `tlsn-wasm` to the API documentation.

tlsn-wasm needs to be build with the wasm32-target. The doc build is now more complicated than before, so I moved it to a separate script.