### PR TITLE
refactor(mpc-tls): remove commit-reveal from tag verification

### DIFF
--- a/crates/mpc-tls/src/record_layer.rs
+++ b/crates/mpc-tls/src/record_layer.rs
@@ -450,16 +450,15 @@ impl RecordLayer {
         let verify_tags = decrypt::verify_tags(&mut (*vm), &mut decrypter, &decrypt_ops)?;
 
         // Run tag computation and VM in parallel.
-        let (mut tags, _, _) = ctx
-            .try_join3(
-                async move |ctx| {
-                    compute_tags
-                        .run(ctx)
-                        .map_err(MpcTlsError::record_layer)
-                        .await
-                },
+        let (mut tags, _) = ctx
+            .try_join(
                 async move |ctx| {
                     verify_tags
+                        .run(ctx)
+                        .map_err(MpcTlsError::record_layer)
+                        .await?;
+
+                    compute_tags
                         .run(ctx)
                         .map_err(MpcTlsError::record_layer)
                         .await

--- a/crates/mpc-tls/src/record_layer/aead/aes_gcm.rs
+++ b/crates/mpc-tls/src/record_layer/aead/aes_gcm.rs
@@ -323,7 +323,7 @@ impl MpcAesGcm {
     }
 
     /// Computes tags for the provided ciphertext. See
-    /// [`verify_tags`](MpcAesGcm::verify_tags) for a method that verifies an
+    /// [`verify_tags`](MpcAesGcm::verify_tags) for a method that verifies
     /// tags instead.
     ///
     /// # Arguments
@@ -378,6 +378,8 @@ impl MpcAesGcm {
     }
 
     /// Verifies the tags for the provided ciphertexts.
+    ///
+    /// Ciphertexts are only authenticated from the leader's perspective.
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
Closes #889 

This PR removes the commit-reveal process from tag verification, which as of #868 it is no longer needed to authenticate the ciphertext for the verifier during the online phase.