### PR TITLE
browser bench fixes

### DIFF
--- a/crates/benches/binary/README.md
+++ b/crates/benches/binary/README.md
@@ -38,7 +38,7 @@ With a Chrome browser installed on your system, make sure you're in the `crates/
 directory, build the wasm module, build the binaries, and then run the script:
 ```sh
 cd browser/wasm
-wasm-pack build --target web
+wasm-pack build --release --target web
 cd ../../binary
 cargo build --release --features browser-bench
 sudo ./bench.sh

--- a/crates/benches/binary/README.md
+++ b/crates/benches/binary/README.md
@@ -38,8 +38,8 @@ With a Chrome browser installed on your system, make sure you're in the `crates/
 directory, build the wasm module, build the binaries, and then run the script:
 ```sh
 cd browser/wasm
-rustup run nightly wasm-pack build --release --target web
-cd ../../binary
+wasm-pack build --target web
+cd ../../binary 
 cargo build --release --features browser-bench
 sudo ./bench.sh
 ```

--- a/crates/benches/binary/README.md
+++ b/crates/benches/binary/README.md
@@ -39,7 +39,7 @@ directory, build the wasm module, build the binaries, and then run the script:
 ```sh
 cd browser/wasm
 wasm-pack build --target web
-cd ../../binary 
+cd ../../binary
 cargo build --release --features browser-bench
 sudo ./bench.sh
 ```

--- a/crates/benches/binary/bench.toml
+++ b/crates/benches/binary/bench.toml
@@ -38,8 +38,8 @@ upload-delay = 25
 download = 250
 download-delay = 25
 upload-size = 1024
-# Setting download-size higher than 45000 will cause a `Maximum call stack size exceeded`
-# error in the browser.
-download-size = [1024, 4096, 16384, 45000]
+# It was observed that setting download-size > 30K causes browser errors that need to
+# be investigated.
+download-size = [1024, 4096, 16384]
 defer-decryption = true
 memory-profile = true

--- a/crates/benches/binary/benches.Dockerfile
+++ b/crates/benches/binary/benches.Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 ARG BENCH_TYPE=native
 
 RUN \
+  rustup update; \
   if [ "$BENCH_TYPE" = "browser" ]; then \
     # ring's build script needs clang.
     apt update && apt install -y clang; \
@@ -12,7 +13,7 @@ RUN \
     rustup component add rust-src --toolchain nightly; \
     cargo install wasm-pack; \
     cd crates/benches/browser/wasm; \
-    rustup run nightly wasm-pack build --release --target web; \
+    wasm-pack build --target web; \
     cd ../../binary; \
     cargo build --release --features browser-bench; \
   else \

--- a/crates/benches/binary/benches.Dockerfile
+++ b/crates/benches/binary/benches.Dockerfile
@@ -13,7 +13,7 @@ RUN \
     rustup component add rust-src --toolchain nightly; \
     cargo install wasm-pack; \
     cd crates/benches/browser/wasm; \
-    wasm-pack build --target web; \
+    wasm-pack build --release --target web; \
     cd ../../binary; \
     cargo build --release --features browser-bench; \
   else \

--- a/crates/benches/browser/wasm/.cargo/config.toml
+++ b/crates/benches/browser/wasm/.cargo/config.toml
@@ -1,11 +1,16 @@
 [build]
 target = "wasm32-unknown-unknown"
 
+[unstable]
+build-std = ["panic_abort", "std"]
+
 [target.wasm32-unknown-unknown]
 rustflags = [
     "-C",
     "target-feature=+atomics,+bulk-memory,+mutable-globals",
+    "-C",
+    # 4GB
+    "link-arg=--max-memory=4294967296",
+    "--cfg",
+    'getrandom_backend="wasm_js"',
 ]
-
-[unstable]
-build-std = ["panic_abort", "std"]

--- a/crates/benches/browser/wasm/Cargo.toml
+++ b/crates/benches/browser/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "tlsn-benches-browser-wasm"
 publish = false
-version = "0.0.1"
+version = "0.0.0"
 
 [lints]
 workspace = true

--- a/crates/benches/browser/wasm/Cargo.toml
+++ b/crates/benches/browser/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "tlsn-benches-browser-wasm"
 publish = false
-version = "0.0.0"
+version = "0.0.1"
 
 [lints]
 workspace = true
@@ -18,9 +18,11 @@ tlsn-wasm = { path = "../../../wasm" }
 serio = { workspace = true }
 
 anyhow = { workspace = true }
+rayon = { workspace = true }
 tracing = { workspace = true }
