### PR TITLE
feat(tlsn): serializable config

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Configuration to prove information to the verifier.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProveConfig {
     server_identity: bool,
     transcript: Option<PartialTranscript>,
@@ -163,7 +163,7 @@ enum ProveConfigBuilderErrorRepr {
 }
 
 /// Configuration to verify information from the prover.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct VerifyConfig {}
 
 impl VerifyConfig {
@@ -210,6 +210,7 @@ pub struct ProvePayload {
 }
 
 /// Prover output.
+#[derive(Serialize, Deserialize)]
 pub struct ProverOutput {
     /// Transcript commitments.
     pub transcript_commitments: Vec<TranscriptCommitment>,
@@ -220,6 +221,7 @@ pub struct ProverOutput {
 opaque_debug::implement!(ProverOutput);
 
 /// Verifier output.
+#[derive(Serialize, Deserialize)]
 pub struct VerifierOutput {
     /// Server identity.
     pub server_name: Option<ServerName>,

--- a/crates/core/src/transcript/commit.rs
+++ b/crates/core/src/transcript/commit.rs
@@ -66,7 +66,7 @@ pub enum TranscriptSecret {
 }
 
 /// Configuration for transcript commitments.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptCommitConfig {
     encoding_hash_alg: HashAlgId,
     has_encoding: bool,

--- a/crates/tlsn/src/config.rs
+++ b/crates/tlsn/src/config.rs
@@ -110,7 +110,7 @@ impl ProtocolConfig {
 
 /// Protocol configuration validator used by checker (i.e. verifier) to perform
 /// compatibility check with the peer's (i.e. the prover's) configuration.
-#[derive(derive_builder::Builder, Clone, Debug)]
+#[derive(derive_builder::Builder, Clone, Debug, Serialize, Deserialize)]
 pub struct ProtocolConfigValidator {
     /// Maximum number of bytes that can be sent.
     max_sent_data: usize,

--- a/crates/tlsn/src/prover/config.rs
+++ b/crates/tlsn/src/prover/config.rs
@@ -1,4 +1,5 @@
 use mpc_tls::Config;
+use serde::{Deserialize, Serialize};
 use tlsn_core::{
     connection::ServerName,
     webpki::{CertificateDer, PrivateKeyDer, RootCertStore},
@@ -7,7 +8,7 @@ use tlsn_core::{
 use crate::config::{NetworkSetting, ProtocolConfig};
 
 /// Configuration for the prover.
-#[derive(Debug, Clone, derive_builder::Builder)]
+#[derive(Debug, Clone, derive_builder::Builder, Serialize, Deserialize)]
 pub struct ProverConfig {
     /// The server DNS name.
     #[builder(setter(into))]
@@ -66,7 +67,7 @@ impl ProverConfig {
 }
 
 /// Configuration for the prover's TLS connection.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct TlsConfig {
     /// Root certificates.
     root_store: Option<RootCertStore>,

--- a/crates/tlsn/src/verifier/config.rs
+++ b/crates/tlsn/src/verifier/config.rs
@@ -1,12 +1,14 @@
 use std::fmt::{Debug, Formatter, Result};
 
-use crate::config::{NetworkSetting, ProtocolConfig, ProtocolConfigValidator};
 use mpc_tls::Config;
+use serde::{Deserialize, Serialize};
 use tlsn_core::webpki::RootCertStore;
+
+use crate::config::{NetworkSetting, ProtocolConfig, ProtocolConfigValidator};
 
 /// Configuration for the [`Verifier`](crate::tls::Verifier).
 #[allow(missing_docs)]
-#[derive(derive_builder::Builder)]
+#[derive(derive_builder::Builder, Serialize, Deserialize)]
 #[builder(pattern = "owned")]
 pub struct VerifierConfig {
     protocol_config_validator: ProtocolConfigValidator,


### PR DESCRIPTION
This PR adds serialization to configuration types. This is motivated by the need to be able to pass these structures across the WASM ABI boundary.