### PR TITLE
fix(wasm): explicitly enable link args for wasm

### DIFF
--- a/crates/harness/executor/.cargo/config.toml
+++ b/crates/harness/executor/.cargo/config.toml
@@ -1,10 +1,14 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-    "-C",
-    "target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128",
-    "-C",
+    "-Ctarget-feature=+atomics,+bulk-memory,+mutable-globals,+simd128",
+    "-Clink-arg=--shared-memory",
     # 4GB
-    "link-arg=--max-memory=4294967296",
+    "-Clink-arg=--max-memory=4294967296",
+    "-Clink-arg=--import-memory",
+    "-Clink-arg=--export=__wasm_init_tls",
+    "-Clink-arg=--export=__tls_size",
+    "-Clink-arg=--export=__tls_align",
+    "-Clink-arg=--export=__tls_base",
     "--cfg",
     'getrandom_backend="wasm_js"',
 ]

--- a/crates/wasm/.cargo/config.toml
+++ b/crates/wasm/.cargo/config.toml
@@ -6,11 +6,15 @@ build-std = ["panic_abort", "std"]
 
 [target.wasm32-unknown-unknown]
 rustflags = [
-    "-C",
-    "target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128",
-    "-C",
+    "-Ctarget-feature=+atomics,+bulk-memory,+mutable-globals,+simd128",
+    "-Clink-arg=--shared-memory",
     # 4GB
-    "link-arg=--max-memory=4294967296",
+    "-Clink-arg=--max-memory=4294967296",
+    "-Clink-arg=--import-memory",
+    "-Clink-arg=--export=__wasm_init_tls",
+    "-Clink-arg=--export=__tls_size",
+    "-Clink-arg=--export=__tls_align",
+    "-Clink-arg=--export=__tls_base",
     "--cfg",
     'getrandom_backend="wasm_js"',
 ]


### PR DESCRIPTION
This PR fixes WASM builds on newer versions of `rustc` by setting required link args.