### PR TITLE
fix(hmac-sha256): compute PHash and AHash concurrently

### DIFF
--- a/crates/components/hmac-sha256/src/prf/function/reduced.rs
+++ b/crates/components/hmac-sha256/src/prf/function/reduced.rs
@@ -145,6 +145,10 @@ impl PrfFunction {
                         msg: output.to_vec(),
                     }
                 };
+
+                // We recurse, so that this PHash and the next AHash could
+                // be computed in a single VM execute call.
+                self.flush(vm)?;
             }
             PrfState::FinishLastP => self.state = PrfState::Done,
             _ => (),


### PR DESCRIPTION
This PR reduces round count in reduced PRF by observing that the PHash value and the next AHash value can be computed concurrently.

As a reminder
```