### PR TITLE
feat(tlsn): insecure mode

### DIFF
--- a/crates/tlsn/Cargo.toml
+++ b/crates/tlsn/Cargo.toml
@@ -40,6 +40,7 @@ mpz-ole = { workspace = true }
 mpz-ot = { workspace = true }
 mpz-vm-core = { workspace = true }
 mpz-zk = { workspace = true }
+mpz-ideal-vm = { workspace = true }
 
 aes = { workspace = true }
 ctr = { workspace = true }

--- a/crates/tlsn/build.rs
+++ b/crates/tlsn/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(tlsn_insecure)");
+}

--- a/crates/tlsn/src/lib.rs
+++ b/crates/tlsn/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub(crate) mod context;
 pub(crate) mod ghash;
 pub(crate) mod map;
+pub(crate) mod mpz;
 pub(crate) mod msg;
 pub(crate) mod mux;
 pub mod prover;

--- a/crates/tlsn/src/mpz.rs
+++ b/crates/tlsn/src/mpz.rs
@@ -1,0 +1,208 @@
+use std::sync::Arc;
+
+use mpc_tls::{Config as MpcTlsConfig, MpcTlsFollower, MpcTlsLeader, SessionKeys};
+use mpz_common::Context;
+use mpz_core::Block;
+#[cfg(not(tlsn_insecure))]
+use mpz_garble::protocol::semihonest::{Evaluator, Garbler};
+use mpz_garble_core::Delta;
+use mpz_memory_core::{
+    Vector,
+    binary::U8,
+    correlated::{Key, Mac},
+};
+#[cfg(not(tlsn_insecure))]
+use mpz_ot::cot::{DerandCOTReceiver, DerandCOTSender};
+use mpz_ot::{
+    chou_orlandi as co, ferret, kos,
+    rcot::shared::{SharedRCOTReceiver, SharedRCOTSender},
+};
+use mpz_zk::{Prover, Verifier};
+#[cfg(not(tlsn_insecure))]
+use rand::Rng;
+use tlsn_deap::Deap;
+use tokio::sync::Mutex;
+
+use crate::transcript_internal::commit::encoding::{KeyStore, MacStore};
+
+#[cfg(not(tlsn_insecure))]
+pub(crate) type ProverMpc =
+    Garbler<DerandCOTSender<SharedRCOTSender<kos::Sender<co::Receiver>, Block>>>;
+#[cfg(tlsn_insecure)]
+pub(crate) type ProverMpc = mpz_ideal_vm::IdealVm;
+
+#[cfg(not(tlsn_insecure))]
+pub(crate) type ProverZk =
+    Prover<SharedRCOTReceiver<ferret::Receiver<kos::Receiver<co::Sender>>, bool, Block>>;
+#[cfg(tlsn_insecure)]
+pub(crate) type ProverZk = mpz_ideal_vm::IdealVm;
+
+#[cfg(not(tlsn_insecure))]
+pub(crate) type VerifierMpc =
+    Evaluator<DerandCOTReceiver<SharedRCOTReceiver<kos::Receiver<co::Sender>, bool, Block>>>;
+#[cfg(tlsn_insecure)]
+pub(crate) type VerifierMpc = mpz_ideal_vm::IdealVm;
+
+#[cfg(not(tlsn_insecure))]
+pub(crate) type VerifierZk =
+    Verifier<SharedRCOTSender<ferret::Sender<kos::Sender<co::Receiver>>, Block>>;
+#[cfg(tlsn_insecure)]
+pub(crate) type VerifierZk = mpz_ideal_vm::IdealVm;
+
+pub(crate) struct ProverDeps {
+    pub(crate) vm: Arc<Mutex<Deap<ProverMpc, ProverZk>>>,
+    pub(crate) mpc_tls: MpcTlsLeader,
+}
+
+pub(crate) fn build_prover_deps(config: MpcTlsConfig, ctx: Context) -> ProverDeps {
+    let mut rng = rand::rng();
+    let delta = Delta::new(Block::random(&mut rng));
+
+    let base_ot_send = co::Sender::default();
+    let base_ot_recv = co::Receiver::default();
+    let rcot_send = kos::Sender::new(
+        kos::SenderConfig::default(),
+        delta.into_inner(),
+        base_ot_recv,
+    );
+    let rcot_recv = kos::Receiver::new(kos::ReceiverConfig::default(), base_ot_send);
+    let rcot_recv = ferret::Receiver::new(
+        ferret::FerretConfig::builder()
+            .lpn_type(ferret::LpnType::Regular)
+            .build()
+            .expect("ferret config is valid"),
+        Block::random(&mut rng),
+        rcot_recv,
+    );
+
+    let rcot_send = SharedRCOTSender::new(rcot_send);
+    let rcot_recv = SharedRCOTReceiver::new(rcot_recv);
+
+    #[cfg(not(tlsn_insecure))]
+    let mpc = ProverMpc::new(DerandCOTSender::new(rcot_send.clone()), rng.random(), delta);
+    #[cfg(tlsn_insecure)]
+    let mpc = mpz_ideal_vm::IdealVm::new();
+
+    #[cfg(not(tlsn_insecure))]
+    let zk = ProverZk::new(Default::default(), rcot_recv.clone());
+    #[cfg(tlsn_insecure)]
+    let zk = mpz_ideal_vm::IdealVm::new();
+
+    let vm = Arc::new(Mutex::new(Deap::new(tlsn_deap::Role::Leader, mpc, zk)));
+    let mpc_tls = MpcTlsLeader::new(
+        config,
+        ctx,
+        vm.clone(),
+        (rcot_send.clone(), rcot_send.clone(), rcot_send),
+        rcot_recv,
+    );
+
+    ProverDeps { vm, mpc_tls }
+}
+
+pub(crate) struct VerifierDeps {
+    pub(crate) vm: Arc<Mutex<Deap<VerifierMpc, VerifierZk>>>,
+    pub(crate) mpc_tls: MpcTlsFollower,
+}
+
+pub(crate) fn build_verifier_deps(config: MpcTlsConfig, ctx: Context) -> VerifierDeps {
+    let mut rng = rand::rng();
+
+    let delta = Delta::random(&mut rng);
+    let base_ot_send = co::Sender::default();
+    let base_ot_recv = co::Receiver::default();
+    let rcot_send = kos::Sender::new(
+        kos::SenderConfig::default(),
+        delta.into_inner(),
+        base_ot_recv,
+    );
+    let rcot_send = ferret::Sender::new(
+        ferret::FerretConfig::builder()
+            .lpn_type(ferret::LpnType::Regular)
+            .build()
+            .expect("ferret config is valid"),
+        Block::random(&mut rng),
+        rcot_send,
+    );
+    let rcot_recv = kos::Receiver::new(kos::ReceiverConfig::default(), base_ot_send);
+
+    let rcot_send = SharedRCOTSender::new(rcot_send);
+    let rcot_recv = SharedRCOTReceiver::new(rcot_recv);
+
+    #[cfg(not(tlsn_insecure))]
+    let mpc = VerifierMpc::new(DerandCOTReceiver::new(rcot_recv.clone()));
+    #[cfg(tlsn_insecure)]
+    let mpc = mpz_ideal_vm::IdealVm::new();
+
+    #[cfg(not(tlsn_insecure))]
+    let zk = VerifierZk::new(Default::default(), delta, rcot_send.clone());
+    #[cfg(tlsn_insecure)]
+    let zk = mpz_ideal_vm::IdealVm::new();
+
+    let vm = Arc::new(Mutex::new(Deap::new(tlsn_deap::Role::Follower, mpc, zk)));
+    let mpc_tls = MpcTlsFollower::new(
+        config,
+        ctx,
+        vm.clone(),
+        rcot_send,
+        (rcot_recv.clone(), rcot_recv.clone(), rcot_recv),
+    );
+
+    VerifierDeps { vm, mpc_tls }
+}
+
+pub(crate) fn translate_keys<Mpc, Zk>(keys: &mut SessionKeys, vm: &Deap<Mpc, Zk>) {
+    keys.client_write_key = vm
+        .translate(keys.client_write_key)
+        .expect("VM memory should be consistent");
+    keys.client_write_iv = vm
+        .translate(keys.client_write_iv)
+        .expect("VM memory should be consistent");
+    keys.server_write_key = vm
+        .translate(keys.server_write_key)
+        .expect("VM memory should be consistent");
+    keys.server_write_iv = vm
+        .translate(keys.server_write_iv)
+        .expect("VM memory should be consistent");
+    keys.server_write_mac_key = vm
+        .translate(keys.server_write_mac_key)
+        .expect("VM memory should be consistent");
+}
+
+impl<T> KeyStore for Verifier<T> {
+    fn delta(&self) -> &Delta {
+        self.delta()
+    }
+
+    fn get_keys(&self, data: Vector<U8>) -> Option<&[Key]> {
+        self.get_keys(data).ok()
+    }
+}
+
+impl<T> MacStore for Prover<T> {
+    fn get_macs(&self, data: Vector<U8>) -> Option<&[Mac]> {
+        self.get_macs(data).ok()
+    }
+}
+
+#[cfg(tlsn_insecure)]
+mod insecure {
+    use super::*;
+    use mpz_ideal_vm::IdealVm;
+
+    impl KeyStore for IdealVm {
+        fn delta(&self) -> &Delta {
+            unimplemented!("encodings not supported in insecure mode")
+        }
+
+        fn get_keys(&self, _data: Vector<U8>) -> Option<&[Key]> {
+            unimplemented!("encodings not supported in insecure mode")
+        }
+    }
+
+    impl MacStore for IdealVm {
+        fn get_macs(&self, _data: Vector<U8>) -> Option<&[Mac]> {
+            unimplemented!("encodings not supported in insecure mode")
+        }
+    }
+}

