### PR TITLE
test: webpki roots fixes

### DIFF
--- a/crates/tls/client/src/verifybench.rs
+++ b/crates/tls/client/src/verifybench.rs
@@ -56,19 +56,6 @@ fn test_arstechnica_cert() {
 }
 
 #[test]
-fn test_servo_cert() {
-    Context::new(
-        "servo",
-        "servo.org",
-        &[
-            include_bytes!("testdata/cert-servo.0.der"),
-            include_bytes!("testdata/cert-servo.1.der"),
-        ],
-    )
-    .bench(100)
-}
-
-#[test]
 fn test_twitter_cert() {
     Context::new(
         "twitter",


### PR DESCRIPTION
This PR fixes failed tested caused by `webpki-roots` upgrade from 0.26.9 -> 0.26.10 in which some of the root certs were invalidated.

Closes https://github.com/tlsnotary/tlsn/issues/822