### PR TITLE
Expose public key shares for user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ Cargo.lock
 # vscode project specific settings
 .vscode/
 
+# idea project specific settings
+.idea
+
 # transcript
 *.json
 

--- a/crates/components/key-exchange/src/exchange.rs
+++ b/crates/components/key-exchange/src/exchange.rs
@@ -221,6 +221,11 @@ where
     }
 
     #[instrument(level = "debug", skip_all, err)]
+    fn key_share(&self) -> Result<PublicKey, KeyExchangeError> {
+        Ok(self.private_key.public_key())
+    }
+
+    #[instrument(level = "debug", skip_all, err)]
     async fn setup(&mut self, ctx: &mut Context) -> Result<(), KeyExchangeError> {
         let State::Setup {
             share_a0,

--- a/crates/components/key-exchange/src/lib.rs
+++ b/crates/components/key-exchange/src/lib.rs
@@ -64,6 +64,13 @@ pub trait KeyExchange {
     /// key.
     fn client_key(&self) -> Result<PublicKey, KeyExchangeError>;
 
+    /// Gets this party's individual public key share (before any combination).
+    ///
+    /// For the Leader, this returns the Leader's public key.
+    /// For the Follower, this returns the Follower's public key.
+    /// This is distinct from `client_key()` which returns the combined key.
+    fn key_share(&self) -> Result<PublicKey, KeyExchangeError>;
+
     /// Performs one-time setup for the key exchange protocol.
     async fn setup(&mut self, ctx: &mut Context) -> Result<(), KeyExchangeError>;
 

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -25,7 +25,7 @@ use mpc_tls::{LeaderCtrl, MpcTlsLeader};
 use rand::Rng;
 use serio::SinkExt;
 use std::sync::Arc;
-use tls_client::{ClientConnection, ServerName as TlsServerName};
+use tls_client::{Backend, ClientConnection, ServerName as TlsServerName};
 use tls_client_async::{bind_client, TlsConnection};
 use tls_core::msgs::enums::ContentType;
 use tlsn_common::{
@@ -41,6 +41,7 @@ use tlsn_core::{
 use tlsn_deap::Deap;
 use tokio::sync::Mutex;
 
+use tls_core::key::PublicKey;
 use tracing::{debug, info_span, instrument, Instrument, Span};
 
 pub(crate) type RCOTSender = mpz_ot::rcot::shared::SharedRCOTSender<
@@ -308,6 +309,23 @@ impl Prover<state::Setup> {
                 ctrl: ProverControl { mpc_ctrl },
             },
         ))
+    }
+
+    /// Gets public client keyshare.
+    pub async fn get_client_key(&mut self) -> Result<PublicKey, ProverError> {
+        let client_key_share = self
+            .state
+            .mpc_tls
+            .get_client_key_share()
+            .await
+            .map_err(ProverError::zk)?;
+        Ok(client_key_share)
+    }
+
+    /// Gets prover's public key share
+    pub fn get_key_share(&self) -> Result<PublicKey, ProverError> {
+        let key_share = self.state.mpc_tls.get_key_share()?;
+        Ok(key_share)
     }
 }
 

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -37,6 +37,7 @@ use tlsn_deap::Deap;
 use tokio::sync::Mutex;
 use web_time::{SystemTime, UNIX_EPOCH};
 
+use tls_core::key::PublicKey;
 use tracing::{debug, info, info_span, instrument, Span};
 
 pub(crate) type RCOTSender = mpz_ot::rcot::shared::SharedRCOTSender<
@@ -295,6 +296,11 @@ impl Verifier<state::Setup> {
                 transcript_refs,
             },
         })
+    }
+
+    /// Gets verifier's public key share
+    pub fn get_key_share(&self) -> Result<PublicKey, VerifierError> {
+        Ok(self.state.mpc_tls.key_share()?)
     }
 }
 


### PR DESCRIPTION
This follow up on proposal here #813 
User's app now able to get the session public key and key share for `Prover`. `Verifier` is only able to fetch public key share he uses.