-wasm-bindgen = { version = "0.2.87" }
-wasm-bindgen-futures = { version = "0.4.37" }
+wasm-bindgen = { version = "0.2" }
+wasm-bindgen-futures = { version = "0.4" }
+web-spawn = { workspace = true, features = ["no-bundler"] }
 web-time = { workspace = true }
 # Use the patched ws_stream_wasm to fix the issue https://github.com/najamelan/ws_stream_wasm/issues/12#issuecomment-1711902958
 ws_stream_wasm = { version = "0.7.4", git = "https://github.com/tlsnotary/ws_stream_wasm", rev = "2ed12aad9f0236e5321f577672f309920b2aef51", features = [

--- a/crates/benches/browser/wasm/pkg/index.js
+++ b/crates/benches/browser/wasm/pkg/index.js
@@ -1,7 +1,5 @@
 import * as Comlink from "./comlink.mjs";
 
-async function init() {
-    const worker = Comlink.wrap(new Worker("worker.js", { type: "module" }));
-    window.worker = worker;
-}
-init();
+const benchWorker = Comlink.wrap(new Worker("worker.js", { type: "module" }));
+
+window.benchWorker = benchWorker;

--- a/crates/benches/browser/wasm/pkg/worker.js
+++ b/crates/benches/browser/wasm/pkg/worker.js
@@ -1,18 +1,14 @@
 import * as Comlink from "./comlink.mjs";
 
-import init, { wasm_main, initialize } from './tlsn_benches_browser_wasm.js';
+import init_wasm, * as wasm from './tlsn_benches_browser_wasm.js';
 
-class Worker {
+class BenchWorker {
   async init() {
     try {
-      await init();
-      // Tracing may interfere with the benchmark results. We should enable it only for debugging.
-      // init_logging({
-      //   level: 'Debug',
-      //   crate_filters: undefined,
-      //   span_events: undefined,
-      // });
-      await initialize({ thread_count: navigator.hardwareConcurrency });
+      await init_wasm();
+      // Using Error level since excessive logging may interfere with the
+      // benchmark results. 
+      await wasm.initialize_bench({ level: "Error" }, navigator.hardwareConcurrency);
     } catch (e) {
       console.error(e);
       throw e;
@@ -27,7 +23,7 @@ class Worker {
     wasm_to_native_port
   ) {
     try {
-      await wasm_main(
+      await wasm.wasm_main(
         ws_ip,
         ws_port,
         wasm_to_server_port,
@@ -40,6 +36,6 @@ class Worker {
   }
 }
 
-const worker = new Worker();
+const worker = new BenchWorker();
 
 Comlink.expose(worker);

--- a/crates/benches/browser/wasm/rust-toolchain.toml
+++ b/crates/benches/browser/wasm/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
 channel = "nightly"
+components = ["rust-src"]
+targets = ["wasm32-unknown-unknown"]

--- a/crates/benches/browser/wasm/src/lib.rs
+++ b/crates/benches/browser/wasm/src/lib.rs
@@ -5,18 +5,19 @@
 //! Conceptually the browser prover consists of the native and the wasm
 //! components.
 
+use anyhow::Result;
 use serio::{stream::IoStreamExt, SinkExt as _};
+use tracing::info;
+use wasm_bindgen::prelude::*;
+use web_time::Instant;
+use ws_stream_wasm::WsMeta;
+
 use tlsn_benches_browser_core::{
     msg::{Config, Runtime},
     FramedIo,
 };
 use tlsn_benches_library::run_prover;
-
-use anyhow::Result;
-use tracing::info;
-use wasm_bindgen::prelude::*;
-use web_time::Instant;
-use ws_stream_wasm::WsMeta;
+use tlsn_wasm::LoggingConfig;
 
 #[wasm_bindgen]
 pub async fn wasm_main(
@@ -85,6 +86,9 @@ pub async fn main(
     let cfg: Config = native_io.expect_next().await?;
 
     let start_time = Instant::now();
+
+    info!("running the prover");
+
     run_prover(
         cfg.upload_size,
         cfg.download_size,
@@ -99,4 +103,13 @@ pub async fn main(
         .await?;
 
     Ok(())
+}
+
+/// Initializes the module.
+#[wasm_bindgen]
+pub async fn initialize_bench(
+    logging_config: Option<LoggingConfig>,
+    thread_count: usize,
+) -> Result<(), JsValue> {
+    tlsn_wasm::initialize(logging_config, thread_count).await
 }


### PR DESCRIPTION
This PR adds changes to the browser bench crate to make it run again.

The benches were run successfully in gh actions multiple times https://github.com/tlsnotary/tlsn/actions/workflows/bench.yml