### PR TITLE
fix(notary-server): parse JWT claims from env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,6 +4362,7 @@ dependencies = [
  "sha1",
  "structopt",
  "strum",
+ "tempfile",
  "thiserror 1.0.69",
  "tlsn-common",
  "tlsn-core",

--- a/crates/notary/server/Cargo.toml
+++ b/crates/notary/server/Cargo.toml
@@ -62,6 +62,9 @@ zeroize = { workspace = true }
 hex = { workspace = true, optional = true }
 mc-sgx-dcap-types = { version = "0.11.0", optional = true }
 
+[dev-dependencies]
+tempfile = "3.15.0"
+
 [build-dependencies]
 git2 = "0.19.0"
 chrono.workspace = true

--- a/crates/notary/server/README.md
+++ b/crates/notary/server/README.md
@@ -105,6 +105,35 @@ Example:
 NS_PORT=8080 NS_NOTARIZATION__MAX_SENT_DATA=2048 cargo run --release --bin notary-server
 ```
 
+##### JWT Claims
+Custom user JWT claims can be specified via `NS_AUTH__JWT__CLAIMS=` environment variable where the input format is as follows:
+
+```
+NS_AUTH__JWT__CLAIMS="<name> <name>:<value>:...:<value>"
+```
+
+Each user claim starts with `<name>` of the claim followed by zero or more values `<value>`, where `:` is used as separator. Therefore, in order to represent a claim:
+
+```yaml
+claims:
+ - name: sub
+   values: ["something"]  
+```
+
+one would write `sub:something`.
+
+Next, each user claim is separated by ` `. Therefore, in order to represent claims:
+
+```yaml
+claims:
+ - name: sub
+ - name: custom
+   values: ["something"]
+```
+
+one would write `NS_AUTH__JWT__CLAIMS="sub custom:something"`.
+
+
 #### Configuration File
 This will override all the default values, hence it needs to **contain all compulsory** configuration keys and values (refer to the [default yaml](#default)). The config file has precedence over environment variables.
 ```bash


### PR DESCRIPTION
Fixes #887

Parsing is facilitated through a custom serde deserializer which accept both string and struct representation and correctly unpacks it into JwtClaim struct.

The implementation of the deserializer is generic over the output type `T`. The only requirement is that `T` implements `std::str::FromStr` trait and that `std::str::FromStr::Err = eyre::Error`.

### Usage example

With this patch, it is now possible to parse JWT claims directly from env variables encoded in compact string representation as follows:

```
NS_AUTH__JWT__CLAIMS="tlsn1 tlsn2:is:cool"
```

where the format is `<name>:<value>:<value>:...:<value>`.

In what follows is a more complete demonstration of this in action:

```
$ cd crates/notary/server
$ NS_AUTH__ENABLED=true NS_AUTH__JWT__PUBLIC_KEY_PATH="../tests-integration/fixture/auth/jwt.key.pub" NS_AUTH__JWT__ALGORITHM="rs256" NS_AUTH__JWT__CLAIMS="tlsn1 tlsn2:is:cool" cargo run
2025-06-06T13:13:22.962178Z DEBUG main ThreadId(01) notary_server: Server config loaded:
host: 0.0.0.0
port: 7047
html_info: "\n                <head>\n                    <meta charset='UTF-8'>\n                    <meta name='author' content='tlsnotary'>\n                    <meta name='viewport' content='width=device-width, initial-scale=1.0'>\n                </head>\n                <body>\n                    <svg width='86' height='88' viewBox='0 0 86 88' fill='none' xmlns='http://www.w3.org/2000/svg'>\n                    <path d='M25.5484 0.708986C25.5484 0.17436 26.1196 -0.167376 26.5923 0.0844205L33.6891 3.86446C33.9202 3.98756 34.0645 4.22766 34.0645 4.48902V9.44049H37.6129C38.0048 9.44049 38.3226 9.75747 38.3226 10.1485V21.4766L36.1936 20.0606V11.5645H34.0645V80.9919C34.0645 81.1134 34.0332 81.2328 33.9735 81.3388L30.4251 87.6388C30.1539 88.1204 29.459 88.1204 29.1878 87.6388L25.6394 81.3388C25.5797 81.2328 25.5484 81.1134 25.5484 80.9919V0.708986Z' fill='#243F5F'/>\n                    <path d='M21.2903 25.7246V76.7012H12.7742V34.2207H0V25.7246H21.2903Z' fill='#243F5F'/>\n                    <path d='M63.871 76.7012H72.3871V34.2207H76.6452V76.7012H85.1613V25.7246H63.871V76.7012Z' fill='#243F5F'/>\n                    <path d='M38.3226 25.7246H59.6129V34.2207H46.8387V46.9649H59.6129V76.7012H38.3226V68.2051H51.0968V55.4609H38.3226V25.7246Z' fill='#243F5F'/>\n                    </svg>\n                    <h1>Notary Server {version}!</h1>\n                    <ul>\n                    <li>public key: <pre>{public_key}</pre></li>\n                    <li>git commit hash: <a href='https://github.com/tlsnotary/tlsn/commit/{git_commit_hash}'>{git_commit_hash}</a></li>\n                    <li><a href='healthcheck'>health check</a></li>\n                    <li><a href='info'>info</a></li>\n                    </ul>\n                </body>\n            "
concurrency: 32
notarization:
  max_sent_data: 4096
  max_recv_data: 16384
  timeout: 1800
  private_key_path: null
  signature_algorithm: secp256k1
  allow_extensions: false
tls:
  enabled: false
  private_key_path: null
  certificate_path: null
log:
  level: DEBUG
  filter: null
  format: COMPACT
auth:
  enabled: true
  jwt:
    algorithm: rs256
    public_key_path: ../tests-integration/fixture/auth/jwt.key.pub
    claims:
    - name: tlsn1
      values: []
    - name: tlsn2
      values:
      - is
      - cool

2025-06-06T13:13:22.962642Z  WARN main ThreadId(01) run_server: notary_server::server: ⚠️ Using a random, ephemeral signing key because `notarization.private_key_path` is not set.
2025-06-06T13:13:22.966334Z DEBUG main ThreadId(01) run_server: notary_server::server: Skipping TLS setup as it is turned off.
2025-06-06T13:13:22.966371Z DEBUG main ThreadId(01) run_server: notary_server::auth: Using JWT for authorization
2025-06-06T13:13:22.967322Z  INFO main ThreadId(01) run_server: notary_server::server: Listening for TCP traffic at 0.0.0.0:7047
```

cc @yuroitaki 