### PR TITLE
perf: preprocess concurrently to mpc-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,7 +1741,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 [[package]]
 name = "clmul"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3770,7 +3770,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 [[package]]
 name = "matrix-transpose"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "bincode",
  "itybity 0.3.1",
@@ -3930,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "mpz-cointoss"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "futures",
  "mpz-cointoss-core",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "mpz-cointoss-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "mpz-core",
  "opaque-debug",
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "mpz-common"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "mpz-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "aes 0.9.0-rc.0",
  "bcs",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "mpz-fields"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-secp256r1",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "mpz-garble"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "async-trait",
  "derive_builder 0.11.2",
@@ -4049,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "mpz-garble-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "aes 0.9.0-rc.0",
  "bitvec",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "mpz-hash"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "itybity 0.3.1",
  "mpz-circuits",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "mpz-memory-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "blake3",
  "futures",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "mpz-ole"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "async-trait",
  "futures",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "mpz-ole-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "hybrid-array",
  "itybity 0.3.1",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "mpz-ot"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4165,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "mpz-ot-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "aes 0.9.0-rc.0",
  "blake3",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "mpz-share-conversion"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "async-trait",
  "mpz-common",
@@ -4212,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "mpz-share-conversion-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "mpz-common",
  "mpz-core",
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "mpz-vm-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "async-trait",
  "futures",
@@ -4239,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "mpz-zk"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4251,12 +4251,13 @@ dependencies = [
  "mpz-zk-core",
  "serio",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
 name = "mpz-zk-core"
 version = "0.1.0-alpha.3"
-source = "git+https://github.com/privacy-scaling-explorations/mpz?rev=ccc0057#ccc00572f35c589706ca6be0e2e8749eb9b4414a"
+source = "git+https://github.com/privacy-scaling-explorations/mpz?branch=refactor%2Fzk_expose_ot_handle#01262276483268259887508d87234911dbf0c336"
 dependencies = [
  "blake3",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,19 +70,19 @@ tlsn-harness-runner = { path = "crates/harness/runner" }
 tlsn-wasm = { path = "crates/wasm" }
 tlsn = { path = "crates/tlsn" }
 
-mpz-circuits = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-memory-core = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-common = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-core = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-vm-core = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-garble = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-garble-core = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-ole = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-ot = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-share-conversion = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-fields = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-zk = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
-mpz-hash = { git = "https://github.com/privacy-scaling-explorations/mpz", rev = "ccc0057" }
+mpz-circuits = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-memory-core = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-common = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-core = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-vm-core = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-garble = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-garble-core = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-ole = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-ot = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-share-conversion = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-fields = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-zk = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
+mpz-hash = { git = "https://github.com/privacy-scaling-explorations/mpz", branch = "refactor/zk_expose_ot_handle" }
 
 rangeset = { version = "0.2" }
 serio = { version = "0.2" }


### PR DESCRIPTION
(This PR is not in a finished form, it may need some polishing and test) 

This PR introduces concurrent preprocessing alongside MPC‑TLS.

Currently, this feature benefits mostly preprocessing the OT setup for QuickSilver, since the execution of QS starts only at the very end of MPC-TLS.

The following changes were made to accommodate this feature:

### mpz changes
 in this branch: [refactor/zk_expose_ot_handle](https://github.com/privacy-scaling-explorations/mpz/compare/refactor/zk_expose_ot_handle)
(I'll discuss the changes here to keep the discussion in one place)
 
- Expose OT handles to the ZK prover and verifier.
    - Allows external code to lock and drive OT in advance.
    - Caveat: callers must avoid simultaneous locks (consider behind a feature flag).

- Support multiple independent contexts sharing a single yamux muxer with unique thread/stream IDs.
    - Necessary so preprocessing and MPC‑TLS can both use the same muxer concurrently.
 

### tlsn changes (in this PR)
- Add a "limited" mode to the DEAP VM (better naming is welcome)
    - Disables any ZK‑VM operations that would conflict with in‑flight OT preprocessing.

- Auxiliary‐future polling
    - MuxFuture can now drive a user‐supplied future (e.g. the OT preprocessing task) alongside the main MPC‑TLS future.


- KOS‑driven OT for key exchange
    - Before:
    <img width="500" height="100" alt="Screenshot From 2025-07-18 15-30-24" src="https://github.com/user-attachments/assets/2030df75-c390-49db-b713-fd43c95c6666" />
     
    - Now:
    <img width="500" height="100" alt="Screenshot From 2025-07-18 15-32-37" src="https://github.com/user-attachments/assets/92646f48-53b8-4ab5-8699-23ad7ed0cecc" />

    - The key exchange’s small OT requirement is served directly by KOS—incurring minimal extra work but eliminating one round‑trip to Ferret and simplifying OT ownership and locking.


### Benchmarks
The improvements start to show when the server payload size is sufficiently large, i.e > 10KB. For a 20KB payload the improvement was ~15%. 

    Before this PR  the runtime was 7000 ms on average 

```
latency,,20,200,2048,20000,true,4796,2263,7093,61483178,3378041,2555529,329257,64107406,3707310,
```

    After this PR  the runtime was 6100 ms on average

```
latency,,20,200,2048,20000,true,3953,2185,6177,61494688,3378137,2556207,329257,64119594,3707406,
``` 