### PR TITLE
refactor(mpc-tls): default to full-mpc PRF

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -238,7 +238,7 @@ pub enum NetworkSetting {
 
 impl Default for NetworkSetting {
     fn default() -> Self {
-        Self::Latency
+        Self::Bandwidth
     }
 }
 


### PR DESCRIPTION
This PR reverts the default back to using the full MPC PRF implementation. Benchmarking shows that the reduced variant currently is too latency sensitive and would cause performance regression at >100Mbps bandwidth levels.