### PR TITLE
ci: enable @claude mentions for code reviews in PRs

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -1,0 +1,40 @@
+name: Claude Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-response:
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: "@claude"
+          claude_args: "--max-turns 10 --append-system-prompt 'When reviewing PRs, follow the guidelines in .github/prompts/review.md'"
+          track_progress: "true"
+          settings: |
+            {
+              "permissions": {
+                "allow": ["Bash(gh *)", "Bash(git *)"]
+              }
+            }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   claude-review:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
+    if: false && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,17 +19,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0 # Full history for git log
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
-            /review
-
-            Follow the guidelines in .github/prompts/review.md
+            Review PR #${{ github.event.pull_request.number }} following the guidelines in .github/prompts/review.md
           claude_args: "--max-turns 10"
-      - name: Show Claude execution log
-        run: cat /home/runner/work/_temp/claude-execution-output.json
+          track_progress: "true"
+          settings: |
+            {
+              "permissions": {
+                "allow": ["Bash(gh *)", "Bash(git *)"]
+              }
+            }
+      - name: Upload Claude execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-log
+          path: /home/runner/work/_temp/claude-execution-output.json
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Add `claude-assistant.yml` workflow that lets team members trigger Claude reviews by commenting `@claude` on any PR
- Only repository owners, members, and collaborators can trigger it
- Disable the existing automatic review workflow (kept for reference, gated with `if: false`)

## Usage
Comment on any PR with `@claude` followed by your request:
- `@claude review this PR`
- `@claude what does this function do?`
- `@claude suggest improvements for error handling here`

## Todo
- [ ] Verify only team members can trigger (outside contributors' mentions are ignored)