### PR TITLE
refactor: remove extension api from request builder

### DIFF
--- a/crates/core/src/fixtures.rs
+++ b/crates/core/src/fixtures.rs
@@ -199,17 +199,20 @@ pub fn request_fixture(
     )
     .unwrap();
 
-    let request_config = RequestConfig::default();
+    let mut builder = RequestConfig::builder();
+
+    for extension in extensions {
+        builder.extension(extension);
+    }
+
+    let request_config = builder.build().unwrap();
+
     let mut request_builder = Request::builder(&request_config);
     request_builder
         .server_name(server_name)
         .server_cert_data(server_cert_data)
         .transcript(transcript)
         .encoding_tree(encoding_tree.clone());
-
-    for extension in extensions {
-        request_builder.extension(extension);
-    }
 
     let (request, _) = request_builder.build(&provider).unwrap();
 

--- a/crates/core/src/request/builder.rs
+++ b/crates/core/src/request/builder.rs
@@ -1,5 +1,4 @@
 use crate::{
-    attestation::Extension,
     connection::{ServerCertData, ServerCertOpening, ServerName},
     index::Index,
     request::{Request, RequestConfig},
@@ -15,7 +14,6 @@ pub struct RequestBuilder<'a> {
     server_cert_data: Option<ServerCertData>,
     encoding_tree: Option<EncodingTree>,
     transcript: Option<Transcript>,
-    extensions: Vec<Extension>,
 }
 
 impl<'a> RequestBuilder<'a> {
@@ -27,7 +25,6 @@ impl<'a> RequestBuilder<'a> {
             server_cert_data: None,
             encoding_tree: None,
             transcript: None,
-            extensions: Vec::new(),
         }
     }
 
@@ -55,12 +52,6 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
-    /// Adds an extension to the request.
-    pub fn extension(&mut self, extension: Extension) -> &mut Self {
-        self.extensions.push(extension);
-        self
-    }
-
     /// Builds the attestation request and returns the corresponding secrets.
     pub fn build(
         self,
@@ -72,7 +63,6 @@ impl<'a> RequestBuilder<'a> {
             server_cert_data,
             encoding_tree,
             transcript,
-            extensions,
         } = self;
 
         let signature_alg = *config.signature_alg();
@@ -96,6 +86,8 @@ impl<'a> RequestBuilder<'a> {
         let server_cert_commitment = server_cert_opening.commit(hasher);
 
         let encoding_commitment_root = encoding_tree.as_ref().map(|tree| tree.root());
+
+        let extensions = config.extensions().to_vec();
 
         let request = Request {
             signature_alg,

--- a/crates/prover/src/notarize.rs
+++ b/crates/prover/src/notarize.rs
@@ -87,10 +87,6 @@ impl Prover<Notarize> {
             }
         }
 
-        for extension in config.extensions() {
-            builder.extension(extension.clone());
-        }
-
         let (request, secrets) = builder.build(provider).map_err(ProverError::attestation)?;
 
         let attestation = mux_fut


### PR DESCRIPTION
This PR removes the extension method from the request builder. It is supposed to be part of the request config api.