### PR TITLE
Move `defer_decryption_from_start` into `ProtocolConfig`

### DIFF
--- a/crates/benches/library/src/lib.rs
+++ b/crates/benches/library/src/lib.rs
@@ -65,26 +65,26 @@ pub async fn run_prover(
         ..Default::default()
     };
 
-    let protocol_config = if defer_decryption {
-        ProtocolConfig::builder()
+    let mut protocol_config = ProtocolConfig::builder();
+    if defer_decryption {
+        protocol_config
             .max_sent_data(upload_size + 256)
             .max_recv_data(download_size + 256)
-            .build()
-            .unwrap()
     } else {
-        ProtocolConfig::builder()
+        protocol_config
             .max_sent_data(upload_size + 256)
             .max_recv_data(download_size + 256)
             .max_recv_data_online(download_size + 256)
-            .build()
-            .unwrap()
     };
+    let protocol_config = protocol_config
+        .defer_decryption_from_start(defer_decryption)
+        .build()
+        .unwrap();
 
     let prover = Prover::new(
         ProverConfig::builder()
             .server_name(SERVER_DOMAIN)
             .protocol_config(protocol_config)
-            .defer_decryption_from_start(defer_decryption)
             .crypto_provider(provider)
             .build()
             .context("invalid prover config")?,

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -37,6 +37,10 @@ pub struct ProtocolConfig {
     /// Maximum number of application data records that can be received.
     #[builder(setter(strip_option), default)]
     max_recv_records: Option<usize>,
+    /// Whether the `deferred decryption` feature is toggled on from the start
+    /// of the MPC-TLS connection.
+    #[builder(default = "true")]
+    defer_decryption_from_start: bool,
     /// Version that is being run by prover/verifier.
     #[builder(setter(skip), default = "VERSION.clone()")]
     version: Version,
@@ -84,6 +88,12 @@ impl ProtocolConfig {
     /// be received.
     pub fn max_recv_records(&self) -> Option<usize> {
         self.max_recv_records
+    }
+
+    /// Returns whether the `deferred decryption` feature is toggled on from the
+    /// start of the MPC-TLS connection.
+    pub fn defer_decryption_from_start(&self) -> bool {
+        self.defer_decryption_from_start
     }
 }
 

--- a/crates/prover/src/config.rs
+++ b/crates/prover/src/config.rs
@@ -12,10 +12,6 @@ pub struct ProverConfig {
     server_name: ServerName,
     /// Protocol configuration to be checked with the verifier.
     protocol_config: ProtocolConfig,
-    /// Whether the `deferred decryption` feature is toggled on from the start
-    /// of the MPC-TLS connection.
-    #[builder(default = "true")]
-    defer_decryption_from_start: bool,
     /// Cryptography provider.
     #[builder(default, setter(into))]
     crypto_provider: Arc<CryptoProvider>,
@@ -42,17 +38,11 @@ impl ProverConfig {
         &self.protocol_config
     }
 
-    /// Returns whether the `deferred decryption` feature is toggled on from the
-    /// start of the MPC-TLS connection.
-    pub fn defer_decryption_from_start(&self) -> bool {
-        self.defer_decryption_from_start
-    }
-
     pub(crate) fn build_mpc_tls_config(&self) -> Config {
         let mut builder = Config::builder();
 
         builder
-            .defer_decryption(self.defer_decryption_from_start)
+            .defer_decryption(self.protocol_config.defer_decryption_from_start())
             .max_sent(self.protocol_config.max_sent_data())
             .max_recv_online(self.protocol_config.max_recv_data_online())
             .max_recv(self.protocol_config.max_recv_data());

--- a/crates/tests-integration/tests/notarize.rs
+++ b/crates/tests-integration/tests/notarize.rs
@@ -54,13 +54,13 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
         .max_sent_data(MAX_SENT_DATA)
         .max_recv_data(MAX_RECV_DATA)
         .max_recv_data_online(MAX_RECV_DATA)
+        .defer_decryption_from_start(false)
         .build()
         .unwrap();
 
     let prover = Prover::new(
         ProverConfig::builder()
             .server_name(SERVER_DOMAIN)
-            .defer_decryption_from_start(false)
             .protocol_config(protocol_config)
             .crypto_provider(provider)
             .build()

--- a/crates/tests-integration/tests/verify.rs
+++ b/crates/tests-integration/tests/verify.rs
@@ -61,11 +61,11 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(notary_socke
     let prover = Prover::new(
         ProverConfig::builder()
             .server_name(SERVER_DOMAIN)
-            .defer_decryption_from_start(true)
             .protocol_config(
                 ProtocolConfig::builder()
                     .max_sent_data(MAX_SENT_DATA)
                     .max_recv_data(MAX_RECV_DATA)
+                    .defer_decryption_from_start(true)
                     .build()
                     .unwrap(),
             )

--- a/crates/wasm/src/prover/config.rs
+++ b/crates/wasm/src/prover/config.rs
@@ -33,16 +33,16 @@ impl From<ProverConfig> for tlsn_prover::ProverConfig {
             builder.max_recv_records(value);
         }
 
+        if let Some(value) = value.defer_decryption_from_start {
+            builder.defer_decryption_from_start(value);
+        }
+
         let protocol_config = builder.build().unwrap();
 
         let mut builder = tlsn_prover::ProverConfig::builder();
         builder
             .server_name(value.server_name.as_ref())
             .protocol_config(protocol_config);
-
-        if let Some(value) = value.defer_decryption_from_start {
-            builder.defer_decryption_from_start(value);
-        }
 
         builder.build().unwrap()
     }


### PR DESCRIPTION
This PR moves the config option `defer_decryption_from_start` from the `ProverConfig` into the `ProtocolConfig`.