### PR TITLE
Feat/get connection

### DIFF
--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -31,7 +31,7 @@ use tlsn_common::{
     commit::{commit_records, hash::prove_hash},
     context::build_mt_context,
     encoding,
-    mux::attach_mux,
+    mux::{attach_mux, MuxControl, MuxFuture},
     tag::verify_tags,
     transcript::{decode_transcript, Record, TlsTranscript},
     zk_aes_ctr::ZkAesCtr,
@@ -565,6 +565,16 @@ impl Prover<state::Committed> {
         }
 
         Ok(())
+    }
+
+    /// Consumes the prover and returns the underlying connection
+    #[instrument(parent = &self.span, level = "info", skip_all, err)]
+    pub async fn into_connection(self) -> Result<(MuxControl, MuxFuture, Context), ProverError> {
+        let state::Committed {
+            mux_ctrl, mux_fut, ctx, ..
+        } = self.state;
+
+        Ok((mux_ctrl, mux_fut, ctx))
     }
 }
 

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -568,13 +568,12 @@ impl Prover<state::Committed> {
     }
 
     /// Consumes the prover and returns the underlying connection
-    #[instrument(parent = &self.span, level = "info", skip_all, err)]
-    pub async fn into_connection(self) -> Result<(MuxControl, MuxFuture, Context), ProverError> {
+    pub async fn into_connection(self) -> (MuxControl, MuxFuture, Context) {
         let state::Committed {
             mux_ctrl, mux_fut, ctx, ..
         } = self.state;
 
-        Ok((mux_ctrl, mux_fut, ctx))
+        (mux_ctrl, mux_fut, ctx)
     }
 }
 

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -27,7 +27,7 @@ use tlsn_common::{
     config::ProtocolConfig,
     context::build_mt_context,
     encoding,
-    mux::attach_mux,
+    mux::{attach_mux, MuxControl, MuxFuture},
     tag::verify_tags,
     transcript::{decode_transcript, verify_transcript, Record, TlsTranscript},
     zk_aes_ctr::ZkAesCtr,
@@ -529,6 +529,16 @@ impl Verifier<state::Committed> {
         }
 
         Ok(())
+    }
+
+    /// Consumes the verifier and returns the underlying connection
+    #[instrument(parent = &self.span, level = "info", skip_all, err)]
+    pub async fn into_connection(self) -> Result<(MuxControl, MuxFuture, Context), VerifierError> {
+        let state::Committed {
+            mux_ctrl, mux_fut, ctx, ..
+        } = self.state;
+
+        Ok((mux_ctrl, mux_fut, ctx))
     }
 }
 

--- a/crates/verifier/src/lib.rs
+++ b/crates/verifier/src/lib.rs
@@ -532,13 +532,12 @@ impl Verifier<state::Committed> {
     }
 
     /// Consumes the verifier and returns the underlying connection
-    #[instrument(parent = &self.span, level = "info", skip_all, err)]
-    pub async fn into_connection(self) -> Result<(MuxControl, MuxFuture, Context), VerifierError> {
+    pub async fn into_connection(self) -> (MuxControl, MuxFuture, Context) {
         let state::Committed {
             mux_ctrl, mux_fut, ctx, ..
         } = self.state;
 
-        Ok((mux_ctrl, mux_fut, ctx))
+        (mux_ctrl, mux_fut, ctx)
     }
 }
 


### PR DESCRIPTION
small feat to allow developers to consume provers/verifiers into their underlying connection primitives - found this helpful in implementing custom communication after protocol is done

if it's important to abstract away the connection from the specific primitives (yamux structs and context) close this.

Also wanted to bring up the idea of adding an API for "custom communication channels" between prover and verifier that share the mux