### PR TITLE
refactor(tlsn): change network setting default to reduce data transfer

### DIFF
--- a/crates/tlsn/src/config.rs
+++ b/crates/tlsn/src/config.rs
@@ -233,15 +233,17 @@ impl ProtocolConfigValidator {
 /// situations.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum NetworkSetting {
-    /// Prefers a bandwidth-heavy protocol.
+    /// Reduces network round-trips at the expense of consuming more network
+    /// bandwidth.
     Bandwidth,
-    /// Prefers a latency-heavy protocol.
+    /// Reduces network bandwidth utilization at the expense of more network
+    /// round-trips.
     Latency,
 }
 
 impl Default for NetworkSetting {
     fn default() -> Self {
-        Self::Bandwidth
+        Self::Latency
     }
 }
 


### PR DESCRIPTION
This PR updates the default network setting to use the reduced MPC variant.

setting | latency | time_total | uploaded_total
-- | -- | -- | --
reduced | 200 | 12335 | 34597687
reduced | 200 | 11757 | 34597699
reduced | 200 | 11967 | 34597699
normal | 200 | 11661 | 49156339
normal | 200 | 11666 | 49156339
normal | 200 | 11458 | 49156327

As you can see there is negligible difference in latency sensitivity between the two modes, while the reduced variant uploads 30% less data.

At first I thought it was #969 which fixed the performance regression of this mode, but I could detect marginal difference from that change. I think the reason we were seeing the regression previously was due to the TCP delay setting that @themighty1 discovered. The reduced variant introduces rounds which communicate a tiny amount of data back and forth to make progress, and this was likely getting penalized heavily by the TCP buffering delay.

It should now be safe to have this mode on by default, but we will have to make sure our users understand that IO buffering can cause serious performance regressions.
