### PR TITLE
fix(tlsn): do not implicitly reveal encoder secret

### DIFF
--- a/crates/attestation/src/lib.rs
+++ b/crates/attestation/src/lib.rs
@@ -219,7 +219,7 @@ use tlsn_core::{
     connection::{ConnectionInfo, ServerEphemKey},
     hash::{Hash, HashAlgorithm, TypedHash},
     merkle::MerkleTree,
-    transcript::TranscriptCommitment,
+    transcript::{TranscriptCommitment, encoding::EncoderSecret},
 };
 
 use crate::{
@@ -327,6 +327,7 @@ pub struct Body {
     connection_info: Field<ConnectionInfo>,
     server_ephemeral_key: Field<ServerEphemKey>,
     cert_commitment: Field<ServerCertCommitment>,
+    encoder_secret: Option<Field<EncoderSecret>>,
     extensions: Vec<Field<Extension>>,
     transcript_commitments: Vec<Field<TranscriptCommitment>>,
 }
@@ -372,6 +373,7 @@ impl Body {
             connection_info: conn_info,
             server_ephemeral_key,
             cert_commitment,
+            encoder_secret,
             extensions,
             transcript_commitments,
         } = self;
@@ -388,6 +390,13 @@ impl Body {
                 hasher.hash_separated(&cert_commitment.data),
             ),
         ];
+
+        if let Some(encoder_secret) = encoder_secret {
+            fields.push((
+                encoder_secret.id,
+                hasher.hash_separated(&encoder_secret.data),
+            ));
+        }
 
         for field in extensions.iter() {
             fields.push((field.id, hasher.hash_separated(&field.data)));

--- a/crates/attestation/src/presentation.rs
+++ b/crates/attestation/src/presentation.rs
@@ -91,6 +91,11 @@ impl Presentation {
                 transcript.verify_with_provider(
                     &provider.hash,
                     &attestation.body.connection_info().transcript_length,
+                    attestation
+                        .body
+                        .encoder_secret
+                        .as_ref()
+                        .map(|field| &field.data),
                     attestation.body.transcript_commitments(),
                 )
             })

--- a/crates/attestation/src/serialize.rs
+++ b/crates/attestation/src/serialize.rs
@@ -49,5 +49,6 @@ impl_domain_separator!(tlsn_core::connection::ConnectionInfo);
 impl_domain_separator!(tlsn_core::connection::CertBinding);
 impl_domain_separator!(tlsn_core::transcript::TranscriptCommitment);
 impl_domain_separator!(tlsn_core::transcript::TranscriptSecret);
+impl_domain_separator!(tlsn_core::transcript::encoding::EncoderSecret);
 impl_domain_separator!(tlsn_core::transcript::encoding::EncodingCommitment);
 impl_domain_separator!(tlsn_core::transcript::hash::PlaintextHash);

--- a/crates/attestation/tests/api.rs
+++ b/crates/attestation/tests/api.rs
@@ -64,7 +64,6 @@ fn test_api() {
 
     let encoding_commitment = EncodingCommitment {
         root: encoding_tree.root(),
-        secret: encoder_secret(),
     };
 
     let request_config = RequestConfig::default();
@@ -96,6 +95,7 @@ fn test_api() {
         .connection_info(connection_info.clone())
         // Server key Notary received during handshake
         .server_ephemeral_key(server_ephemeral_key)
+        .encoder_secret(encoder_secret())
         .transcript_commitments(vec![TranscriptCommitment::Encoding(encoding_commitment)]);
 
     let attestation = attestation_builder.build(&provider).unwrap();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     connection::{HandshakeData, ServerName},
     transcript::{
-        Direction, PartialTranscript, Transcript, TranscriptCommitConfig, TranscriptCommitRequest,
-        TranscriptCommitment, TranscriptSecret,
+        encoding::EncoderSecret, Direction, PartialTranscript, Transcript, TranscriptCommitConfig,
+        TranscriptCommitRequest, TranscriptCommitment, TranscriptSecret,
     },
 };
 
@@ -220,6 +220,8 @@ pub struct VerifierOutput {
     pub server_name: Option<ServerName>,
     /// Transcript data.
     pub transcript: Option<PartialTranscript>,
+    /// Encoding commitment secret.
+    pub encoder_secret: Option<EncoderSecret>,
     /// Transcript commitments.
     pub transcript_commitments: Vec<TranscriptCommitment>,
 }

--- a/crates/core/src/transcript/encoding.rs
+++ b/crates/core/src/transcript/encoding.rs
@@ -19,6 +19,4 @@ use crate::hash::TypedHash;
 pub struct EncodingCommitment {
     /// Merkle root of the encoding commitments.
     pub root: TypedHash,
-    /// Seed used to generate the encodings.
-    pub secret: EncoderSecret,
 }

--- a/crates/core/src/transcript/encoding/tree.rs
+++ b/crates/core/src/transcript/encoding/tree.rs
@@ -222,14 +222,12 @@ mod tests {
 
         let proof = tree.proof([&idx_0, &idx_1].into_iter()).unwrap();
 
-        let commitment = EncodingCommitment {
-            root: tree.root(),
-            secret: encoder_secret(),
-        };
+        let commitment = EncodingCommitment { root: tree.root() };
 
         let (auth_sent, auth_recv) = proof
             .verify_with_provider(
                 &HashProvider::default(),
+                &encoder_secret(),
                 &commitment,
                 transcript.sent(),
                 transcript.received(),
@@ -260,14 +258,12 @@ mod tests {
             .proof([&idx_0, &idx_1, &idx_2, &idx_3].into_iter())
             .unwrap();
 
-        let commitment = EncodingCommitment {
-            root: tree.root(),
-            secret: encoder_secret(),
-        };
+        let commitment = EncodingCommitment { root: tree.root() };
 
         let (auth_sent, auth_recv) = proof
             .verify_with_provider(
                 &HashProvider::default(),
+                &encoder_secret(),
                 &commitment,
                 transcript.sent(),
                 transcript.received(),


### PR DESCRIPTION
This PR fixes an issue where the encoder secret is implicitly revealed to the Prover. This changes it such that it must be handled explicitly by the verifier after proving is fully complete.