--- a/crates/tlsn/src/prover/state.rs
+++ b/crates/tlsn/src/prover/state.rs
@@ -9,8 +9,8 @@ use tlsn_deap::Deap;
 use tokio::sync::Mutex;
 
 use crate::{
+    mpz::{ProverMpc, ProverZk},
     mux::{MuxControl, MuxFuture},
-    prover::{Mpc, Zk},
 };
 
 /// Entry state
@@ -24,7 +24,7 @@ pub struct Setup {
     pub(crate) mux_fut: MuxFuture,
     pub(crate) mpc_tls: MpcTlsLeader,
     pub(crate) keys: SessionKeys,
-    pub(crate) vm: Arc<Mutex<Deap<Mpc, Zk>>>,
+    pub(crate) vm: Arc<Mutex<Deap<ProverMpc, ProverZk>>>,
 }
 
 opaque_debug::implement!(Setup);
@@ -34,7 +34,7 @@ pub struct Committed {
     pub(crate) mux_ctrl: MuxControl,
     pub(crate) mux_fut: MuxFuture,
     pub(crate) ctx: Context,
-    pub(crate) vm: Zk,
+    pub(crate) vm: ProverZk,
     pub(crate) keys: SessionKeys,
     pub(crate) tls_transcript: TlsTranscript,
     pub(crate) transcript: Transcript,

--- a/crates/tlsn/src/transcript_internal/commit/encoding.rs
+++ b/crates/tlsn/src/transcript_internal/commit/encoding.rs
@@ -177,24 +177,8 @@ pub(crate) trait KeyStore {
     fn get_keys(&self, data: Vector<U8>) -> Option<&[Key]>;
 }
 
-impl KeyStore for crate::verifier::Zk {
-    fn delta(&self) -> &Delta {
-        crate::verifier::Zk::delta(self)
-    }
-
-    fn get_keys(&self, data: Vector<U8>) -> Option<&[Key]> {
-        self.get_keys(data).ok()
-    }
-}
-
 pub(crate) trait MacStore {
     fn get_macs(&self, data: Vector<U8>) -> Option<&[Mac]>;
-}
-
-impl MacStore for crate::prover::Zk {
-    fn get_macs(&self, data: Vector<U8>) -> Option<&[Mac]> {
-        self.get_macs(data).ok()
-    }
 }
 
 #[derive(Debug)]

--- a/crates/tlsn/src/verifier/state.rs
+++ b/crates/tlsn/src/verifier/state.rs
@@ -12,7 +12,7 @@ use tlsn_core::{ProveRequest, transcript::TlsTranscript};
 use tlsn_deap::Deap;
 use tokio::sync::Mutex;
 
-use crate::verifier::{Mpc, Zk};
+use crate::mpz::{VerifierMpc, VerifierZk};
 
 /// TLS Verifier state.
 pub trait VerifierState: sealed::Sealed {}
@@ -38,7 +38,7 @@ pub struct Setup {
     pub(crate) mux_fut: MuxFuture,
     pub(crate) mpc_tls: MpcTlsFollower,
     pub(crate) keys: SessionKeys,
-    pub(crate) vm: Arc<Mutex<Deap<Mpc, Zk>>>,
+    pub(crate) vm: Arc<Mutex<Deap<VerifierMpc, VerifierZk>>>,
 }
 
 opaque_debug::implement!(Setup);
@@ -48,7 +48,7 @@ pub struct Committed {
     pub(crate) mux_ctrl: MuxControl,
     pub(crate) mux_fut: MuxFuture,
     pub(crate) ctx: Context,
-    pub(crate) vm: Zk,
+    pub(crate) vm: VerifierZk,
     pub(crate) keys: SessionKeys,
     pub(crate) tls_transcript: TlsTranscript,
 }
@@ -60,7 +60,7 @@ pub struct Verify {
     pub(crate) mux_ctrl: MuxControl,
     pub(crate) mux_fut: MuxFuture,
     pub(crate) ctx: Context,
-    pub(crate) vm: Zk,
+    pub(crate) vm: VerifierZk,
     pub(crate) keys: SessionKeys,
     pub(crate) tls_transcript: TlsTranscript,
     pub(crate) request: ProveRequest,


### PR DESCRIPTION
Closes #1029 

This PR adds an "insecure" mode which can be enabled by compiling `tlsn` with the `tlsn_insecure` flag. This will compile using the `IdealVm` from `mpz` which avoids performing a bunch of expensive cryptography.

A follow up PR can also replace COT protocols with ideal replacements.