### PR TITLE
fix(harness): fix browser latency emulation and enable TCP nodelay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8602,7 +8602,7 @@ dependencies = [
 [[package]]
 name = "websocket-relay"
 version = "0.1.0"
-source = "git+https://github.com/tlsnotary/tlsn-utils?rev=6f1a934#6f1a934bc4ce358c268b26abf4fd086267b91c70"
+source = "git+https://github.com/tlsnotary/tlsn-utils?rev=92197f9#92197f928b08cd3a1c799d513347c56881db1cb6"
 dependencies = [
  "anyhow",
  "form_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ mpz-ideal-vm = { git = "https://github.com/privacy-ethereum/mpz", tag = "v0.1.0-
 rangeset = { version = "0.4" }
 serio = { version = "0.2" }
 spansy = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "adfc5ba" }
-websocket-relay = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "6f1a934" }
+websocket-relay = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "92197f9" }
 
 aead = { version = "0.4" }
 aes = { version = "0.8" }

--- a/crates/harness/core/src/network.rs
+++ b/crates/harness/core/src/network.rs
@@ -9,6 +9,10 @@ pub const PORT_PROXY: u16 = 8000;
 pub const PORT_WASM_SERVER: u16 = 8080;
 pub const PORT_RPC: u16 = 8000;
 pub const PORT_BROWSER: u16 = 8001;
+/// Localhost port for proto proxy (browser connects here, DNAT to proto_0)
+pub const PORT_PROTO_PROXY_LOCAL: u16 = 8000;
+/// Localhost port for app proxy (browser connects here, DNAT to app_0)
+pub const PORT_APP_PROXY_LOCAL: u16 = 8002;
 pub const NS_0: &str = "tlsn-ns0";
 pub const NS_1: &str = "tlsn-ns1";
 pub const NS_APP: &str = "tlsn-nsapp";

--- a/crates/harness/executor/src/provider.rs
+++ b/crates/harness/executor/src/provider.rs
@@ -37,6 +37,7 @@ mod native {
         pub async fn provide_server_io(&self) -> Result<impl Io> {
             TcpStream::connect(self.config.app)
                 .await
+                .inspect(|io| io.set_nodelay(true).unwrap())
                 .map(|io| io.compat())
                 .map_err(anyhow::Error::from)
         }

--- a/crates/harness/runner/Cargo.toml
+++ b/crates/harness/runner/Cargo.toml
@@ -42,3 +42,7 @@ path = "src/bin/runner.rs"
 [[bin]]
 name = "tlsn-harness-wasm-server"
 path = "src/bin/wasm.rs"
+
+[[bin]]
+name = "ws-proxy"
+path = "src/bin/ws_proxy.rs"

--- a/crates/harness/runner/src/bin/ws_proxy.rs
+++ b/crates/harness/runner/src/bin/ws_proxy.rs
@@ -1,0 +1,22 @@
+use std::{env, net::IpAddr};
+
+use anyhow::{Context, Result};
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let port: u16 = env::var("PROXY_PORT")
+        .map(|port| port.parse().expect("port should be valid integer"))
+        .unwrap_or(8080);
+    let addr: IpAddr = env::var("PROXY_IP")
+        .map(|addr| addr.parse().expect("should be valid IP address"))
+        .unwrap_or(IpAddr::V4("127.0.0.1".parse().unwrap()));
+
+    let listener = TcpListener::bind((addr, port))
+        .await
+        .context("failed to bind to address")?;
+
+    websocket_relay::run(listener).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR fixes a bug in the harness due to which the delay was not applied in the Prover->Verifier direction in browser benches.

Before this PR, when RTT was expected to be 400ms :
```
Browser path (only verifier→websocket-relay has delay):                                                                                                   
websocket-relay(host) → bridge → veth_proto_1.1 → veth_proto_1.0 → verifier(ns_1)     [NO delay]                                                                           
verifier(ns_1) → veth_proto_1.0[+200ms] →  veth_proto_1.1 → bridge → websocket-relay(host)  [+200ms]                                                                        
RTT = ~200ms (asymmetric) 
```

The solution in this PR is to run websocket-relay inside a namespace:
```
websocket-relay(ns_0) → veth_proto_0.0[+200ms] → bridge → veth_proto_1.1 → veth_proto_1.0 → verifier(ns_1) [+200ms]                                                                                         
verifier(ns_1) → veth_proto_1.0[+200ms] → veth_proto_1.1 → bridge → veth_proto_0.0 → websocket-relay(ns_0) [+200ms]
RTT = ~400ms            
 ```

Also removes Nagel from the app server IO while we are at it.


I analyzed a network trace before and after this PR to double-check that the diagrams above are correct.