### PR TITLE
fix(prf): set correct default logic

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -238,7 +238,7 @@ pub enum NetworkSetting {
 
 impl Default for NetworkSetting {
     fn default() -> Self {
-        Self::Bandwidth
+        Self::Latency
     }
 }
 

--- a/crates/components/hmac-sha256/src/config.rs
+++ b/crates/components/hmac-sha256/src/config.rs
@@ -8,9 +8,3 @@ pub enum Mode {
     /// Computes the whole PRF in MPC.
     Normal,
 }
-
-impl Default for Mode {
-    fn default() -> Self {
-        Self::Reduced
-    }
-}

--- a/crates/mpc-tls/src/config.rs
+++ b/crates/mpc-tls/src/config.rs
@@ -69,9 +69,9 @@ impl Config {
 }
 
 impl ConfigBuilder {
-    /// Optimizes the protocol for low bandwidth networks.
-    pub fn low_bandwidth(&mut self) -> &mut Self {
-        self.prf = Some(PrfMode::Reduced);
+    /// Optimizes the protocol for high bandwidth networks.
+    pub fn high_bandwidth(&mut self) -> &mut Self {
+        self.prf = Some(PrfMode::Normal);
         self
     }
 
@@ -105,7 +105,7 @@ impl ConfigBuilder {
             .max_recv_records
             .unwrap_or_else(|| PROTOCOL_RECORD_COUNT_RECV + default_record_count(max_recv));
 
-        let prf = self.prf.unwrap_or_default();
+        let prf = self.prf.unwrap_or(PrfMode::Reduced);
 
         Ok(Config {
             defer_decryption,

--- a/crates/prover/src/config.rs
+++ b/crates/prover/src/config.rs
@@ -55,8 +55,8 @@ impl ProverConfig {
             builder.max_recv_records(max_recv_records);
         }
 
-        if let NetworkSetting::Latency = self.protocol_config.network() {
-            builder.low_bandwidth();
+        if let NetworkSetting::Bandwidth = self.protocol_config.network() {
+            builder.high_bandwidth();
         }
 
         builder.build().unwrap()

--- a/crates/verifier/src/config.rs
+++ b/crates/verifier/src/config.rs
@@ -58,8 +58,8 @@ impl VerifierConfig {
             builder.max_recv_records(max_recv_records);
         }
 
-        if let NetworkSetting::Latency = protocol_config.network() {
-            builder.low_bandwidth();
+        if let NetworkSetting::Bandwidth = protocol_config.network() {
+            builder.high_bandwidth();
         }
 
         builder.build().unwrap()


### PR DESCRIPTION
This PR fixes a bug in the default logic and sets the reduced PRF variant as default. If `NetworkSetting::HighBandwidth` is selected the normal PRF is selected.