### PR TITLE
feat(mpc-tls): add config to recv record cushion

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -27,6 +27,15 @@ pub struct ProtocolConfig {
     max_recv_data_online: usize,
     /// Maximum number of bytes that can be received.
     max_recv_data: usize,
+    /// A cushion for handling more incoming TLS records than estimated by the
+    /// internal algorithm.
+    ///
+    /// We internally estimate based on an optimistic assumption that the
+    /// incoming TLS record's size will be 16KB, but in practice it is often
+    /// not the case.
+    /// This value will be added to the internal estimate.
+    #[builder(default = "0")]
+    extra_recv_records: usize,
     /// Version that is being run by prover/verifier.
     #[builder(setter(skip), default = "VERSION.clone()")]
     version: Version,
@@ -62,6 +71,12 @@ impl ProtocolConfig {
     /// Returns the maximum number of bytes that can be received.
     pub fn max_recv_data(&self) -> usize {
         self.max_recv_data
+    }
+
+    /// Returns a cushion for handling more incoming TLS records than estimated
+    /// by the internal algorithm.
+    pub fn extra_recv_records(&self) -> usize {
+        self.extra_recv_records
     }
 }
 

--- a/crates/mpc-tls/src/config.rs
+++ b/crates/mpc-tls/src/config.rs
@@ -79,4 +79,14 @@ impl ConfigBuilder {
             max_recv,
         })
     }
+
+    /// Builds the configuration with `count` additional received records.
+    pub fn build_with_extra_recv_records(
+        &self,
+        count: usize,
+    ) -> Result<Config, ConfigBuilderError> {
+        let mut config = self.build()?;
+        config.max_recv_records += count;
+        Ok(config)
+    }
 }

--- a/crates/prover/src/config.rs
+++ b/crates/prover/src/config.rs
@@ -54,7 +54,7 @@ impl ProverConfig {
             .max_sent(self.protocol_config.max_sent_data())
             .max_recv_online(self.protocol_config.max_recv_data_online())
             .max_recv(self.protocol_config.max_recv_data())
-            .build()
+            .build_with_extra_recv_records(self.protocol_config.extra_recv_records())
             .unwrap()
     }
 }

--- a/crates/verifier/src/config.rs
+++ b/crates/verifier/src/config.rs
@@ -47,7 +47,7 @@ impl VerifierConfig {
             .max_sent(protocol_config.max_sent_data())
             .max_recv_online(protocol_config.max_recv_data_online())
             .max_recv(protocol_config.max_recv_data())
-            .build()
+            .build_with_extra_recv_records(protocol_config.extra_recv_records())
             .unwrap()
     }
 }


### PR DESCRIPTION
This PR adds a config option for a cushion to handle cases when the number of incoming TLS record is underestimated by the internal algorithm.

Closes https://github.com/tlsnotary/tlsn/issues/739