### PR TITLE
fix(wasm): expose reveal server identity.

### DIFF
--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -159,6 +159,10 @@ impl JsProver {
             builder.reveal_recv(&range)?;
         }
 
+        if reveal.server_identity {
+            builder.server_identity();
+        }
+
         let config = builder.build()?;
 
         prover.prove(&config).await?;

--- a/crates/wasm/src/tests.rs
+++ b/crates/wasm/src/tests.rs
@@ -70,6 +70,7 @@ pub async fn test_prove() -> Result<(), JsValue> {
         .reveal(Reveal {
             sent: vec![0..10],
             recv: vec![0..10],
+            server_identity: true,
         })
         .await?;
 
@@ -144,6 +145,7 @@ pub async fn test_notarize() -> Result<(), JsValue> {
         Reveal {
             sent: vec![(0..10)],
             recv: vec![(0..10)],
+            server_identity: false,
         },
     )?;
 

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -171,6 +171,8 @@ pub struct Commit {
 pub struct Reveal {
     pub sent: Vec<Range<usize>>,
     pub recv: Vec<Range<usize>>,
+    #[serde(default)]
+    pub server_identity: bool,
 }
 
 #[derive(Debug, Tsify, Deserialize)]

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -171,7 +171,6 @@ pub struct Commit {
 pub struct Reveal {
     pub sent: Vec<Range<usize>>,
     pub recv: Vec<Range<usize>>,
-    #[serde(default)]
     pub server_identity: bool,
 }
 


### PR DESCRIPTION
Needed for interactive prover-verifier flow on wasm side e.g. https://github.com/tlsnotary/tlsn-js/blob/main/demo/interactive-demo/prover-ts/src/app.tsx#L98, where one can do

```ts
const reveal: Reveal = {
  server_identity: true,
  sent: subtractRanges(
    ...
```