### PR TITLE
misc(notary): improve error msg when tls is expected

### DIFF
--- a/crates/notary/client/src/client.rs
+++ b/crates/notary/client/src/client.rs
@@ -187,6 +187,14 @@ impl NotaryClient {
                         .and_then(|inner| inner.downcast_ref::<rustls::Error>())
                     {
                         error!("Perhaps the notary server is not accepting our TLS connection");
+                    } else if let Some(err) = err
+                        .get_ref()
+                        .and_then(|inner| inner.downcast_ref::<hyper::Error>())
+                    {
+                        // Check if the hyper error is `Kind::Parse(Parse::Version)`.
+                        if err.to_string() == "invalid HTTP version parsed" {
+                            error!("Perhaps the notary server is not accepting our TLS connection");
+                        }
                     }
 
                     ClientError::new(ErrorKind::TlsSetup, Some(Box::new(err)))

--- a/crates/notary/client/src/client.rs
+++ b/crates/notary/client/src/client.rs
@@ -188,7 +188,7 @@ impl NotaryClient {
                                 )
                             {
                                 error!(
-                                    "The notary server does not seem to accept our TLS connection"
+                                    "Perhaps the notary server is not accepting our TLS connection"
                                 );
                             }
                         }

--- a/crates/notary/client/src/client.rs
+++ b/crates/notary/client/src/client.rs
@@ -482,14 +482,6 @@ fn is_tls_mismatch_error(err: &std::io::Error) -> bool {
         .and_then(|inner| inner.downcast_ref::<rustls::Error>())
     {
         return true;
-    } else if let Some(err) = err
-        .get_ref()
-        .and_then(|inner| inner.downcast_ref::<hyper::Error>())
-    {
-        // Check if the hyper error is `Kind::Parse(Parse::Version)`.
-        if err.to_string() == "invalid HTTP version parsed" {
-            return true;
-        }
     }
     false
 }

--- a/crates/notary/server/src/server.rs
+++ b/crates/notary/server/src/server.rs
@@ -210,14 +210,14 @@ pub async fn run_server(config: &NotaryServerProperties) -> Result<(), NotarySer
                     }
                     Err(err) => {
                         error!("{}", NotaryServerError::Connection(err.to_string()));
-                        if let Ok(error) = err.downcast::<rustls::Error>() {
-                            if error
-                                == rustls::Error::InvalidMessage(
-                                    rustls::InvalidMessage::InvalidContentType,
-                                )
-                            {
-                                error!("Perhaps you should turn on `TLSProperties::enabled` to accept client's TLS connections");
-                            }
+
+                        if let Some(rustls::Error::InvalidMessage(
+                            rustls::InvalidMessage::InvalidContentType,
+                        )) = err
+                            .get_ref()
+                            .and_then(|inner| inner.downcast_ref::<rustls::Error>())
+                        {
+                            error!("Perhaps you should turn on `TLSProperties::enabled` to accept client's TLS connections");
                         }
                     }
                 }

--- a/crates/notary/server/src/server.rs
+++ b/crates/notary/server/src/server.rs
@@ -216,7 +216,7 @@ pub async fn run_server(config: &NotaryServerProperties) -> Result<(), NotarySer
                                     rustls::InvalidMessage::InvalidContentType,
                                 )
                             {
-                                error!("You should turn on `TLSProperties::enabled` to accept client's TLS connections");
+                                error!("Perhaps you should turn on `TLSProperties::enabled` to accept client's TLS connections");
                             }
                         }
                     }

--- a/crates/notary/server/src/server.rs
+++ b/crates/notary/server/src/server.rs
@@ -221,7 +221,7 @@ pub async fn run_server(config: &NotaryServerProperties) -> Result<(), NotarySer
                             .get_ref()
                             .and_then(|inner| inner.downcast_ref::<rustls::Error>())
                         {
-                            error!("Perhaps you should turn on `TLSProperties::enabled` to accept client's TLS connections");
+                            error!("Perhaps the client is connecting without TLS");
                         }
                     }
                 }


### PR DESCRIPTION
This PR improves the error message in cases when the client or notary unexpectedly get a connection without TLS enabled.