### PR TITLE
chore(bench): added headed mode for debugging

### DIFF
--- a/crates/harness/runner/src/cli.rs
+++ b/crates/harness/runner/src/cli.rs
@@ -16,6 +16,10 @@ pub struct Cli {
     /// Subnet to assign harness network interfaces.
     #[arg(long, default_value = "10.250.0.0/24", env = "SUBNET")]
     pub subnet: Ipv4Net,
+    /// Run browser in headed mode (visible window) for debugging.
+    /// Works with both X11 and Wayland.
+    #[arg(long)]
+    pub headed: bool,
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
This PR adds a headed mode to the harness which is useful when Chrome Task Manager needs to be examined to diagnose memory leaks. 