### PR TITLE
Reduce WASM size with wasm profile settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ opt-level = 1
 [profile.wasm]
 inherits = "release"
 lto = true
+panic = "abort"
+codegen-units = 1
 
 [workspace.dependencies]
 tls-server-fixture = { path = "crates/tls/server-fixture" }

--- a/crates/harness/executor/Cargo.toml
+++ b/crates/harness/executor/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 name = "harness_executor"
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.wasm-pack.profile.custom]
-wasm-opt = ["-O3"]
-
 [dependencies]
 tlsn-harness-core = { workspace = true }
 tlsn = { workspace = true }

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -14,9 +14,6 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.wasm-pack.profile.custom]
-wasm-opt = ["-O3"]
-
 [features]
 default = []
 test = []


### PR DESCRIPTION
This PR reduces the generated Wasm size by ~9% (from 9,266,036 to 8,444,117 bytes) by adjusting the wasm profile settings.

Notes
* Benchmarks have not been run, but I expect no negative performance impact
* Setting `lto = "fat"` was tested: it increases build time but does not produce a meaningful size improvement compared to lto = true.