### PR TITLE
chore(notary): ignore clippy warning on large enum

### DIFF
--- a/crates/notary/client/src/client.rs
+++ b/crates/notary/client/src/client.rs
@@ -65,7 +65,7 @@ pub enum NotaryConnection {
     /// Unencrypted TCP connection.
     Tcp(TcpStream),
     /// TLS connection.
-    Tls(TlsStream<TcpStream>),
+    Tls(Box<TlsStream<TcpStream>>),
 }
 
 impl AsyncRead for NotaryConnection {
@@ -205,7 +205,7 @@ impl NotaryClient {
                 .await
                 .map(|(connection, session_id)| Accepted {
                     id: session_id,
-                    io: NotaryConnection::Tls(connection),
+                    io: NotaryConnection::Tls(Box::new(connection)),
                 })
         } else {
             debug!("Setting up tcp connection...");

--- a/crates/notary/client/src/client.rs
+++ b/crates/notary/client/src/client.rs
@@ -61,11 +61,12 @@ pub struct Accepted {
 
 /// A notary server connection.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum NotaryConnection {
     /// Unencrypted TCP connection.
     Tcp(TcpStream),
     /// TLS connection.
-    Tls(Box<TlsStream<TcpStream>>),
+    Tls(TlsStream<TcpStream>),
 }
 
 impl AsyncRead for NotaryConnection {
@@ -205,7 +206,7 @@ impl NotaryClient {
                 .await
                 .map(|(connection, session_id)| Accepted {
                     id: session_id,
-                    io: NotaryConnection::Tls(Box::new(connection)),
+                    io: NotaryConnection::Tls(connection),
                 })
         } else {
             debug!("Setting up tcp connection...");


### PR DESCRIPTION
Rust 1.87 update caused this clippy [warning](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant) in our CI (https://github.com/tlsnotary/tlsn/actions/runs/15061240029/job/42336652489)

Given that most clients would use `Tls` variant to connect to notary server, I think we can ignore this warning as the memory overhead is negligible