### PR TITLE
fix: select non-app recs correctly

### DIFF
--- a/crates/mpc-tls/Cargo.toml
+++ b/crates/mpc-tls/Cargo.toml
@@ -21,6 +21,7 @@ tlsn-hmac-sha256 = { workspace = true }
 tlsn-key-exchange = { workspace = true }
 tlsn-tls-backend = { workspace = true }
 tlsn-tls-core = { workspace = true, features = ["serde"] }
+tlsn-utils = { workspace = true }
 
 mpz-common = { workspace = true }
 mpz-core = { workspace = true }


### PR DESCRIPTION
This PR fixes a bug where non-application data records were incorrectly selected.
Also makes sure that the received records are not sorted by the order of decryption (which happens when deferred decryption is in use) but instead by their sequence number.