### PR TITLE
fix(harness): improve harness stability

### DIFF
--- a/crates/harness/core/src/lib.rs
+++ b/crates/harness/core/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Id {
     One,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum IoMode {
     Client,
     Server,

--- a/crates/harness/runner/src/executor.rs
+++ b/crates/harness/runner/src/executor.rs
@@ -12,7 +12,7 @@ use chromiumoxide::{
 };
 use futures::StreamExt;
 use harness_core::{
-    ExecutorConfig, Id, IoMode,
+    ExecutorConfig, Id,
     bench::BenchOutput,
     network::PORT_BROWSER,
     rpc::{BenchCmd, TestCmd},
@@ -285,10 +285,6 @@ impl Executor {
 
             Ok(())
         }
-    }
-
-    pub fn is_client(&self) -> bool {
-        self.config.io_mode() == &IoMode::Client
     }
 }
 

--- a/crates/harness/runner/src/executor.rs
+++ b/crates/harness/runner/src/executor.rs
@@ -8,10 +8,11 @@ use chromiumoxide::{
         network::{EnableParams, SetCacheDisabledParams},
         page::ReloadParams,
     },
+    handler::HandlerConfig,
 };
 use futures::StreamExt;
 use harness_core::{
-    ExecutorConfig, Id,
+    ExecutorConfig, Id, IoMode,
     bench::BenchOutput,
     network::PORT_BROWSER,
     rpc::{BenchCmd, TestCmd},
@@ -126,8 +127,18 @@ impl Executor {
                 const TIMEOUT: usize = 10000;
                 const DELAY: usize = 100;
                 let mut retries = 0;
+                let config = HandlerConfig {
+                    // Bump the timeout for long-running benches.
+                    request_timeout: Duration::from_secs(120),
+                    ..Default::default()
+                };
+
                 let (browser, mut handler) = loop {
-                    match Browser::connect(format!("http://{}:{}", rpc_addr.0, PORT_BROWSER)).await
+                    match Browser::connect_with_config(
+                        format!("http://{}:{}", rpc_addr.0, PORT_BROWSER),
+                        config.clone(),
+                    )
+                    .await
                     {
                         Ok(browser) => break browser,
                         Err(e) => {
@@ -143,6 +154,14 @@ impl Executor {
                 tokio::spawn(async move {
                     while let Some(res) = handler.next().await {
                         if let Err(e) = res {
+                            if e.to_string()
+                                == "data did not match any variant of untagged enum Message"
+                            {
+                                // Do not log this error. It appears to be
+                                // caused by a bug upstream.
+                                // https://github.com/mattsse/chromiumoxide/issues/167
+                                continue;
+                            }
                             eprintln!("chromium error: {e:?}");
                         }
                     }
@@ -266,6 +285,10 @@ impl Executor {
 
             Ok(())
         }
+    }
+
+    pub fn is_client(&self) -> bool {
+        self.config.io_mode() == &IoMode::Client
     }
 }
 

--- a/crates/harness/runner/src/lib.rs
+++ b/crates/harness/runner/src/lib.rs
@@ -153,37 +153,16 @@ pub async fn main() -> Result<()> {
             let mut failed = 0;
             let mut failed_tests = Vec::new();
             for name in tests {
-                let exec_p_fut = async {
-                    if runner.exec_p.is_client() {
-                        // Allow the server counterpart some time to be ready
-                        // to accept our connection.
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
-                    runner
-                        .exec_p
-                        .test(TestCmd {
-                            name: name.clone(),
-                            role: Role::Prover,
-                        })
-                        .await
-                };
-
-                let exec_v_fut = async {
-                    if runner.exec_v.is_client() {
-                        // Allow the server counterpart some time to be ready
-                        // to accept our connection.
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
-                    runner
-                        .exec_v
-                        .test(TestCmd {
-                            name: name.clone(),
-                            role: Role::Verifier,
-                        })
-                        .await
-                };
-
-                let (output_p, output_v) = tokio::try_join!(exec_p_fut, exec_v_fut)?;
+                let (output_p, output_v) = tokio::try_join!(
+                    runner.exec_p.test(TestCmd {
+                        name: name.clone(),
+                        role: Role::Prover,
+                    }),
+                    runner.exec_v.test(TestCmd {
+                        name: name.clone(),
+                        role: Role::Verifier,
+                    })
+                )?;
 
                 if output_p.status.is_passed() && output_v.status.is_passed() {
                     success += 1;
@@ -248,37 +227,16 @@ pub async fn main() -> Result<()> {
                 // Wait for the network to stabilize
                 tokio::time::sleep(Duration::from_millis(100)).await;
 
-                let exec_p_fut = async {
-                    if runner.exec_p.is_client() {
-                        // Allow the server counterpart some time to be ready
-                        // to accept our connection.
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
-                    runner
-                        .exec_p
-                        .bench(BenchCmd {
-                            config: config.clone(),
-                            role: Role::Prover,
-                        })
-                        .await
-                };
-
-                let exec_v_fut = async {
-                    if runner.exec_v.is_client() {
-                        // Allow the server counterpart some time to be ready
-                        // to accept our connection.
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
-                    runner
-                        .exec_v
-                        .bench(BenchCmd {
-                            config: config.clone(),
-                            role: Role::Verifier,
-                        })
-                        .await
-                };
-
-                let (output, _) = tokio::try_join!(exec_p_fut, exec_v_fut)?;
+                let (output, _) = tokio::try_join!(
+                    runner.exec_p.bench(BenchCmd {
+                        config: config.clone(),
+                        role: Role::Prover,
+                    }),
+                    runner.exec_v.bench(BenchCmd {
+                        config: config.clone(),
+                        role: Role::Verifier,
+                    })
+                )?;
 
                 let BenchOutput::Prover { metrics } = output else {
                     panic!("expected prover output");


### PR DESCRIPTION
This PR improves harness stability esp. for wasm:

- increase timeout for long running benches
- dont log a non-critical chrome debug protocol error 
- make sure the server executor has enough time to become ready (I ran a few times into errors when the client executor tried to connect when the server wasn't yet ready)

Supersedes https://github.com/tlsnotary/tlsn/pull/946