### PR TITLE
Additional attestation validation

### DIFF
--- a/crates/core/src/attestation.rs
+++ b/crates/core/src/attestation.rs
@@ -47,7 +47,10 @@ use crate::{
     merkle::MerkleTree,
     presentation::PresentationBuilder,
     signing::{Signature, VerifyingKey},
-    transcript::{encoding::EncodingCommitment, hash::PlaintextHash},
+    transcript::{
+        encoding::{EncoderSecret, EncodingCommitment},
+        hash::PlaintextHash,
+    },
     CryptoProvider,
 };
 
@@ -165,6 +168,13 @@ impl Body {
     /// Returns the attestation verifying key.
     pub fn verifying_key(&self) -> &VerifyingKey {
         &self.verifying_key.data
+    }
+
+    /// Returns the encoder secret.
+    pub fn encoder_secret(&self) -> Option<&EncoderSecret> {
+        self.encoding_commitment
+            .as_ref()
+            .map(|field| &field.data.secret)
     }
 
     /// Computes the Merkle root of the attestation fields.

--- a/crates/core/src/request.rs
+++ b/crates/core/src/request.rs
@@ -78,6 +78,10 @@ impl Request {
                     "encoding commitment root does not match".to_string(),
                 ));
             }
+        } else if attestation.body.encoding_commitment().is_some() {
+            return Err(InconsistentAttestation(
+                "encoding commitment is present even though it was not requested".to_string(),
+            ));
         }
 
         // TODO: improve the O(M*N) complexity of this check.


### PR DESCRIPTION
This PR adds a missing validation to the encoder secret in the attestation.
It also disallows the encoding commitment to be present in the attestation when it was not requested.

Related to #774