### PR TITLE
fix(harness): add custom wasm-pack to build script

### DIFF
--- a/crates/harness/build.wasm.sh
+++ b/crates/harness/build.wasm.sh
@@ -3,6 +3,9 @@
 # Ensure the script runs in the folder that contains this script
 cd "$(dirname "$0")"
 
+# A specific version of `wasm-pack` must be installed to build the WASM binary
+cargo install --git https://github.com/rustwasm/wasm-pack.git --rev 32e52ca
+
 rustup run nightly \
     wasm-pack build executor \
         --profile wasm \


### PR DESCRIPTION
When checking out the repo for the first time and trying to build a harness, the user will get an error without a custom wasm-pack