### PR TITLE
fix(harness): pull latest docker images

### DIFF
--- a/crates/harness/docker.md
+++ b/crates/harness/docker.md
@@ -2,7 +2,7 @@
 
 In the root folder of this repository, run:
 ```
-docker build -t tlsn-bench . -f ./crates/harness/harness.Dockerfile
+docker build --pull -t tlsn-bench . -f ./crates/harness/harness.Dockerfile
 ```
 
 Next run the benches with:


### PR DESCRIPTION
The user may locally have old version of `rust` and `debian` images. They may have incompatible glibc version. Pulling the latest images will prevent incompatibility.