### PR TITLE
fix(wasm): use patched sharded-slab with manual thread state release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6640,8 +6640,7 @@ dependencies = [
 [[package]]
 name = "sharded-slab"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+source = "git+https://github.com/tlsnotary/sharded-slab#5dd1d23d5b1f57e52b1858cb3c42ef4748062f3b"
 dependencies = [
  "lazy_static",
 ]
@@ -7665,6 +7664,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "sharded-slab",
  "time",
  "tlsn",
  "tlsn-core",
@@ -8415,9 +8415,8 @@ dependencies = [
 
 [[package]]
 name = "web-spawn"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81aa4e191851788bbf25b06490e2800a3ca4f4da98d2da1b8a612af98526bbb1"
+version = "0.3.0"
+source = "git+https://github.com/tlsnotary/tlsn-utils?rev=f674edd#f674eddff4b0c29fed5ea16d0d25816d6124dd5d"
 dependencies = [
  "crossbeam-channel",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ sct = { version = "0.7" }
 semver = { version = "1.0" }
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }
+sharded-slab = { version = "0.1" }
 sha2 = { version = "0.10" }
 signature = { version = "2.2" }
 thiserror = { version = "1.0" }
@@ -162,9 +163,14 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
-web-spawn = { version = "0.2" }
+web-spawn = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "f674edd" }
 web-time = { version = "0.2" }
 webpki-roots = { version = "1.0" }
 webpki-root-certs = { version = "1.0" }
 ws_stream_wasm = { version = "0.7.5" }
 zeroize = { version = "1.8" }
+
+[patch.crates-io]
+# Replace sharded-slab with a wasm-friendly fork that provides explicit
+# thread-id cleanup (wasm-bindgen does not run Rust TLS destructors).
+sharded-slab = { git = "https://github.com/tlsnotary/sharded-slab" }

--- a/crates/harness/executor/Cargo.toml
+++ b/crates/harness/executor/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2024"
 publish = false
 
 [features]
-# Disable tracing events as a workaround for issue 959. 
-default = ["tracing/release_max_level_off"]
+default = []
 # Used to debug the executor itself.
 debug = []
 

--- a/crates/harness/executor/src/wasm.rs
+++ b/crates/harness/executor/src/wasm.rs
@@ -12,6 +12,7 @@ use harness_core::{
 
 use crate::Executor;
 
+#[allow(unused_imports)]
 pub use tlsn_wasm::*;
 
 unsafe extern "C" {

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -38,6 +38,7 @@ pin-project-lite = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { version = "1.0" }
+sharded-slab = { workspace = true }
 time = { version = "=0.3.37", features = ["wasm-bindgen"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["time"] }


### PR DESCRIPTION
This PR patches a transitive dep `sharded-slab` in order to allow our wasm build to manually call destructors of objects in  thread-local storage.
Fixes: https://github.com/tlsnotary/tlsn/issues/959

Depends on https://github.com/tlsnotary/tlsn-utils/pull/73

Tested by running the wasm prover 100+ times (whereas before it would panic on the 8th run). 