### PR TITLE
build(wasm): enable simd128 feature

### DIFF
--- a/crates/harness/executor/.cargo/config.toml
+++ b/crates/harness/executor/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
     "-C",
-    "target-feature=+atomics,+bulk-memory,+mutable-globals",
+    "target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128",
     "-C",
     # 4GB
     "link-arg=--max-memory=4294967296",

--- a/crates/wasm/.cargo/config.toml
+++ b/crates/wasm/.cargo/config.toml
@@ -7,7 +7,7 @@ build-std = ["panic_abort", "std"]
 [target.wasm32-unknown-unknown]
 rustflags = [
     "-C",
-    "target-feature=+atomics,+bulk-memory,+mutable-globals",
+    "target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128",
     "-C",
     # 4GB
     "link-arg=--max-memory=4294967296",


### PR DESCRIPTION
This PR enables the SIMD wasm extension for our builds. On my machine this yields ~17% performance improvement using the harness.

This feature has strong support across major runtimes: https://webassembly.org/features/