### PR TITLE
build(wasm): add wasm profile and optimize for perf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,8 @@ jobs:
           sudo apt-get install -y chromium-chromedriver
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        # we install a specific version which supports custom profiles
+        run: cargo install --git https://github.com/rustwasm/wasm-pack.git --rev 32e52ca
 
       - name: Use caching
         uses: Swatinem/rust-cache@v2.7.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,9 @@ resolver = "2"
 inherits = "release"
 opt-level = 1
 
-[profile.release.package."tlsn-wasm"]
-opt-level = "z"
-
-[profile.dev.package."tlsn-wasm"]
-debug = false
+[profile.wasm]
+inherits = "release"
+lto = true
 
 [workspace.dependencies]
 notary-client = { path = "crates/notary/client" }

--- a/crates/harness/README.md
+++ b/crates/harness/README.md
@@ -2,6 +2,15 @@
 
 A harness for testing and benchmarking the TLSNotary protocol with both native and browser support.
 
+## Installation
+
+The harness requires the nightly compiler to build the WASM binary. Additionally, we depend on a specific
+version of `wasm-pack` which must be installed:
+
+```bash
+cargo install --git https://github.com/rustwasm/wasm-pack.git --rev 32e52ca
+```
+
 ## Getting started
 
 First build the harness.

--- a/crates/harness/build.wasm.sh
+++ b/crates/harness/build.wasm.sh
@@ -4,4 +4,8 @@
 cd "$(dirname "$0")"
 
 rustup run nightly \
-    wasm-pack build executor --target web --no-pack --out-dir=../static/generated -- -Zbuild-std=panic_abort,std
+    wasm-pack build executor \
+        --profile wasm \
+        --target web \
+        --out-dir=../static/generated \
+        -- -Zbuild-std=panic_abort,std

--- a/crates/harness/executor/Cargo.toml
+++ b/crates/harness/executor/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 name = "harness_executor"
 crate-type = ["cdylib", "rlib"]
 
+[package.metadata.wasm-pack.profile.custom]
+wasm-opt = ["-O3"]
+
 [dependencies]
 tlsn-harness-core = { workspace = true }
 tlsn-prover = { workspace = true }

--- a/crates/harness/runner/src/wasm_server.rs
+++ b/crates/harness/runner/src/wasm_server.rs
@@ -79,6 +79,10 @@ pub async fn main() -> Result<()> {
             HeaderName::from_static("cross-origin-opener-policy"),
             HeaderValue::from_static("same-origin"),
         ))
+        .layer(SetResponseHeaderLayer::overriding(
+            HeaderName::from_static("cache-control"),
+            HeaderValue::from_static("no-store"),
+        ))
         .service(files);
 
     // build our application with a single route

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,6 +14,9 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[package.metadata.wasm-pack.profile.custom]
+wasm-opt = ["-O3"]
+
 [features]
 default = []
 test = []

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -4,6 +4,14 @@ This crate provides a WebAssembly package for TLSNotary, offering core functiona
 
 For most use cases, you may prefer to use the `tlsn-js` package instead: [tlsn-js on npm](https://www.npmjs.com/package/tlsn-js).
 
+## Dependencies
+
+A specific version of `wasm-pack` must be installed to build the WASM binary:
+
+```bash
+cargo install --git https://github.com/rustwasm/wasm-pack.git --rev 32e52ca
+```
+
 ## Links
 
 - [Website](https://tlsnotary.org)

--- a/crates/wasm/build.sh
+++ b/crates/wasm/build.sh
@@ -9,7 +9,10 @@ set -e
 rm -rf pkg
 
 # Build tlsn_wasm package
-wasm-pack build --release --target web .
+wasm-pack build \
+    --profile wasm \
+    --target web \
+    .
 
 # Patch tlsn_wasm.js import in spawn.js snippet and copy it to the main folder
 file=$(find ./pkg/snippets -name "spawn.js" -print -quit)


### PR DESCRIPTION
This PR makes a couple changes to our build process for WASM.

1. Define a `wasm` build profile instead of using package specific config. The build profile is used by both the harness and wasm packages.
2. Configure `wasm-opt` to optimize for speed