### PR TITLE
feat(notary): add concurrency limit

### DIFF
--- a/crates/notary/client/Cargo.toml
+++ b/crates/notary/client/Cargo.toml
@@ -3,6 +3,10 @@ name = "notary-client"
 version = "0.1.0-alpha.10-pre"
 edition = "2021"
 
+[features]
+# Exposes some API which are only meant for testing.
+test-api = []
+
 [dependencies]
 notary-server = { workspace = true }
 

--- a/crates/notary/server/config/config.yaml
+++ b/crates/notary/server/config/config.yaml
@@ -44,3 +44,5 @@ logging:
 authorization:
   enabled: false
   whitelist_csv_path: "./fixture/auth/whitelist.csv"
+
+concurrency: 1000

--- a/crates/notary/server/src/config.rs
+++ b/crates/notary/server/src/config.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct NotaryServerProperties {
     /// Name and address of the notary server
     pub server: ServerProperties,
@@ -14,6 +14,23 @@ pub struct NotaryServerProperties {
     pub logging: LoggingProperties,
     /// Setting for authorization
     pub authorization: AuthorizationProperties,
+    /// The maximum number of concurrent notarization sessions
+    pub concurrency: usize,
+}
+
+impl Default for NotaryServerProperties {
+    fn default() -> Self {
+        Self {
+            server: ServerProperties::default(),
+            notarization: NotarizationProperties::default(),
+            tls: TLSProperties::default(),
+            notary_key: NotarySigningKeyProperties::default(),
+            logging: LoggingProperties::default(),
+            authorization: AuthorizationProperties::default(),
+            // By default there is essentially no concurrency limit.
+            concurrency: usize::MAX,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]

--- a/crates/notary/server/src/lib.rs
+++ b/crates/notary/server/src/lib.rs
@@ -17,7 +17,10 @@ pub use config::{
 };
 pub use domain::{
     cli::CliFields,
-    notary::{ClientType, NotarizationSessionRequest, NotarizationSessionResponse},
+    notary::{
+        ClientType, NotarizationRetryResponse, NotarizationSessionRequest,
+        NotarizationSessionResponse,
+    },
 };
 pub use error::NotaryServerError;
 pub use server::{read_pem_file, run_server};

--- a/crates/notary/server/src/server.rs
+++ b/crates/notary/server/src/server.rs
@@ -49,6 +49,8 @@ use crate::{
 #[cfg(feature = "tee_quote")]
 use crate::tee::{generate_ephemeral_keypair, quote};
 
+use tokio::sync::Semaphore;
+
 /// Start a TCP server (with or without TLS) to accept notarization request for
 /// both TCP and WebSocket clients
 #[tracing::instrument(skip(config))]
@@ -114,6 +116,7 @@ pub async fn run_server(config: &NotaryServerProperties) -> Result<(), NotarySer
         Arc::new(crypto_provider),
         config.notarization.clone(),
         authorization_whitelist,
+        Arc::new(Semaphore::new(config.concurrency)),
     );
 
     // Parameters needed for the info endpoint

--- a/crates/notary/server/src/service.rs
+++ b/crates/notary/server/src/service.rs
@@ -23,8 +23,8 @@ use uuid::Uuid;
 
 use crate::{
     domain::notary::{
-        NotarizationRequestQuery, NotarizationSessionRequest, NotarizationSessionResponse,
-        NotaryGlobals,
+        NotarizationRequestQuery, NotarizationRetryResponse, NotarizationSessionRequest,
+        NotarizationSessionResponse, NotaryGlobals,
     },
     error::NotaryServerError,
     service::{
@@ -78,6 +78,18 @@ pub async fn upgrade_protocol(
     State(notary_globals): State<NotaryGlobals>,
     Query(params): Query<NotarizationRequestQuery>,
 ) -> Response {
+    let permit = if let Ok(permit) = notary_globals.semaphore.clone().try_acquire_owned() {
+        permit
+    } else {
+        // Ask the client to retry later.
+        // TODO: estimate the time more precisely to avoid unnecessary retries.
+        return (
+            StatusCode::OK,
+            Json(NotarizationRetryResponse { retry_in: 5 }),
+        )
+            .into_response();
+    };
+
     info!("Received upgrade protocol request");
     let session_id = params.session_id;
     // Check if session_id exists in the store, this also removes session_id from
@@ -96,12 +108,14 @@ pub async fn upgrade_protocol(
     // This completes the HTTP Upgrade request and returns a successful response to
     // the client, meanwhile initiating the websocket or tcp connection
     match protocol_upgrade {
-        ProtocolUpgrade::Ws(ws) => {
-            ws.on_upgrade(move |socket| websocket_notarize(socket, notary_globals, session_id))
-        }
-        ProtocolUpgrade::Tcp(tcp) => {
-            tcp.on_upgrade(move |stream| tcp_notarize(stream, notary_globals, session_id))
-        }
+        ProtocolUpgrade::Ws(ws) => ws.on_upgrade(move |socket| async move {
+            websocket_notarize(socket, notary_globals, session_id).await;
+            drop(permit);
+        }),
+        ProtocolUpgrade::Tcp(tcp) => tcp.on_upgrade(move |stream| async move {
+            tcp_notarize(stream, notary_globals, session_id).await;
+            drop(permit);
+        }),
     }
 }
 

--- a/crates/notary/tests-integration/Cargo.toml
+++ b/crates/notary/tests-integration/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dev-dependencies]
-notary-client = { workspace = true }
+notary-client = { workspace = true, features = ["test-api"] }
 notary-server = { workspace = true }
 tls-server-fixture = { workspace = true }
 tlsn-common = { workspace = true }
@@ -14,6 +14,7 @@ tlsn-tls-core = { workspace = true }
 tlsn-core = { workspace = true }
 
 async-tungstenite = { workspace = true, features = ["tokio-native-tls"] }
+futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["client", "http1", "server"] }


### PR DESCRIPTION
This PR adds adds a concurrency limit feature to the notary server allowing it to limit the number of concurrent notarizations.

This PR does not implement any queueing mechanism. Instead the client retries the request until it is accepted.
There are many ways to implement queueing with different trade-offs and I left it out of scope for this PR.