### PR TITLE
feat(wasm): add no_logging flag

### DIFF
--- a/crates/wasm/src/log.rs
+++ b/crates/wasm/src/log.rs
@@ -86,6 +86,7 @@ impl From<SpanEvent> for FmtSpan {
             SpanEvent::New => FmtSpan::NEW,
             SpanEvent::Close => FmtSpan::CLOSE,
             SpanEvent::Active => FmtSpan::ACTIVE,
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a flag to the wasm binary to avoid registering a tracing subscriber.

### Motivation
Due to a panic caused by https://github.com/tlsnotary/tlsn/issues/959 , a temporary work-around would be to not register a tracing subscriber,


The panic in 959 was gone when the tracing subscriber was not registered.