### PR TITLE
feat(harness): add granular benchmark phase metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,10 +7514,13 @@ dependencies = [
 name = "tlsn-harness-core"
 version = "0.1.0"
 dependencies = [
+ "bincode 1.3.3",
  "bon",
+ "csv",
  "enum-try-as-inner",
  "ipnet",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 
@@ -7577,6 +7580,7 @@ dependencies = [
  "futures",
  "indicatif",
  "ipnet",
+ "reqwest",
  "serde",
  "serde_json",
  "serio",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod connection;
 pub mod fixtures;
 pub mod hash;
 pub mod merkle;
+pub mod telemetry;
 pub mod transcript;
 pub mod webpki;
 pub use rangeset;

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -1,0 +1,104 @@
+//! Benchmark telemetry types shared across TLSNotary crates.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+/// A stable benchmark phase name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BenchPhase {
+    /// MPC-TLS preprocessing, including concurrent setup work.
+    PreprocessSetup,
+    /// Online key exchange setup and completion.
+    ///
+    /// This phase may occur more than once during a handshake when completion is
+    /// deferred until dependent VM work has finished.
+    HandshakeKeOnline,
+    /// PRF work for handshake/session key derivation.
+    HandshakePrfSessionKeys,
+    /// Record-layer setup after handshake keys are ready.
+    HandshakeRecordSetup,
+    /// PRF work for the server `Finished` verification data.
+    HandshakePrfServerFinished,
+    /// PRF work for the client `Finished` verification data.
+    HandshakePrfClientFinished,
+    /// Record-layer flush work that performs at least one encrypt/decrypt op.
+    RecordLayerFlush,
+    /// TLS authentication finalization after the socket closes.
+    FinalizeTlsAuth,
+    /// Transcript proving, including setup, VM execution, and finalization.
+    ProveTranscript,
+}
+
+impl BenchPhase {
+    /// All benchmark phases in stable serialization order.
+    pub const ALL: [Self; 9] = [
+        Self::PreprocessSetup,
+        Self::HandshakeKeOnline,
+        Self::HandshakePrfSessionKeys,
+        Self::HandshakeRecordSetup,
+        Self::HandshakePrfServerFinished,
+        Self::HandshakePrfClientFinished,
+        Self::RecordLayerFlush,
+        Self::FinalizeTlsAuth,
+        Self::ProveTranscript,
+    ];
+
+    /// Returns the stable string form for this phase.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PreprocessSetup => "preprocess_setup",
+            Self::HandshakeKeOnline => "handshake_ke_online",
+            Self::HandshakePrfSessionKeys => "handshake_prf_session_keys",
+            Self::HandshakeRecordSetup => "handshake_record_setup",
+            Self::HandshakePrfServerFinished => "handshake_prf_server_finished",
+            Self::HandshakePrfClientFinished => "handshake_prf_client_finished",
+            Self::RecordLayerFlush => "record_layer_flush",
+            Self::FinalizeTlsAuth => "finalize_tls_auth",
+            Self::ProveTranscript => "prove_transcript",
+        }
+    }
+}
+
+impl Serialize for BenchPhase {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for BenchPhase {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <&str>::deserialize(deserializer)?;
+        match value {
+            "preprocess_setup" => Ok(Self::PreprocessSetup),
+            "handshake_ke_online" => Ok(Self::HandshakeKeOnline),
+            "handshake_prf_session_keys" => Ok(Self::HandshakePrfSessionKeys),
+            "handshake_record_setup" => Ok(Self::HandshakeRecordSetup),
+            "handshake_prf_server_finished" => Ok(Self::HandshakePrfServerFinished),
+            "handshake_prf_client_finished" => Ok(Self::HandshakePrfClientFinished),
+            "record_layer_flush" => Ok(Self::RecordLayerFlush),
+            "finalize_tls_auth" => Ok(Self::FinalizeTlsAuth),
+            "prove_transcript" => Ok(Self::ProveTranscript),
+            _ => Err(D::Error::custom(format!("unknown benchmark phase: {value}"))),
+        }
+    }
+}
+
+/// A phase lifecycle event emitted by benchmark instrumentation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PhaseEvent {
+    /// The phase started.
+    Start,
+    /// The phase ended.
+    End,
+}
+
+/// Receives benchmark phase events.
+pub trait TelemetrySink: Send + Sync + 'static {
+    /// Records a benchmark phase lifecycle event.
+    fn phase_event(&self, phase: BenchPhase, event: PhaseEvent);
+}

--- a/crates/harness/core/Cargo.toml
+++ b/crates/harness/core/Cargo.toml
@@ -13,3 +13,8 @@ serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 enum-try-as-inner = { workspace = true }
 ipnet = { workspace = true, features = ["serde"] }
+
+[dev-dependencies]
+bincode = { workspace = true }
+csv = "1.3"
+serde_json = { workspace = true }

--- a/crates/harness/core/src/bench.rs
+++ b/crates/harness/core/src/bench.rs
@@ -185,7 +185,122 @@ pub enum BenchOutput {
     Verifier,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct PhaseMetrics {
+    // Named phase totals are intentionally partial and do not sum to the
+    // coarse runtime totals. Control-plane exchanges and other orchestration
+    // overhead remain visible only in the coarse metrics.
+    #[serde(default)]
+    pub phase_preprocess_setup_count: u64,
+    #[serde(default)]
+    pub phase_preprocess_setup_time_ms: u64,
+    #[serde(default)]
+    pub phase_preprocess_setup_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_preprocess_setup_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_preprocess_setup_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_preprocess_setup_io_wait_write_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_ke_online_count: u64,
+    #[serde(default)]
+    pub phase_handshake_ke_online_time_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_ke_online_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_ke_online_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_ke_online_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_ke_online_io_wait_write_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_session_keys_count: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_session_keys_time_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_session_keys_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_session_keys_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_session_keys_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_session_keys_io_wait_write_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_record_setup_count: u64,
+    #[serde(default)]
+    pub phase_handshake_record_setup_time_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_record_setup_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_record_setup_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_record_setup_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_record_setup_io_wait_write_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_server_finished_count: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_server_finished_time_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_server_finished_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_server_finished_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_server_finished_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_server_finished_io_wait_write_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_client_finished_count: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_client_finished_time_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_client_finished_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_client_finished_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_client_finished_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_handshake_prf_client_finished_io_wait_write_ms: u64,
+    #[serde(default)]
+    pub phase_record_layer_flush_count: u64,
+    #[serde(default)]
+    pub phase_record_layer_flush_time_ms: u64,
+    #[serde(default)]
+    pub phase_record_layer_flush_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_record_layer_flush_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_record_layer_flush_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_record_layer_flush_io_wait_write_ms: u64,
+    #[serde(default)]
+    pub phase_finalize_tls_auth_count: u64,
+    #[serde(default)]
+    pub phase_finalize_tls_auth_time_ms: u64,
+    #[serde(default)]
+    pub phase_finalize_tls_auth_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_finalize_tls_auth_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_finalize_tls_auth_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_finalize_tls_auth_io_wait_write_ms: u64,
+    #[serde(default)]
+    pub phase_prove_transcript_count: u64,
+    #[serde(default)]
+    pub phase_prove_transcript_time_ms: u64,
+    #[serde(default)]
+    pub phase_prove_transcript_uploaded_bytes: u64,
+    #[serde(default)]
+    pub phase_prove_transcript_downloaded_bytes: u64,
+    #[serde(default)]
+    pub phase_prove_transcript_io_wait_read_ms: u64,
+    #[serde(default)]
+    pub phase_prove_transcript_io_wait_write_ms: u64,
+}
+
+#[derive(Debug, Clone)]
 pub struct ProverMetrics {
     /// Time taken to preprocess the connection in milliseconds.
     pub time_preprocess: u64,
@@ -211,9 +326,295 @@ pub struct ProverMetrics {
     pub downloaded_total: u64,
     /// Peak heap memory usage in bytes.
     pub heap_max_bytes: Option<usize>,
+    pub phase_metrics: PhaseMetrics,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProverMetricsRecord {
+    time_preprocess: u64,
+    time_online: u64,
+    time_total: u64,
+    uploaded_preprocess: u64,
+    downloaded_preprocess: u64,
+    uploaded_online: u64,
+    downloaded_online: u64,
+    uploaded_total: u64,
+    downloaded_total: u64,
+    heap_max_bytes: Option<usize>,
+    #[serde(default)]
+    phase_preprocess_setup_count: u64,
+    #[serde(default)]
+    phase_preprocess_setup_time_ms: u64,
+    #[serde(default)]
+    phase_preprocess_setup_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_preprocess_setup_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_preprocess_setup_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_preprocess_setup_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_count: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_count: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_count: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_count: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_count: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_record_layer_flush_count: u64,
+    #[serde(default)]
+    phase_record_layer_flush_time_ms: u64,
+    #[serde(default)]
+    phase_record_layer_flush_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_record_layer_flush_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_record_layer_flush_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_record_layer_flush_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_count: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_time_ms: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_prove_transcript_count: u64,
+    #[serde(default)]
+    phase_prove_transcript_time_ms: u64,
+    #[serde(default)]
+    phase_prove_transcript_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_prove_transcript_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_prove_transcript_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_prove_transcript_io_wait_write_ms: u64,
+}
+
+impl From<ProverMetrics> for ProverMetricsRecord {
+    fn from(value: ProverMetrics) -> Self {
+        let phase = value.phase_metrics;
+        Self {
+            time_preprocess: value.time_preprocess,
+            time_online: value.time_online,
+            time_total: value.time_total,
+            uploaded_preprocess: value.uploaded_preprocess,
+            downloaded_preprocess: value.downloaded_preprocess,
+            uploaded_online: value.uploaded_online,
+            downloaded_online: value.downloaded_online,
+            uploaded_total: value.uploaded_total,
+            downloaded_total: value.downloaded_total,
+            heap_max_bytes: value.heap_max_bytes,
+            phase_preprocess_setup_count: phase.phase_preprocess_setup_count,
+            phase_preprocess_setup_time_ms: phase.phase_preprocess_setup_time_ms,
+            phase_preprocess_setup_uploaded_bytes: phase.phase_preprocess_setup_uploaded_bytes,
+            phase_preprocess_setup_downloaded_bytes: phase.phase_preprocess_setup_downloaded_bytes,
+            phase_preprocess_setup_io_wait_read_ms: phase.phase_preprocess_setup_io_wait_read_ms,
+            phase_preprocess_setup_io_wait_write_ms: phase.phase_preprocess_setup_io_wait_write_ms,
+            phase_handshake_ke_online_count: phase.phase_handshake_ke_online_count,
+            phase_handshake_ke_online_time_ms: phase.phase_handshake_ke_online_time_ms,
+            phase_handshake_ke_online_uploaded_bytes: phase.phase_handshake_ke_online_uploaded_bytes,
+            phase_handshake_ke_online_downloaded_bytes: phase.phase_handshake_ke_online_downloaded_bytes,
+            phase_handshake_ke_online_io_wait_read_ms: phase.phase_handshake_ke_online_io_wait_read_ms,
+            phase_handshake_ke_online_io_wait_write_ms: phase.phase_handshake_ke_online_io_wait_write_ms,
+            phase_handshake_prf_session_keys_count: phase.phase_handshake_prf_session_keys_count,
+            phase_handshake_prf_session_keys_time_ms: phase.phase_handshake_prf_session_keys_time_ms,
+            phase_handshake_prf_session_keys_uploaded_bytes: phase.phase_handshake_prf_session_keys_uploaded_bytes,
+            phase_handshake_prf_session_keys_downloaded_bytes: phase.phase_handshake_prf_session_keys_downloaded_bytes,
+            phase_handshake_prf_session_keys_io_wait_read_ms: phase.phase_handshake_prf_session_keys_io_wait_read_ms,
+            phase_handshake_prf_session_keys_io_wait_write_ms: phase.phase_handshake_prf_session_keys_io_wait_write_ms,
+            phase_handshake_record_setup_count: phase.phase_handshake_record_setup_count,
+            phase_handshake_record_setup_time_ms: phase.phase_handshake_record_setup_time_ms,
+            phase_handshake_record_setup_uploaded_bytes: phase.phase_handshake_record_setup_uploaded_bytes,
+            phase_handshake_record_setup_downloaded_bytes: phase.phase_handshake_record_setup_downloaded_bytes,
+            phase_handshake_record_setup_io_wait_read_ms: phase.phase_handshake_record_setup_io_wait_read_ms,
+            phase_handshake_record_setup_io_wait_write_ms: phase.phase_handshake_record_setup_io_wait_write_ms,
+            phase_handshake_prf_server_finished_count: phase.phase_handshake_prf_server_finished_count,
+            phase_handshake_prf_server_finished_time_ms: phase.phase_handshake_prf_server_finished_time_ms,
+            phase_handshake_prf_server_finished_uploaded_bytes: phase.phase_handshake_prf_server_finished_uploaded_bytes,
+            phase_handshake_prf_server_finished_downloaded_bytes: phase.phase_handshake_prf_server_finished_downloaded_bytes,
+            phase_handshake_prf_server_finished_io_wait_read_ms: phase.phase_handshake_prf_server_finished_io_wait_read_ms,
+            phase_handshake_prf_server_finished_io_wait_write_ms: phase.phase_handshake_prf_server_finished_io_wait_write_ms,
+            phase_handshake_prf_client_finished_count: phase.phase_handshake_prf_client_finished_count,
+            phase_handshake_prf_client_finished_time_ms: phase.phase_handshake_prf_client_finished_time_ms,
+            phase_handshake_prf_client_finished_uploaded_bytes: phase.phase_handshake_prf_client_finished_uploaded_bytes,
+            phase_handshake_prf_client_finished_downloaded_bytes: phase.phase_handshake_prf_client_finished_downloaded_bytes,
+            phase_handshake_prf_client_finished_io_wait_read_ms: phase.phase_handshake_prf_client_finished_io_wait_read_ms,
+            phase_handshake_prf_client_finished_io_wait_write_ms: phase.phase_handshake_prf_client_finished_io_wait_write_ms,
+            phase_record_layer_flush_count: phase.phase_record_layer_flush_count,
+            phase_record_layer_flush_time_ms: phase.phase_record_layer_flush_time_ms,
+            phase_record_layer_flush_uploaded_bytes: phase.phase_record_layer_flush_uploaded_bytes,
+            phase_record_layer_flush_downloaded_bytes: phase.phase_record_layer_flush_downloaded_bytes,
+            phase_record_layer_flush_io_wait_read_ms: phase.phase_record_layer_flush_io_wait_read_ms,
+            phase_record_layer_flush_io_wait_write_ms: phase.phase_record_layer_flush_io_wait_write_ms,
+            phase_finalize_tls_auth_count: phase.phase_finalize_tls_auth_count,
+            phase_finalize_tls_auth_time_ms: phase.phase_finalize_tls_auth_time_ms,
+            phase_finalize_tls_auth_uploaded_bytes: phase.phase_finalize_tls_auth_uploaded_bytes,
+            phase_finalize_tls_auth_downloaded_bytes: phase.phase_finalize_tls_auth_downloaded_bytes,
+            phase_finalize_tls_auth_io_wait_read_ms: phase.phase_finalize_tls_auth_io_wait_read_ms,
+            phase_finalize_tls_auth_io_wait_write_ms: phase.phase_finalize_tls_auth_io_wait_write_ms,
+            phase_prove_transcript_count: phase.phase_prove_transcript_count,
+            phase_prove_transcript_time_ms: phase.phase_prove_transcript_time_ms,
+            phase_prove_transcript_uploaded_bytes: phase.phase_prove_transcript_uploaded_bytes,
+            phase_prove_transcript_downloaded_bytes: phase.phase_prove_transcript_downloaded_bytes,
+            phase_prove_transcript_io_wait_read_ms: phase.phase_prove_transcript_io_wait_read_ms,
+            phase_prove_transcript_io_wait_write_ms: phase.phase_prove_transcript_io_wait_write_ms,
+        }
+    }
+}
+
+impl From<ProverMetricsRecord> for ProverMetrics {
+    fn from(value: ProverMetricsRecord) -> Self {
+        Self {
+            time_preprocess: value.time_preprocess,
+            time_online: value.time_online,
+            time_total: value.time_total,
+            uploaded_preprocess: value.uploaded_preprocess,
+            downloaded_preprocess: value.downloaded_preprocess,
+            uploaded_online: value.uploaded_online,
+            downloaded_online: value.downloaded_online,
+            uploaded_total: value.uploaded_total,
+            downloaded_total: value.downloaded_total,
+            heap_max_bytes: value.heap_max_bytes,
+            phase_metrics: PhaseMetrics {
+                phase_preprocess_setup_count: value.phase_preprocess_setup_count,
+                phase_preprocess_setup_time_ms: value.phase_preprocess_setup_time_ms,
+                phase_preprocess_setup_uploaded_bytes: value.phase_preprocess_setup_uploaded_bytes,
+                phase_preprocess_setup_downloaded_bytes: value.phase_preprocess_setup_downloaded_bytes,
+                phase_preprocess_setup_io_wait_read_ms: value.phase_preprocess_setup_io_wait_read_ms,
+                phase_preprocess_setup_io_wait_write_ms: value.phase_preprocess_setup_io_wait_write_ms,
+                phase_handshake_ke_online_count: value.phase_handshake_ke_online_count,
+                phase_handshake_ke_online_time_ms: value.phase_handshake_ke_online_time_ms,
+                phase_handshake_ke_online_uploaded_bytes: value.phase_handshake_ke_online_uploaded_bytes,
+                phase_handshake_ke_online_downloaded_bytes: value.phase_handshake_ke_online_downloaded_bytes,
+                phase_handshake_ke_online_io_wait_read_ms: value.phase_handshake_ke_online_io_wait_read_ms,
+                phase_handshake_ke_online_io_wait_write_ms: value.phase_handshake_ke_online_io_wait_write_ms,
+                phase_handshake_prf_session_keys_count: value.phase_handshake_prf_session_keys_count,
+                phase_handshake_prf_session_keys_time_ms: value.phase_handshake_prf_session_keys_time_ms,
+                phase_handshake_prf_session_keys_uploaded_bytes: value.phase_handshake_prf_session_keys_uploaded_bytes,
+                phase_handshake_prf_session_keys_downloaded_bytes: value.phase_handshake_prf_session_keys_downloaded_bytes,
+                phase_handshake_prf_session_keys_io_wait_read_ms: value.phase_handshake_prf_session_keys_io_wait_read_ms,
+                phase_handshake_prf_session_keys_io_wait_write_ms: value.phase_handshake_prf_session_keys_io_wait_write_ms,
+                phase_handshake_record_setup_count: value.phase_handshake_record_setup_count,
+                phase_handshake_record_setup_time_ms: value.phase_handshake_record_setup_time_ms,
+                phase_handshake_record_setup_uploaded_bytes: value.phase_handshake_record_setup_uploaded_bytes,
+                phase_handshake_record_setup_downloaded_bytes: value.phase_handshake_record_setup_downloaded_bytes,
+                phase_handshake_record_setup_io_wait_read_ms: value.phase_handshake_record_setup_io_wait_read_ms,
+                phase_handshake_record_setup_io_wait_write_ms: value.phase_handshake_record_setup_io_wait_write_ms,
+                phase_handshake_prf_server_finished_count: value.phase_handshake_prf_server_finished_count,
+                phase_handshake_prf_server_finished_time_ms: value.phase_handshake_prf_server_finished_time_ms,
+                phase_handshake_prf_server_finished_uploaded_bytes: value.phase_handshake_prf_server_finished_uploaded_bytes,
+                phase_handshake_prf_server_finished_downloaded_bytes: value.phase_handshake_prf_server_finished_downloaded_bytes,
+                phase_handshake_prf_server_finished_io_wait_read_ms: value.phase_handshake_prf_server_finished_io_wait_read_ms,
+                phase_handshake_prf_server_finished_io_wait_write_ms: value.phase_handshake_prf_server_finished_io_wait_write_ms,
+                phase_handshake_prf_client_finished_count: value.phase_handshake_prf_client_finished_count,
+                phase_handshake_prf_client_finished_time_ms: value.phase_handshake_prf_client_finished_time_ms,
+                phase_handshake_prf_client_finished_uploaded_bytes: value.phase_handshake_prf_client_finished_uploaded_bytes,
+                phase_handshake_prf_client_finished_downloaded_bytes: value.phase_handshake_prf_client_finished_downloaded_bytes,
+                phase_handshake_prf_client_finished_io_wait_read_ms: value.phase_handshake_prf_client_finished_io_wait_read_ms,
+                phase_handshake_prf_client_finished_io_wait_write_ms: value.phase_handshake_prf_client_finished_io_wait_write_ms,
+                phase_record_layer_flush_count: value.phase_record_layer_flush_count,
+                phase_record_layer_flush_time_ms: value.phase_record_layer_flush_time_ms,
+                phase_record_layer_flush_uploaded_bytes: value.phase_record_layer_flush_uploaded_bytes,
+                phase_record_layer_flush_downloaded_bytes: value.phase_record_layer_flush_downloaded_bytes,
+                phase_record_layer_flush_io_wait_read_ms: value.phase_record_layer_flush_io_wait_read_ms,
+                phase_record_layer_flush_io_wait_write_ms: value.phase_record_layer_flush_io_wait_write_ms,
+                phase_finalize_tls_auth_count: value.phase_finalize_tls_auth_count,
+                phase_finalize_tls_auth_time_ms: value.phase_finalize_tls_auth_time_ms,
+                phase_finalize_tls_auth_uploaded_bytes: value.phase_finalize_tls_auth_uploaded_bytes,
+                phase_finalize_tls_auth_downloaded_bytes: value.phase_finalize_tls_auth_downloaded_bytes,
+                phase_finalize_tls_auth_io_wait_read_ms: value.phase_finalize_tls_auth_io_wait_read_ms,
+                phase_finalize_tls_auth_io_wait_write_ms: value.phase_finalize_tls_auth_io_wait_write_ms,
+                phase_prove_transcript_count: value.phase_prove_transcript_count,
+                phase_prove_transcript_time_ms: value.phase_prove_transcript_time_ms,
+                phase_prove_transcript_uploaded_bytes: value.phase_prove_transcript_uploaded_bytes,
+                phase_prove_transcript_downloaded_bytes: value.phase_prove_transcript_downloaded_bytes,
+                phase_prove_transcript_io_wait_read_ms: value.phase_prove_transcript_io_wait_read_ms,
+                phase_prove_transcript_io_wait_write_ms: value.phase_prove_transcript_io_wait_write_ms,
+            },
+        }
+    }
+}
+
+impl Serialize for ProverMetrics {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        ProverMetricsRecord::from(self.clone()).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ProverMetrics {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        ProverMetricsRecord::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Measurement {
     pub group: Option<String>,
     pub name: Option<String>,
@@ -246,6 +647,7 @@ pub struct Measurement {
     pub downloaded_total: u64,
     /// Peak heap memory usage in bytes.
     pub heap_max_bytes: Option<usize>,
+    pub phase_metrics: PhaseMetrics,
 }
 
 impl Measurement {
@@ -268,6 +670,509 @@ impl Measurement {
             uploaded_total: metrics.uploaded_total,
             downloaded_total: metrics.downloaded_total,
             heap_max_bytes: metrics.heap_max_bytes,
+            phase_metrics: metrics.phase_metrics,
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MeasurementRecord {
+    group: Option<String>,
+    name: Option<String>,
+    latency: usize,
+    bandwidth: usize,
+    upload_size: usize,
+    download_size: usize,
+    defer_decryption: bool,
+    time_preprocess: u64,
+    time_online: u64,
+    time_total: u64,
+    uploaded_preprocess: u64,
+    downloaded_preprocess: u64,
+    uploaded_online: u64,
+    downloaded_online: u64,
+    uploaded_total: u64,
+    downloaded_total: u64,
+    heap_max_bytes: Option<usize>,
+    #[serde(default)]
+    phase_preprocess_setup_count: u64,
+    #[serde(default)]
+    phase_preprocess_setup_time_ms: u64,
+    #[serde(default)]
+    phase_preprocess_setup_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_preprocess_setup_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_preprocess_setup_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_preprocess_setup_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_count: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_ke_online_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_count: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_session_keys_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_count: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_record_setup_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_count: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_server_finished_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_count: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_time_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_handshake_prf_client_finished_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_record_layer_flush_count: u64,
+    #[serde(default)]
+    phase_record_layer_flush_time_ms: u64,
+    #[serde(default)]
+    phase_record_layer_flush_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_record_layer_flush_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_record_layer_flush_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_record_layer_flush_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_count: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_time_ms: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_finalize_tls_auth_io_wait_write_ms: u64,
+    #[serde(default)]
+    phase_prove_transcript_count: u64,
+    #[serde(default)]
+    phase_prove_transcript_time_ms: u64,
+    #[serde(default)]
+    phase_prove_transcript_uploaded_bytes: u64,
+    #[serde(default)]
+    phase_prove_transcript_downloaded_bytes: u64,
+    #[serde(default)]
+    phase_prove_transcript_io_wait_read_ms: u64,
+    #[serde(default)]
+    phase_prove_transcript_io_wait_write_ms: u64,
+}
+
+impl From<Measurement> for MeasurementRecord {
+    fn from(value: Measurement) -> Self {
+        let phase = value.phase_metrics;
+        Self {
+            group: value.group,
+            name: value.name,
+            latency: value.latency,
+            bandwidth: value.bandwidth,
+            upload_size: value.upload_size,
+            download_size: value.download_size,
+            defer_decryption: value.defer_decryption,
+            time_preprocess: value.time_preprocess,
+            time_online: value.time_online,
+            time_total: value.time_total,
+            uploaded_preprocess: value.uploaded_preprocess,
+            downloaded_preprocess: value.downloaded_preprocess,
+            uploaded_online: value.uploaded_online,
+            downloaded_online: value.downloaded_online,
+            uploaded_total: value.uploaded_total,
+            downloaded_total: value.downloaded_total,
+            heap_max_bytes: value.heap_max_bytes,
+            phase_preprocess_setup_count: phase.phase_preprocess_setup_count,
+            phase_preprocess_setup_time_ms: phase.phase_preprocess_setup_time_ms,
+            phase_preprocess_setup_uploaded_bytes: phase.phase_preprocess_setup_uploaded_bytes,
+            phase_preprocess_setup_downloaded_bytes: phase.phase_preprocess_setup_downloaded_bytes,
+            phase_preprocess_setup_io_wait_read_ms: phase.phase_preprocess_setup_io_wait_read_ms,
+            phase_preprocess_setup_io_wait_write_ms: phase.phase_preprocess_setup_io_wait_write_ms,
+            phase_handshake_ke_online_count: phase.phase_handshake_ke_online_count,
+            phase_handshake_ke_online_time_ms: phase.phase_handshake_ke_online_time_ms,
+            phase_handshake_ke_online_uploaded_bytes: phase.phase_handshake_ke_online_uploaded_bytes,
+            phase_handshake_ke_online_downloaded_bytes: phase.phase_handshake_ke_online_downloaded_bytes,
+            phase_handshake_ke_online_io_wait_read_ms: phase.phase_handshake_ke_online_io_wait_read_ms,
+            phase_handshake_ke_online_io_wait_write_ms: phase.phase_handshake_ke_online_io_wait_write_ms,
+            phase_handshake_prf_session_keys_count: phase.phase_handshake_prf_session_keys_count,
+            phase_handshake_prf_session_keys_time_ms: phase.phase_handshake_prf_session_keys_time_ms,
+            phase_handshake_prf_session_keys_uploaded_bytes: phase.phase_handshake_prf_session_keys_uploaded_bytes,
+            phase_handshake_prf_session_keys_downloaded_bytes: phase.phase_handshake_prf_session_keys_downloaded_bytes,
+            phase_handshake_prf_session_keys_io_wait_read_ms: phase.phase_handshake_prf_session_keys_io_wait_read_ms,
+            phase_handshake_prf_session_keys_io_wait_write_ms: phase.phase_handshake_prf_session_keys_io_wait_write_ms,
+            phase_handshake_record_setup_count: phase.phase_handshake_record_setup_count,
+            phase_handshake_record_setup_time_ms: phase.phase_handshake_record_setup_time_ms,
+            phase_handshake_record_setup_uploaded_bytes: phase.phase_handshake_record_setup_uploaded_bytes,
+            phase_handshake_record_setup_downloaded_bytes: phase.phase_handshake_record_setup_downloaded_bytes,
+            phase_handshake_record_setup_io_wait_read_ms: phase.phase_handshake_record_setup_io_wait_read_ms,
+            phase_handshake_record_setup_io_wait_write_ms: phase.phase_handshake_record_setup_io_wait_write_ms,
+            phase_handshake_prf_server_finished_count: phase.phase_handshake_prf_server_finished_count,
+            phase_handshake_prf_server_finished_time_ms: phase.phase_handshake_prf_server_finished_time_ms,
+            phase_handshake_prf_server_finished_uploaded_bytes: phase.phase_handshake_prf_server_finished_uploaded_bytes,
+            phase_handshake_prf_server_finished_downloaded_bytes: phase.phase_handshake_prf_server_finished_downloaded_bytes,
+            phase_handshake_prf_server_finished_io_wait_read_ms: phase.phase_handshake_prf_server_finished_io_wait_read_ms,
+            phase_handshake_prf_server_finished_io_wait_write_ms: phase.phase_handshake_prf_server_finished_io_wait_write_ms,
+            phase_handshake_prf_client_finished_count: phase.phase_handshake_prf_client_finished_count,
+            phase_handshake_prf_client_finished_time_ms: phase.phase_handshake_prf_client_finished_time_ms,
+            phase_handshake_prf_client_finished_uploaded_bytes: phase.phase_handshake_prf_client_finished_uploaded_bytes,
+            phase_handshake_prf_client_finished_downloaded_bytes: phase.phase_handshake_prf_client_finished_downloaded_bytes,
+            phase_handshake_prf_client_finished_io_wait_read_ms: phase.phase_handshake_prf_client_finished_io_wait_read_ms,
+            phase_handshake_prf_client_finished_io_wait_write_ms: phase.phase_handshake_prf_client_finished_io_wait_write_ms,
+            phase_record_layer_flush_count: phase.phase_record_layer_flush_count,
+            phase_record_layer_flush_time_ms: phase.phase_record_layer_flush_time_ms,
+            phase_record_layer_flush_uploaded_bytes: phase.phase_record_layer_flush_uploaded_bytes,
+            phase_record_layer_flush_downloaded_bytes: phase.phase_record_layer_flush_downloaded_bytes,
+            phase_record_layer_flush_io_wait_read_ms: phase.phase_record_layer_flush_io_wait_read_ms,
+            phase_record_layer_flush_io_wait_write_ms: phase.phase_record_layer_flush_io_wait_write_ms,
+            phase_finalize_tls_auth_count: phase.phase_finalize_tls_auth_count,
+            phase_finalize_tls_auth_time_ms: phase.phase_finalize_tls_auth_time_ms,
+            phase_finalize_tls_auth_uploaded_bytes: phase.phase_finalize_tls_auth_uploaded_bytes,
+            phase_finalize_tls_auth_downloaded_bytes: phase.phase_finalize_tls_auth_downloaded_bytes,
+            phase_finalize_tls_auth_io_wait_read_ms: phase.phase_finalize_tls_auth_io_wait_read_ms,
+            phase_finalize_tls_auth_io_wait_write_ms: phase.phase_finalize_tls_auth_io_wait_write_ms,
+            phase_prove_transcript_count: phase.phase_prove_transcript_count,
+            phase_prove_transcript_time_ms: phase.phase_prove_transcript_time_ms,
+            phase_prove_transcript_uploaded_bytes: phase.phase_prove_transcript_uploaded_bytes,
+            phase_prove_transcript_downloaded_bytes: phase.phase_prove_transcript_downloaded_bytes,
+            phase_prove_transcript_io_wait_read_ms: phase.phase_prove_transcript_io_wait_read_ms,
+            phase_prove_transcript_io_wait_write_ms: phase.phase_prove_transcript_io_wait_write_ms,
+        }
+    }
+}
+
+impl From<MeasurementRecord> for Measurement {
+    fn from(value: MeasurementRecord) -> Self {
+        Self {
+            group: value.group,
+            name: value.name,
+            latency: value.latency,
+            bandwidth: value.bandwidth,
+            upload_size: value.upload_size,
+            download_size: value.download_size,
+            defer_decryption: value.defer_decryption,
+            time_preprocess: value.time_preprocess,
+            time_online: value.time_online,
+            time_total: value.time_total,
+            uploaded_preprocess: value.uploaded_preprocess,
+            downloaded_preprocess: value.downloaded_preprocess,
+            uploaded_online: value.uploaded_online,
+            downloaded_online: value.downloaded_online,
+            uploaded_total: value.uploaded_total,
+            downloaded_total: value.downloaded_total,
+            heap_max_bytes: value.heap_max_bytes,
+            phase_metrics: PhaseMetrics {
+                phase_preprocess_setup_count: value.phase_preprocess_setup_count,
+                phase_preprocess_setup_time_ms: value.phase_preprocess_setup_time_ms,
+                phase_preprocess_setup_uploaded_bytes: value.phase_preprocess_setup_uploaded_bytes,
+                phase_preprocess_setup_downloaded_bytes: value.phase_preprocess_setup_downloaded_bytes,
+                phase_preprocess_setup_io_wait_read_ms: value.phase_preprocess_setup_io_wait_read_ms,
+                phase_preprocess_setup_io_wait_write_ms: value.phase_preprocess_setup_io_wait_write_ms,
+                phase_handshake_ke_online_count: value.phase_handshake_ke_online_count,
+                phase_handshake_ke_online_time_ms: value.phase_handshake_ke_online_time_ms,
+                phase_handshake_ke_online_uploaded_bytes: value.phase_handshake_ke_online_uploaded_bytes,
+                phase_handshake_ke_online_downloaded_bytes: value.phase_handshake_ke_online_downloaded_bytes,
+                phase_handshake_ke_online_io_wait_read_ms: value.phase_handshake_ke_online_io_wait_read_ms,
+                phase_handshake_ke_online_io_wait_write_ms: value.phase_handshake_ke_online_io_wait_write_ms,
+                phase_handshake_prf_session_keys_count: value.phase_handshake_prf_session_keys_count,
+                phase_handshake_prf_session_keys_time_ms: value.phase_handshake_prf_session_keys_time_ms,
+                phase_handshake_prf_session_keys_uploaded_bytes: value.phase_handshake_prf_session_keys_uploaded_bytes,
+                phase_handshake_prf_session_keys_downloaded_bytes: value.phase_handshake_prf_session_keys_downloaded_bytes,
+                phase_handshake_prf_session_keys_io_wait_read_ms: value.phase_handshake_prf_session_keys_io_wait_read_ms,
+                phase_handshake_prf_session_keys_io_wait_write_ms: value.phase_handshake_prf_session_keys_io_wait_write_ms,
+                phase_handshake_record_setup_count: value.phase_handshake_record_setup_count,
+                phase_handshake_record_setup_time_ms: value.phase_handshake_record_setup_time_ms,
+                phase_handshake_record_setup_uploaded_bytes: value.phase_handshake_record_setup_uploaded_bytes,
+                phase_handshake_record_setup_downloaded_bytes: value.phase_handshake_record_setup_downloaded_bytes,
+                phase_handshake_record_setup_io_wait_read_ms: value.phase_handshake_record_setup_io_wait_read_ms,
+                phase_handshake_record_setup_io_wait_write_ms: value.phase_handshake_record_setup_io_wait_write_ms,
+                phase_handshake_prf_server_finished_count: value.phase_handshake_prf_server_finished_count,
+                phase_handshake_prf_server_finished_time_ms: value.phase_handshake_prf_server_finished_time_ms,
+                phase_handshake_prf_server_finished_uploaded_bytes: value.phase_handshake_prf_server_finished_uploaded_bytes,
+                phase_handshake_prf_server_finished_downloaded_bytes: value.phase_handshake_prf_server_finished_downloaded_bytes,
+                phase_handshake_prf_server_finished_io_wait_read_ms: value.phase_handshake_prf_server_finished_io_wait_read_ms,
+                phase_handshake_prf_server_finished_io_wait_write_ms: value.phase_handshake_prf_server_finished_io_wait_write_ms,
+                phase_handshake_prf_client_finished_count: value.phase_handshake_prf_client_finished_count,
+                phase_handshake_prf_client_finished_time_ms: value.phase_handshake_prf_client_finished_time_ms,
+                phase_handshake_prf_client_finished_uploaded_bytes: value.phase_handshake_prf_client_finished_uploaded_bytes,
+                phase_handshake_prf_client_finished_downloaded_bytes: value.phase_handshake_prf_client_finished_downloaded_bytes,
+                phase_handshake_prf_client_finished_io_wait_read_ms: value.phase_handshake_prf_client_finished_io_wait_read_ms,
+                phase_handshake_prf_client_finished_io_wait_write_ms: value.phase_handshake_prf_client_finished_io_wait_write_ms,
+                phase_record_layer_flush_count: value.phase_record_layer_flush_count,
+                phase_record_layer_flush_time_ms: value.phase_record_layer_flush_time_ms,
+                phase_record_layer_flush_uploaded_bytes: value.phase_record_layer_flush_uploaded_bytes,
+                phase_record_layer_flush_downloaded_bytes: value.phase_record_layer_flush_downloaded_bytes,
+                phase_record_layer_flush_io_wait_read_ms: value.phase_record_layer_flush_io_wait_read_ms,
+                phase_record_layer_flush_io_wait_write_ms: value.phase_record_layer_flush_io_wait_write_ms,
+                phase_finalize_tls_auth_count: value.phase_finalize_tls_auth_count,
+                phase_finalize_tls_auth_time_ms: value.phase_finalize_tls_auth_time_ms,
+                phase_finalize_tls_auth_uploaded_bytes: value.phase_finalize_tls_auth_uploaded_bytes,
+                phase_finalize_tls_auth_downloaded_bytes: value.phase_finalize_tls_auth_downloaded_bytes,
+                phase_finalize_tls_auth_io_wait_read_ms: value.phase_finalize_tls_auth_io_wait_read_ms,
+                phase_finalize_tls_auth_io_wait_write_ms: value.phase_finalize_tls_auth_io_wait_write_ms,
+                phase_prove_transcript_count: value.phase_prove_transcript_count,
+                phase_prove_transcript_time_ms: value.phase_prove_transcript_time_ms,
+                phase_prove_transcript_uploaded_bytes: value.phase_prove_transcript_uploaded_bytes,
+                phase_prove_transcript_downloaded_bytes: value.phase_prove_transcript_downloaded_bytes,
+                phase_prove_transcript_io_wait_read_ms: value.phase_prove_transcript_io_wait_read_ms,
+                phase_prove_transcript_io_wait_write_ms: value.phase_prove_transcript_io_wait_write_ms,
+            },
+        }
+    }
+}
+
+impl Serialize for Measurement {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        MeasurementRecord::from(self.clone()).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Measurement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        MeasurementRecord::deserialize(deserializer).map(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use bincode;
+    use csv::{ReaderBuilder, WriterBuilder};
+    use serde_json::json;
+
+    use super::{Bench, BenchOutput, Measurement, PhaseMetrics, ProverMetrics};
+
+    #[test]
+    fn prover_metrics_round_trip_with_phase_metrics() {
+        let metrics = ProverMetrics {
+            time_preprocess: 1,
+            time_online: 2,
+            time_total: 3,
+            uploaded_preprocess: 4,
+            downloaded_preprocess: 5,
+            uploaded_online: 6,
+            downloaded_online: 7,
+            uploaded_total: 8,
+            downloaded_total: 9,
+            heap_max_bytes: Some(10),
+            phase_metrics: PhaseMetrics {
+                phase_record_layer_flush_count: 2,
+                phase_record_layer_flush_time_ms: 11,
+                phase_record_layer_flush_uploaded_bytes: 12,
+                phase_record_layer_flush_downloaded_bytes: 13,
+                phase_record_layer_flush_io_wait_read_ms: 14,
+                phase_record_layer_flush_io_wait_write_ms: 15,
+                ..PhaseMetrics::default()
+            },
+        };
+
+        let encoded = serde_json::to_string(&metrics).expect("metrics should serialize");
+        let decoded: ProverMetrics =
+            serde_json::from_str(&encoded).expect("metrics should deserialize");
+
+        assert_eq!(decoded.phase_metrics.phase_record_layer_flush_count, 2);
+        assert_eq!(decoded.phase_metrics.phase_record_layer_flush_time_ms, 11);
+        assert_eq!(decoded.phase_metrics.phase_record_layer_flush_uploaded_bytes, 12);
+        assert_eq!(decoded.phase_metrics.phase_record_layer_flush_downloaded_bytes, 13);
+        assert_eq!(decoded.phase_metrics.phase_record_layer_flush_io_wait_read_ms, 14);
+        assert_eq!(decoded.phase_metrics.phase_record_layer_flush_io_wait_write_ms, 15);
+    }
+
+    #[test]
+    fn bench_output_bincode_round_trip_with_phase_metrics() {
+        let output = BenchOutput::Prover {
+            metrics: ProverMetrics {
+                time_preprocess: 1,
+                time_online: 2,
+                time_total: 3,
+                uploaded_preprocess: 4,
+                downloaded_preprocess: 5,
+                uploaded_online: 6,
+                downloaded_online: 7,
+                uploaded_total: 8,
+                downloaded_total: 9,
+                heap_max_bytes: Some(10),
+                phase_metrics: PhaseMetrics {
+                    phase_record_layer_flush_count: 2,
+                    phase_record_layer_flush_time_ms: 11,
+                    phase_record_layer_flush_uploaded_bytes: 12,
+                    phase_record_layer_flush_downloaded_bytes: 13,
+                    phase_record_layer_flush_io_wait_read_ms: 14,
+                    phase_record_layer_flush_io_wait_write_ms: 15,
+                    ..PhaseMetrics::default()
+                },
+            },
+        };
+
+        let encoded = bincode::serialize(&output).expect("bench output should bincode serialize");
+        let decoded: BenchOutput =
+            bincode::deserialize(&encoded).expect("bench output should bincode deserialize");
+
+        let BenchOutput::Prover { metrics } = decoded else {
+            panic!("expected prover bench output");
+        };
+
+        assert_eq!(metrics.phase_metrics.phase_record_layer_flush_count, 2);
+        assert_eq!(metrics.phase_metrics.phase_record_layer_flush_time_ms, 11);
+        assert_eq!(metrics.phase_metrics.phase_record_layer_flush_uploaded_bytes, 12);
+        assert_eq!(metrics.phase_metrics.phase_record_layer_flush_downloaded_bytes, 13);
+        assert_eq!(metrics.phase_metrics.phase_record_layer_flush_io_wait_read_ms, 14);
+        assert_eq!(metrics.phase_metrics.phase_record_layer_flush_io_wait_write_ms, 15);
+    }
+
+    #[test]
+    fn measurement_deserializes_old_rows_without_phase_columns() {
+        let old_row = json!({
+            "group": "group-a",
+            "name": "bench-a",
+            "latency": 10,
+            "bandwidth": 1000,
+            "upload_size": 1024,
+            "download_size": 2048,
+            "defer_decryption": true,
+            "time_preprocess": 1,
+            "time_online": 2,
+            "time_total": 3,
+            "uploaded_preprocess": 4,
+            "downloaded_preprocess": 5,
+            "uploaded_online": 6,
+            "downloaded_online": 7,
+            "uploaded_total": 8,
+            "downloaded_total": 9,
+            "heap_max_bytes": null
+        });
+
+        let measurement: Measurement =
+            serde_json::from_value(old_row).expect("old measurement should deserialize");
+
+        assert_eq!(measurement.phase_metrics.phase_preprocess_setup_count, 0);
+        assert_eq!(measurement.phase_metrics.phase_record_layer_flush_count, 0);
+        assert_eq!(measurement.phase_metrics.phase_prove_transcript_count, 0);
+    }
+
+    #[test]
+    fn measurement_csv_round_trip_preserves_phase_columns() {
+        let measurement = Measurement::new(
+            Bench {
+                group: Some("group-a".into()),
+                name: Some("bench-a".into()),
+                protocol_latency: 10,
+                app_latency: 10,
+                bandwidth: 1000,
+                upload_size: 1024,
+                download_size: 2048,
+                defer_decryption: true,
+                memory_profile: false,
+                reveal_all: false,
+            },
+            ProverMetrics {
+                time_preprocess: 1,
+                time_online: 2,
+                time_total: 3,
+                uploaded_preprocess: 4,
+                downloaded_preprocess: 5,
+                uploaded_online: 6,
+                downloaded_online: 7,
+                uploaded_total: 8,
+                downloaded_total: 9,
+                heap_max_bytes: None,
+                phase_metrics: PhaseMetrics {
+                    phase_prove_transcript_count: 1,
+                    phase_prove_transcript_time_ms: 11,
+                    phase_prove_transcript_uploaded_bytes: 12,
+                    phase_prove_transcript_downloaded_bytes: 13,
+                    phase_prove_transcript_io_wait_read_ms: 14,
+                    phase_prove_transcript_io_wait_write_ms: 15,
+                    ..PhaseMetrics::default()
+                },
+            },
+        );
+
+        let mut writer = WriterBuilder::new().from_writer(Vec::new());
+        writer
+            .serialize(&measurement)
+            .expect("measurement should serialize to csv");
+        let csv = String::from_utf8(
+            writer
+                .into_inner()
+                .expect("writer should yield bytes"),
+        )
+        .expect("csv should be utf8");
+
+        let mut reader = ReaderBuilder::new().from_reader(Cursor::new(csv));
+        let decoded: Vec<Measurement> = reader
+            .deserialize()
+            .collect::<Result<_, _>>()
+            .expect("csv should deserialize");
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].phase_metrics.phase_prove_transcript_count, 1);
+        assert_eq!(decoded[0].phase_metrics.phase_prove_transcript_time_ms, 11);
+    }
+
+    #[test]
+    fn measurement_csv_deserializes_old_rows_without_phase_columns() {
+        let csv = "\
+group,name,latency,bandwidth,upload_size,download_size,defer_decryption,time_preprocess,time_online,time_total,uploaded_preprocess,downloaded_preprocess,uploaded_online,downloaded_online,uploaded_total,downloaded_total,heap_max_bytes\n\
+group-a,bench-a,10,1000,1024,2048,true,1,2,3,4,5,6,7,8,9,\n";
+
+        let mut reader = ReaderBuilder::new().from_reader(Cursor::new(csv));
+        let decoded: Vec<Measurement> = reader
+            .deserialize()
+            .collect::<Result<_, _>>()
+            .expect("old csv rows should deserialize");
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].phase_metrics.phase_preprocess_setup_count, 0);
+        assert_eq!(decoded[0].phase_metrics.phase_record_layer_flush_count, 0);
     }
 }

--- a/crates/harness/executor/Cargo.toml
+++ b/crates/harness/executor/Cargo.toml
@@ -50,3 +50,9 @@ getrandom_03 = { package = "getrandom", version = "0.3", features = [
 [[bin]]
 name = "tlsn-harness-executor-native"
 path = "src/bin/native.rs"
+
+[package.metadata.wasm-pack.profile.custom]
+# The harness builds the browser bundle with `wasm-pack build --profile wasm`.
+# Disable wasm-opt here so local/browser smoke builds do not depend on
+# downloading Binaryen at build time.
+wasm-opt = false

--- a/crates/harness/executor/src/bench.rs
+++ b/crates/harness/executor/src/bench.rs
@@ -1,5 +1,6 @@
 mod io;
 mod prover;
+mod telemetry;
 mod verifier;
 
 /// Number of bytes to pad the receive configuration with due to HTTP structure
@@ -8,4 +9,5 @@ const RECV_PADDING: usize = 256;
 
 pub(crate) use io::Meter;
 pub(crate) use prover::bench_prover;
+pub(crate) use telemetry::BenchmarkTelemetry;
 pub(crate) use verifier::bench_verifier;

--- a/crates/harness/executor/src/bench/io.rs
+++ b/crates/harness/executor/src/bench/io.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::Result,
+    io::{IoSlice, Result},
     pin::Pin,
     sync::{
         Arc,
@@ -10,11 +10,51 @@ use std::{
 
 use futures::{AsyncRead, AsyncWrite};
 use pin_project_lite::pin_project;
+use web_time::Instant;
+
+#[derive(Clone, Debug)]
+pub(crate) struct MeterStats {
+    sent: Arc<AtomicU64>,
+    recv: Arc<AtomicU64>,
+    read_wait_ns: Arc<AtomicU64>,
+    write_wait_ns: Arc<AtomicU64>,
+}
+
+impl MeterStats {
+    fn new() -> Self {
+        Self {
+            sent: Arc::new(AtomicU64::new(0)),
+            recv: Arc::new(AtomicU64::new(0)),
+            read_wait_ns: Arc::new(AtomicU64::new(0)),
+            write_wait_ns: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> MeterSnapshot {
+        MeterSnapshot {
+            sent: self.sent.load(Ordering::Relaxed),
+            recv: self.recv.load(Ordering::Relaxed),
+            read_wait_ns: self.read_wait_ns.load(Ordering::Relaxed),
+            write_wait_ns: self.write_wait_ns.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct MeterSnapshot {
+    pub(crate) sent: u64,
+    pub(crate) recv: u64,
+    pub(crate) read_wait_ns: u64,
+    pub(crate) write_wait_ns: u64,
+}
 
 pin_project! {
     pub(crate) struct Meter<Io> {
-        sent: Arc<AtomicU64>,
-        recv: Arc<AtomicU64>,
+        stats: MeterStats,
+        pending_read: Option<Instant>,
+        pending_write: Option<Instant>,
+        pending_write_vectored: Option<Instant>,
+        pending_flush: Option<Instant>,
         #[pin] io: Io,
     }
 }
@@ -22,19 +62,34 @@ pin_project! {
 impl<Io> Meter<Io> {
     pub(crate) fn new(io: Io) -> Self {
         Self {
-            sent: Arc::new(AtomicU64::new(0)),
-            recv: Arc::new(AtomicU64::new(0)),
+            stats: MeterStats::new(),
+            pending_read: None,
+            pending_write: None,
+            pending_write_vectored: None,
+            pending_flush: None,
             io,
         }
     }
 
-    pub(crate) fn sent(&self) -> Arc<AtomicU64> {
-        self.sent.clone()
+    pub(crate) fn stats(&self) -> MeterStats {
+        self.stats.clone()
     }
+}
 
-    pub(crate) fn recv(&self) -> Arc<AtomicU64> {
-        self.recv.clone()
+fn wait_started_at(slot: &mut Option<Instant>) {
+    if slot.is_none() {
+        *slot = Some(Instant::now());
     }
+}
+
+fn finish_wait(slot: &mut Option<Instant>, counter: &AtomicU64) {
+    if let Some(started_at) = slot.take() {
+        counter.fetch_add(duration_to_ns(started_at.elapsed()), Ordering::Relaxed);
+    }
+}
+
+fn duration_to_ns(duration: std::time::Duration) -> u64 {
+    duration.as_nanos().min(u64::MAX as u128) as u64
 }
 
 impl<Io> AsyncWrite for Meter<Io>
@@ -42,16 +97,57 @@ where
     Io: AsyncWrite,
 {
     fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
-        let this = self.project();
-        this.io.poll_write(cx, buf).map(|res| {
-            res.inspect(|n| {
-                this.sent.fetch_add(*n as u64, Ordering::Relaxed);
-            })
-        })
+        let mut this = self.project();
+        match this.io.as_mut().poll_write(cx, buf) {
+            Poll::Pending => {
+                wait_started_at(this.pending_write);
+                Poll::Pending
+            }
+            Poll::Ready(result) => {
+                finish_wait(this.pending_write, &this.stats.write_wait_ns);
+
+                Poll::Ready(result.map(|n| {
+                    this.stats.sent.fetch_add(n as u64, Ordering::Relaxed);
+                    n
+                }))
+            }
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize>> {
+        let mut this = self.project();
+        match this.io.as_mut().poll_write_vectored(cx, bufs) {
+            Poll::Pending => {
+                wait_started_at(this.pending_write_vectored);
+                Poll::Pending
+            }
+            Poll::Ready(result) => {
+                finish_wait(this.pending_write_vectored, &this.stats.write_wait_ns);
+
+                Poll::Ready(result.map(|n| {
+                    this.stats.sent.fetch_add(n as u64, Ordering::Relaxed);
+                    n
+                }))
+            }
+        }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        self.project().io.poll_flush(cx)
+        let mut this = self.project();
+        match this.io.as_mut().poll_flush(cx) {
+            Poll::Pending => {
+                wait_started_at(this.pending_flush);
+                Poll::Pending
+            }
+            Poll::Ready(result) => {
+                finish_wait(this.pending_flush, &this.stats.write_wait_ns);
+                Poll::Ready(result)
+            }
+        }
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
@@ -68,11 +164,178 @@ where
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<Result<usize>> {
-        let this = self.project();
-        this.io.poll_read(cx, buf).map(|res| {
-            res.inspect(|n| {
-                this.recv.fetch_add(*n as u64, Ordering::Relaxed);
-            })
-        })
+        let mut this = self.project();
+        match this.io.as_mut().poll_read(cx, buf) {
+            Poll::Pending => {
+                wait_started_at(this.pending_read);
+                Poll::Pending
+            }
+            Poll::Ready(result) => {
+                finish_wait(this.pending_read, &this.stats.read_wait_ns);
+
+                Poll::Ready(result.map(|n| {
+                    this.stats.recv.fetch_add(n as u64, Ordering::Relaxed);
+                    n
+                }))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, io, thread, time::Duration};
+
+    use futures::task::noop_waker;
+
+    use super::*;
+
+    fn ready<T>(poll: Poll<io::Result<T>>) -> T {
+        match poll {
+            Poll::Ready(Ok(value)) => value,
+            Poll::Ready(Err(err)) => panic!("unexpected io error: {err}"),
+            Poll::Pending => panic!("operation should be ready"),
+        }
+    }
+
+    #[derive(Default)]
+    struct ScriptedIo {
+        reads: VecDeque<ReadStep>,
+        writes: VecDeque<Step<usize>>,
+        vectored_writes: VecDeque<Step<usize>>,
+        flushes: VecDeque<Step<()>>,
+    }
+
+    enum ReadStep {
+        Pending,
+        Ready(Vec<u8>),
+    }
+
+    enum Step<T> {
+        Pending,
+        Ready(T),
+    }
+
+    impl AsyncWrite for ScriptedIo {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            match self.writes.pop_front().expect("write step should exist") {
+                Step::Pending => Poll::Pending,
+                Step::Ready(n) => Poll::Ready(Ok(n)),
+            }
+        }
+
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _bufs: &[IoSlice<'_>],
+        ) -> Poll<io::Result<usize>> {
+            match self
+                .vectored_writes
+                .pop_front()
+                .expect("vectored write step should exist")
+            {
+                Step::Pending => Poll::Pending,
+                Step::Ready(n) => Poll::Ready(Ok(n)),
+            }
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            match self.flushes.pop_front().expect("flush step should exist") {
+                Step::Pending => Poll::Pending,
+                Step::Ready(()) => Poll::Ready(Ok(())),
+            }
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncRead for ScriptedIo {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            match self.reads.pop_front().expect("read step should exist") {
+                ReadStep::Pending => Poll::Pending,
+                ReadStep::Ready(bytes) => {
+                    buf[..bytes.len()].copy_from_slice(&bytes);
+                    Poll::Ready(Ok(bytes.len()))
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn meter_preserves_byte_counters() {
+        let io = ScriptedIo {
+            reads: VecDeque::from([ReadStep::Ready(vec![1, 2, 3, 4])]),
+            writes: VecDeque::from([Step::Ready(3)]),
+            vectored_writes: VecDeque::from([Step::Ready(5)]),
+            flushes: VecDeque::from([Step::Ready(())]),
+        };
+        let mut meter = Meter::new(io);
+        let stats = meter.stats();
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let _ = ready(Pin::new(&mut meter).poll_write(&mut cx, b"abcdef"));
+
+        let bufs = [IoSlice::new(b"ab"), IoSlice::new(b"cdefg")];
+        let _ = ready(Pin::new(&mut meter).poll_write_vectored(&mut cx, &bufs));
+
+        let mut buf = [0u8; 8];
+        let _ = ready(Pin::new(&mut meter).poll_read(&mut cx, &mut buf));
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.sent, 8);
+        assert_eq!(snapshot.recv, 4);
+    }
+
+    #[test]
+    fn meter_accumulates_pending_ready_wait_time() {
+        let io = ScriptedIo {
+            reads: VecDeque::from([ReadStep::Pending, ReadStep::Ready(vec![1])]),
+            writes: VecDeque::from([Step::Pending, Step::Ready(1)]),
+            vectored_writes: VecDeque::from([Step::Pending, Step::Ready(2)]),
+            flushes: VecDeque::from([Step::Pending, Step::Ready(())]),
+        };
+        let mut meter = Meter::new(io);
+        let stats = meter.stats();
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(Pin::new(&mut meter).poll_write(&mut cx, b"x").is_pending());
+        thread::sleep(Duration::from_millis(2));
+        let _ = ready(Pin::new(&mut meter).poll_write(&mut cx, b"x"));
+
+        let bufs = [IoSlice::new(b"x"), IoSlice::new(b"y")];
+        assert!(Pin::new(&mut meter)
+            .poll_write_vectored(&mut cx, &bufs)
+            .is_pending());
+        thread::sleep(Duration::from_millis(2));
+        let _ = ready(Pin::new(&mut meter).poll_write_vectored(&mut cx, &bufs));
+
+        assert!(Pin::new(&mut meter).poll_flush(&mut cx).is_pending());
+        thread::sleep(Duration::from_millis(2));
+        ready(Pin::new(&mut meter).poll_flush(&mut cx));
+
+        let mut buf = [0u8; 1];
+        assert!(Pin::new(&mut meter)
+            .poll_read(&mut cx, &mut buf)
+            .is_pending());
+        thread::sleep(Duration::from_millis(2));
+        let _ = ready(Pin::new(&mut meter).poll_read(&mut cx, &mut buf));
+
+        let snapshot = stats.snapshot();
+        assert!(snapshot.write_wait_ns > 0);
+        assert!(snapshot.read_wait_ns > 0);
+        assert_eq!(snapshot.sent, 3);
+        assert_eq!(snapshot.recv, 1);
     }
 }

--- a/crates/harness/executor/src/bench/prover.rs
+++ b/crates/harness/executor/src/bench/prover.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use anyhow::Result;
 use futures::{AsyncReadExt, AsyncWriteExt, TryFutureExt};
@@ -19,22 +19,22 @@ use tlsn_server_fixture_certs::{CA_CERT_DER, SERVER_DOMAIN};
 
 use crate::{
     IoProvider,
-    bench::{Meter, RECV_PADDING},
+    bench::{BenchmarkTelemetry, Meter, RECV_PADDING},
     spawn,
 };
 
 pub async fn bench_prover(provider: &IoProvider, config: &Bench) -> Result<ProverMetrics> {
     let verifier_io = Meter::new(provider.provide_proto_io().await?);
-
-    let sent = verifier_io.sent();
-    let recv = verifier_io.recv();
+    let meter = verifier_io.stats();
+    let telemetry = Arc::new(BenchmarkTelemetry::new(meter.clone()));
 
     let mut session = Session::new(verifier_io);
 
-    let prover = session.new_prover(ProverConfig::builder().build()?)?;
+    let prover = session
+        .new_prover(ProverConfig::builder().build()?)?
+        .with_telemetry(telemetry.clone());
     let (session, handle) = session.split();
-
-    _ = spawn(session);
+    let session_task = spawn(session);
 
     let time_start = web_time::Instant::now();
 
@@ -60,8 +60,9 @@ pub async fn bench_prover(provider: &IoProvider, config: &Bench) -> Result<Prove
 
     let time_preprocess = time_start.elapsed().as_millis();
     let time_start_online = web_time::Instant::now();
-    let uploaded_preprocess = sent.load(Ordering::Relaxed);
-    let downloaded_preprocess = recv.load(Ordering::Relaxed);
+    let preprocess_snapshot = meter.snapshot();
+    let uploaded_preprocess = preprocess_snapshot.sent;
+    let downloaded_preprocess = preprocess_snapshot.recv;
 
     let (mut conn, prover_fut) = prover.connect(
         TlsClientConfig::builder()
@@ -94,8 +95,9 @@ pub async fn bench_prover(provider: &IoProvider, config: &Bench) -> Result<Prove
     )?;
 
     let time_online = time_start_online.elapsed().as_millis();
-    let uploaded_online = sent.load(Ordering::Relaxed) - uploaded_preprocess;
-    let downloaded_online = recv.load(Ordering::Relaxed) - downloaded_preprocess;
+    let online_snapshot = meter.snapshot();
+    let uploaded_online = online_snapshot.sent - uploaded_preprocess;
+    let downloaded_online = online_snapshot.recv - downloaded_preprocess;
 
     let (sent_len, recv_len) = prover.transcript().len();
 
@@ -125,7 +127,9 @@ pub async fn bench_prover(provider: &IoProvider, config: &Bench) -> Result<Prove
     prover.close().await?;
     handle.close();
 
+    let _ = session_task.await??;
     let time_total = time_start.elapsed().as_millis();
+    let total_snapshot = meter.snapshot();
 
     Ok(ProverMetrics {
         time_preprocess: time_preprocess as u64,
@@ -135,8 +139,9 @@ pub async fn bench_prover(provider: &IoProvider, config: &Bench) -> Result<Prove
         downloaded_preprocess,
         uploaded_online,
         downloaded_online,
-        uploaded_total: sent.load(Ordering::Relaxed),
-        downloaded_total: recv.load(Ordering::Relaxed),
+        uploaded_total: total_snapshot.sent,
+        downloaded_total: total_snapshot.recv,
         heap_max_bytes: None,
+        phase_metrics: telemetry.phase_metrics(),
     })
 }

--- a/crates/harness/executor/src/bench/telemetry.rs
+++ b/crates/harness/executor/src/bench/telemetry.rs
@@ -1,0 +1,312 @@
+use std::{
+    collections::HashMap,
+    sync::{Mutex, PoisonError},
+    time::Duration,
+};
+
+use harness_core::bench::PhaseMetrics;
+use tlsn::telemetry::{BenchPhase, PhaseEvent, TelemetrySink};
+use web_time::Instant;
+
+use crate::bench::io::{MeterSnapshot, MeterStats};
+
+#[derive(Clone)]
+struct PhaseSnapshot {
+    started_at: Instant,
+    meter: MeterSnapshot,
+}
+
+#[derive(Clone, Copy, Default)]
+struct PhaseAggregate {
+    count: u64,
+    time_ns: u64,
+    uploaded_bytes: u64,
+    downloaded_bytes: u64,
+    io_wait_read_ns: u64,
+    io_wait_write_ns: u64,
+}
+
+#[derive(Default)]
+struct State {
+    active: HashMap<BenchPhase, Vec<PhaseSnapshot>>,
+    aggregates: HashMap<BenchPhase, PhaseAggregate>,
+}
+
+pub(crate) struct BenchmarkTelemetry {
+    meter: MeterStats,
+    state: Mutex<State>,
+}
+
+impl BenchmarkTelemetry {
+    pub(crate) fn new(meter: MeterStats) -> Self {
+        Self {
+            meter,
+            state: Mutex::new(State::default()),
+        }
+    }
+
+    pub(crate) fn phase_metrics(&self) -> PhaseMetrics {
+        let state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+        let mut metrics = PhaseMetrics::default();
+
+        for phase in BenchPhase::ALL {
+            let aggregate = state.aggregates.get(&phase).copied().unwrap_or_default();
+            apply_phase_metrics(&mut metrics, phase, aggregate);
+        }
+
+        metrics
+    }
+}
+
+impl TelemetrySink for BenchmarkTelemetry {
+    fn phase_event(&self, phase: BenchPhase, event: PhaseEvent) {
+        let meter = self.meter.snapshot();
+        let now = Instant::now();
+        let mut state = self.state.lock().unwrap_or_else(PoisonError::into_inner);
+
+        match event {
+            PhaseEvent::Start => {
+                state
+                    .active
+                    .entry(phase)
+                    .or_default()
+                    .push(PhaseSnapshot {
+                        started_at: now,
+                        meter,
+                    });
+            }
+            PhaseEvent::End => {
+                let Some(snapshot) = state.active.get_mut(&phase).and_then(Vec::pop) else {
+                    return;
+                };
+
+                let aggregate = state.aggregates.entry(phase).or_default();
+                aggregate.count += 1;
+                aggregate.time_ns += duration_to_ns(now.duration_since(snapshot.started_at));
+                aggregate.uploaded_bytes += meter.sent.saturating_sub(snapshot.meter.sent);
+                aggregate.downloaded_bytes += meter.recv.saturating_sub(snapshot.meter.recv);
+                aggregate.io_wait_read_ns += meter
+                    .read_wait_ns
+                    .saturating_sub(snapshot.meter.read_wait_ns);
+                aggregate.io_wait_write_ns += meter
+                    .write_wait_ns
+                    .saturating_sub(snapshot.meter.write_wait_ns);
+            }
+        }
+    }
+}
+
+fn duration_to_ns(duration: Duration) -> u64 {
+    duration.as_nanos().min(u64::MAX as u128) as u64
+}
+
+fn ns_to_ms(duration_ns: u64) -> u64 {
+    duration_ns / 1_000_000
+}
+
+fn apply_phase_metrics(metrics: &mut PhaseMetrics, phase: BenchPhase, aggregate: PhaseAggregate) {
+    match phase {
+        BenchPhase::PreprocessSetup => {
+            metrics.phase_preprocess_setup_count = aggregate.count;
+            metrics.phase_preprocess_setup_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_preprocess_setup_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_preprocess_setup_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_preprocess_setup_io_wait_read_ms = ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_preprocess_setup_io_wait_write_ms = ns_to_ms(aggregate.io_wait_write_ns);
+        }
+        BenchPhase::HandshakeKeOnline => {
+            metrics.phase_handshake_ke_online_count = aggregate.count;
+            metrics.phase_handshake_ke_online_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_handshake_ke_online_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_handshake_ke_online_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_handshake_ke_online_io_wait_read_ms = ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_handshake_ke_online_io_wait_write_ms =
+                ns_to_ms(aggregate.io_wait_write_ns);
+        }
+        BenchPhase::HandshakePrfSessionKeys => {
+            metrics.phase_handshake_prf_session_keys_count = aggregate.count;
+            metrics.phase_handshake_prf_session_keys_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_handshake_prf_session_keys_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_handshake_prf_session_keys_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_handshake_prf_session_keys_io_wait_read_ms =
+                ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_handshake_prf_session_keys_io_wait_write_ms =
+                ns_to_ms(aggregate.io_wait_write_ns);
+        }
+        BenchPhase::HandshakeRecordSetup => {
+            metrics.phase_handshake_record_setup_count = aggregate.count;
+            metrics.phase_handshake_record_setup_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_handshake_record_setup_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_handshake_record_setup_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_handshake_record_setup_io_wait_read_ms =
+                ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_handshake_record_setup_io_wait_write_ms =
+                ns_to_ms(aggregate.io_wait_write_ns);
+        }
+        BenchPhase::HandshakePrfServerFinished => {
+            metrics.phase_handshake_prf_server_finished_count = aggregate.count;
+            metrics.phase_handshake_prf_server_finished_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_handshake_prf_server_finished_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_handshake_prf_server_finished_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_handshake_prf_server_finished_io_wait_read_ms =
+                ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_handshake_prf_server_finished_io_wait_write_ms =
+                ns_to_ms(aggregate.io_wait_write_ns);
+        }
+        BenchPhase::HandshakePrfClientFinished => {
+            metrics.phase_handshake_prf_client_finished_count = aggregate.count;
+            metrics.phase_handshake_prf_client_finished_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_handshake_prf_client_finished_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_handshake_prf_client_finished_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_handshake_prf_client_finished_io_wait_read_ms =
+                ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_handshake_prf_client_finished_io_wait_write_ms =
+                ns_to_ms(aggregate.io_wait_write_ns);
+        }
+        BenchPhase::RecordLayerFlush => {
+            metrics.phase_record_layer_flush_count = aggregate.count;
+            metrics.phase_record_layer_flush_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_record_layer_flush_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_record_layer_flush_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_record_layer_flush_io_wait_read_ms = ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_record_layer_flush_io_wait_write_ms =
+                ns_to_ms(aggregate.io_wait_write_ns);
+        }
+        BenchPhase::FinalizeTlsAuth => {
+            metrics.phase_finalize_tls_auth_count = aggregate.count;
+            metrics.phase_finalize_tls_auth_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_finalize_tls_auth_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_finalize_tls_auth_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_finalize_tls_auth_io_wait_read_ms = ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_finalize_tls_auth_io_wait_write_ms =
+                ns_to_ms(aggregate.io_wait_write_ns);
+        }
+        BenchPhase::ProveTranscript => {
+            metrics.phase_prove_transcript_count = aggregate.count;
+            metrics.phase_prove_transcript_time_ms = ns_to_ms(aggregate.time_ns);
+            metrics.phase_prove_transcript_uploaded_bytes = aggregate.uploaded_bytes;
+            metrics.phase_prove_transcript_downloaded_bytes = aggregate.downloaded_bytes;
+            metrics.phase_prove_transcript_io_wait_read_ms = ns_to_ms(aggregate.io_wait_read_ns);
+            metrics.phase_prove_transcript_io_wait_write_ms =
+                ns_to_ms(aggregate.io_wait_write_ns);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io, pin::Pin, sync::Arc, task::Poll, thread, time::Duration};
+
+    use futures::{AsyncRead, AsyncWrite};
+
+    use super::*;
+    use crate::bench::Meter;
+
+    #[derive(Default)]
+    struct NoopIo;
+
+    impl AsyncWrite for NoopIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncRead for NoopIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+    }
+
+    struct TestGuard {
+        telemetry: Arc<BenchmarkTelemetry>,
+        phase: BenchPhase,
+    }
+
+    impl TestGuard {
+        fn new(telemetry: Arc<BenchmarkTelemetry>, phase: BenchPhase) -> Self {
+            telemetry.phase_event(phase, PhaseEvent::Start);
+            Self { telemetry, phase }
+        }
+    }
+
+    impl Drop for TestGuard {
+        fn drop(&mut self) {
+            self.telemetry.phase_event(self.phase, PhaseEvent::End);
+        }
+    }
+
+    #[test]
+    fn benchmark_telemetry_accumulates_repeated_entries() {
+        let telemetry = Arc::new(BenchmarkTelemetry::new(Meter::new(NoopIo).stats()));
+
+        {
+            let _guard = TestGuard::new(telemetry.clone(), BenchPhase::RecordLayerFlush);
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        {
+            let _guard = TestGuard::new(telemetry.clone(), BenchPhase::RecordLayerFlush);
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        let metrics = telemetry.phase_metrics();
+        assert_eq!(metrics.phase_record_layer_flush_count, 2);
+        assert!(metrics.phase_record_layer_flush_time_ms > 0);
+    }
+
+    #[test]
+    fn benchmark_telemetry_keeps_phases_isolated() {
+        let telemetry = Arc::new(BenchmarkTelemetry::new(Meter::new(NoopIo).stats()));
+
+        {
+            let _guard = TestGuard::new(telemetry.clone(), BenchPhase::PreprocessSetup);
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        {
+            let _guard = TestGuard::new(telemetry.clone(), BenchPhase::ProveTranscript);
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        let metrics = telemetry.phase_metrics();
+        assert_eq!(metrics.phase_preprocess_setup_count, 1);
+        assert_eq!(metrics.phase_prove_transcript_count, 1);
+        assert_eq!(metrics.phase_record_layer_flush_count, 0);
+    }
+
+    #[test]
+    fn benchmark_telemetry_records_end_on_error_drop() {
+        fn fail_with_guard(telemetry: Arc<BenchmarkTelemetry>) -> Result<(), &'static str> {
+            let _guard = TestGuard::new(telemetry, BenchPhase::FinalizeTlsAuth);
+            Err("boom")
+        }
+
+        let telemetry = Arc::new(BenchmarkTelemetry::new(Meter::new(NoopIo).stats()));
+        assert!(fail_with_guard(telemetry.clone()).is_err());
+
+        let metrics = telemetry.phase_metrics();
+        assert_eq!(metrics.phase_finalize_tls_auth_count, 1);
+    }
+}

--- a/crates/harness/executor/src/bench/verifier.rs
+++ b/crates/harness/executor/src/bench/verifier.rs
@@ -22,14 +22,15 @@ pub async fn bench_verifier(provider: &IoProvider, _config: &Bench) -> Result<()
             .build()?,
     )?;
 
-    let (session, handle) = session.split();
-
-    _ = spawn(session);
+    let (session, _handle) = session.split();
+    let session_task = spawn(session);
 
     let verifier = verifier.commit().await?.accept().await?.run().await?;
     let (_, verifier) = verifier.verify().await?.accept().await?;
     verifier.close().await?;
-    handle.close();
+    // Let the prover drive session shutdown after it finishes transcript proof
+    // traffic so the verifier does not tear down the mux early.
+    let _ = session_task.await??;
 
     Ok(())
 }

--- a/crates/harness/runner/Cargo.toml
+++ b/crates/harness/runner/Cargo.toml
@@ -27,6 +27,7 @@ ipnet = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serio = { workspace = true }
 serde_json = { workspace = true }
+reqwest = { version = "0.12", default-features = false }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true, features = ["compat", "codec"] }
 toml = { workspace = true }

--- a/crates/harness/runner/src/executor.rs
+++ b/crates/harness/runner/src/executor.rs
@@ -8,7 +8,7 @@ use chromiumoxide::{
         network::{EnableParams, SetCacheDisabledParams},
         page::ReloadParams,
     },
-    handler::HandlerConfig,
+    handler::{Handler, HandlerConfig},
 };
 use futures::StreamExt;
 use harness_core::{
@@ -18,11 +18,18 @@ use harness_core::{
     rpc::{BenchCmd, TestCmd},
     test::{TestOutput, TestStatus},
 };
+use serde::Deserialize;
 
 use crate::{Target, log::parse_rust_log, network::Namespace, rpc::Rpc};
 
 #[cfg(feature = "debug")]
 use crate::debug_prelude::*;
+
+#[derive(Debug, Default, Deserialize)]
+struct BrowserVersion {
+    #[serde(rename = "webSocketDebuggerUrl")]
+    web_socket_debugger_url: String,
+}
 
 pub struct Executor {
     ns: Namespace,
@@ -150,6 +157,9 @@ impl Executor {
 
                 args.push(chrome_path.to_string_lossy().into());
                 args.push(format!("--remote-debugging-port={PORT_BROWSER}"));
+                // Bind DevTools on the namespace interface so the host can
+                // connect directly to the executor's RPC address.
+                args.push("--remote-debugging-address=0.0.0.0".into());
 
                 if headed {
                     // Headed mode: no headless, add flags to suppress first-run dialogs
@@ -188,18 +198,76 @@ impl Executor {
                     ..Default::default()
                 };
 
-                let (browser, mut handler) = loop {
-                    match Browser::connect_with_config(
-                        format!("http://{}:{}", rpc_addr.0, PORT_BROWSER),
-                        config.clone(),
-                    )
-                    .await
+                let version_url = format!("http://{}:{}/json/version", rpc_addr.0, PORT_BROWSER);
+                let client = reqwest::Client::builder()
+                    .no_proxy()
+                    .build()
+                    .context("failed to build DevTools HTTP client")?;
+
+                let (browser, mut handler): (Browser, Handler) = loop {
+                    let response = match client
+                        .get(&version_url)
+                        .header("content-type", "application/json")
+                        .send()
+                        .await
                     {
+                        Ok(response) => response,
+                        Err(e) => {
+                            retries += 1;
+                            if retries * DELAY > TIMEOUT {
+                                return Err(e)
+                                    .context("timed out probing browser DevTools HTTP endpoint");
+                            }
+                            tokio::time::sleep(Duration::from_millis(DELAY as u64)).await;
+                            continue;
+                        }
+                    };
+
+                    let body = match response.bytes().await {
+                        Ok(body) => body,
+                        Err(e) => {
+                            retries += 1;
+                            if retries * DELAY > TIMEOUT {
+                                return Err(e)
+                                    .context("timed out reading browser DevTools response body");
+                            }
+                            tokio::time::sleep(Duration::from_millis(DELAY as u64)).await;
+                            continue;
+                        }
+                    };
+
+                    let version = match serde_json::from_slice::<BrowserVersion>(&body) {
+                        Ok(version) if !version.web_socket_debugger_url.is_empty() => version,
+                        Ok(_) => {
+                            retries += 1;
+                            if retries * DELAY > TIMEOUT {
+                                return Err(anyhow!(
+                                    "browser DevTools response did not include a websocket URL"
+                                ));
+                            }
+                            tokio::time::sleep(Duration::from_millis(DELAY as u64)).await;
+                            continue;
+                        }
+                        Err(e) => {
+                            retries += 1;
+                            if retries * DELAY > TIMEOUT {
+                                return Err(e)
+                                    .context("timed out decoding browser DevTools response");
+                            }
+                            tokio::time::sleep(Duration::from_millis(DELAY as u64)).await;
+                            continue;
+                        }
+                    };
+
+                    let debug_ws_url =
+                        version.web_socket_debugger_url.replace("127.0.0.1", &rpc_addr.0.to_string());
+
+                    match Browser::connect_with_config(debug_ws_url, config.clone()).await {
                         Ok(browser) => break browser,
                         Err(e) => {
                             retries += 1;
                             if retries * DELAY > TIMEOUT {
-                                return Err(e.into());
+                                return Err(anyhow!(e));
                             }
                             tokio::time::sleep(Duration::from_millis(DELAY as u64)).await;
                         }
@@ -265,7 +333,9 @@ impl Executor {
                 .await?;
                 page.execute(ReloadParams::builder().ignore_cache(true).build())
                     .await?;
-                page.wait_for_navigation().await?;
+                tokio::time::timeout(Duration::from_secs(30), page.wait_for_navigation())
+                    .await
+                    .context("timed out waiting for browser page navigation")??;
                 page.bring_to_front().await?;
 
                 // Build logging config from RUST_LOG environment variable
@@ -278,21 +348,25 @@ impl Executor {
                     "null".to_string()
                 };
 
-                page.evaluate(format!(
-                    r#"
-                        (async () => {{
-                            const config = JSON.parse('{config}');
-                            const loggingConfig = JSON.parse('{logging_config}');
-                            console.log("initializing executor", config, "logging:", loggingConfig);
-                            await window.executor.init(config, loggingConfig);
-                            console.log("executor initialized");
-                            return;
-                        }})();
-                    "#,
-                    config = serde_json::to_string(&self.config)?,
-                    logging_config = logging_config_js
-                ))
-                .await?;
+                tokio::time::timeout(
+                    Duration::from_secs(60),
+                    page.evaluate(format!(
+                        r#"
+                            (async () => {{
+                                const config = JSON.parse('{config}');
+                                const loggingConfig = JSON.parse('{logging_config}');
+                                console.log("initializing executor", config, "logging:", loggingConfig);
+                                await window.executor.init(config, loggingConfig);
+                                console.log("executor initialized");
+                                return;
+                            }})();
+                        "#,
+                        config = serde_json::to_string(&self.config)?,
+                        logging_config = logging_config_js
+                    )),
+                )
+                .await
+                .context("timed out waiting for browser executor initialization")??;
 
                 let rpc = Rpc::new_browser(page);
 
@@ -355,11 +429,44 @@ impl Executor {
     }
 
     pub async fn bench(&mut self, bench: BenchCmd) -> Result<BenchOutput> {
-        let State::Started { rpc, .. } = &mut self.state else {
+        let State::Started { process, rpc, .. } = &mut self.state else {
             return Err(anyhow!("executor not started"));
         };
 
-        rpc.bench(bench).await?.map_err(From::from)
+        let output: Result<BenchOutput> = match rpc.bench(bench).await {
+            Ok(res) => res.map_err(From::from),
+            // Bench could cause the native executor process to panic or exit
+            // before the RPC reply is serialized.
+            Err(e) if self.target == Target::Native => {
+                // Wait a moment to give the process time to exit.
+                tokio::time::sleep(Duration::from_millis(100)).await;
+
+                if let Some(output) = process.try_wait()? {
+                    let res = if output.status.success() {
+                        Err(e).context(
+                            "executor process closed with success exit code even though RPC call returned an error",
+                        )
+                    } else {
+                        Err(anyhow!(
+                            "native benchmark executor exited unexpectedly:\n{}",
+                            String::from_utf8_lossy(&output.stderr)
+                        ))
+                    };
+
+                    // Restart the executor so the runner state remains valid.
+                    self.start().await?;
+
+                    return res;
+                }
+
+                return Err(e.into());
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        };
+
+        output
     }
 
     pub fn shutdown(&mut self) -> impl Future<Output = Result<()>> {

--- a/crates/harness/runner/src/rpc.rs
+++ b/crates/harness/runner/src/rpc.rs
@@ -105,15 +105,19 @@ impl Rpc {
 }
 
 async fn browser_cmd(page: &Page, cmd: Cmd) -> io::Result<Result<CmdOutput>> {
-    page.evaluate(format!(
-        r#"
-            (async () => {{
-                return await window.executor.call(JSON.parse('{cmd}'));
-            }})();
-        "#,
-        cmd = serde_json::to_string(&cmd).unwrap()
-    ))
+    tokio::time::timeout(
+        Duration::from_secs(120),
+        page.evaluate(format!(
+            r#"
+                (async () => {{
+                    return await window.executor.call(JSON.parse('{cmd}'));
+                }})();
+            "#,
+            cmd = serde_json::to_string(&cmd).unwrap()
+        )),
+    )
     .await
+    .map_err(|e| io::Error::new(io::ErrorKind::TimedOut, e))?
     .map_err(io::Error::other)?
     .into_value()
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))

--- a/crates/mpc-tls/src/leader.rs
+++ b/crates/mpc-tls/src/leader.rs
@@ -4,6 +4,7 @@ use crate::{
         ClientFinishedVd, Decrypt, Encrypt, Message, ServerFinishedVd, SetClientRandom,
         SetServerKey, SetServerRandom, StartHandshake,
     },
+    phase::{TelemetryHandle, in_phase},
     record_layer::{aead::MpcAesGcm, DecryptMode, EncryptMode, RecordLayer},
     utils::opaque_into_parts,
     Config, Role, SessionKeys, Vm,
@@ -42,6 +43,7 @@ use tls_core::{
 };
 use tlsn_core::{
     connection::{CertBinding, CertBindingV1_2, ServerSignature, TlsVersion, VerifyData},
+    telemetry::{BenchPhase, TelemetrySink},
     transcript::TlsTranscript,
     webpki::CertificateDer,
 };
@@ -58,6 +60,7 @@ pub struct MpcTlsLeader {
     notifier: BackendNotifier,
     /// Whether the record layer is decrypting application data.
     is_decrypting: bool,
+    telemetry: Option<TelemetryHandle>,
 }
 
 impl MpcTlsLeader {
@@ -117,7 +120,16 @@ impl MpcTlsLeader {
             },
             notifier: BackendNotifier::new(),
             is_decrypting,
+            telemetry: None,
         }
+    }
+
+    /// Attaches a benchmark telemetry sink to the leader.
+    pub fn set_telemetry(
+        &mut self,
+        sink: std::sync::Arc<dyn TelemetrySink + Send + Sync>,
+    ) {
+        self.telemetry = Some(TelemetryHandle::new(sink));
     }
 
     /// Allocates resources for the connection.
@@ -206,43 +218,51 @@ impl MpcTlsLeader {
             .clone()
             .try_lock_owned()
             .map_err(|_| MpcTlsError::other("VM lock is held"))?;
+        let (ke, record_layer, _) = in_phase(
+            self.telemetry.as_ref(),
+            BenchPhase::PreprocessSetup,
+            async {
+                let (ke, record_layer, _) = ctx
+                    .try_join3(
+                        async move |ctx| {
+                            ke.setup(ctx)
+                                .await
+                                .map(|_| ke)
+                                .map_err(MpcTlsError::preprocess)
+                        },
+                        async move |ctx| {
+                            record_layer
+                                .preprocess(ctx)
+                                .await
+                                .map(|_| record_layer)
+                                .map_err(MpcTlsError::preprocess)
+                        },
+                        async move |ctx| {
+                            vm_lock
+                                .preprocess(ctx)
+                                .await
+                                .map_err(MpcTlsError::preprocess)?;
+                            vm_lock.flush(ctx).await.map_err(MpcTlsError::preprocess)?;
 
-        let (ke, record_layer, _) = ctx
-            .try_join3(
-                async move |ctx| {
-                    ke.setup(ctx)
-                        .await
-                        .map(|_| ke)
-                        .map_err(MpcTlsError::preprocess)
-                },
-                async move |ctx| {
-                    record_layer
-                        .preprocess(ctx)
-                        .await
-                        .map(|_| record_layer)
-                        .map_err(MpcTlsError::preprocess)
-                },
-                async move |ctx| {
-                    vm_lock
-                        .preprocess(ctx)
-                        .await
-                        .map_err(MpcTlsError::preprocess)?;
-                    vm_lock.flush(ctx).await.map_err(MpcTlsError::preprocess)?;
+                            Ok::<_, MpcTlsError>(())
+                        },
+                    )
+                    .await
+                    .map_err(MpcTlsError::preprocess)??;
 
-                    Ok::<_, MpcTlsError>(())
-                },
-            )
-            .await
-            .map_err(MpcTlsError::preprocess)??;
+                ctx.io_mut()
+                    .send(Message::SetClientRandom(SetClientRandom {
+                        random: client_random.0,
+                    }))
+                    .await
+                    .map_err(MpcTlsError::from)?;
 
-        ctx.io_mut()
-            .send(Message::SetClientRandom(SetClientRandom {
-                random: client_random.0,
-            }))
-            .await
-            .map_err(MpcTlsError::from)?;
+                prf.set_client_random(client_random.0)?;
 
-        prf.set_client_random(client_random.0)?;
+                Ok::<_, MpcTlsError>((ke, record_layer, ()))
+            },
+        )
+        .await?;
 
         self.state = State::Handshake {
             ctx,
@@ -583,20 +603,26 @@ impl Backend for MpcTlsLeader {
             .try_lock()
             .map_err(|_| MpcTlsError::other("VM lock is held"))?;
         prf.set_sf_hash(hash).map_err(MpcTlsError::hs)?;
+        in_phase(
+            self.telemetry.as_ref(),
+            BenchPhase::HandshakePrfServerFinished,
+            async {
+                while prf.wants_flush() {
+                    prf.flush(&mut *vm).map_err(MpcTlsError::hs)?;
+                    vm.execute_all(ctx).await.map_err(MpcTlsError::hs)?;
+                }
 
-        while prf.wants_flush() {
-            prf.flush(&mut *vm).map_err(MpcTlsError::hs)?;
-            vm.execute_all(ctx).await.map_err(MpcTlsError::hs)?;
-        }
+                let vd = sf_vd_fut
+                    .try_recv()
+                    .map_err(MpcTlsError::hs)?
+                    .ok_or_else(|| MpcTlsError::hs("sf_vd is not decoded"))?;
 
-        let vd = sf_vd_fut
-            .try_recv()
-            .map_err(MpcTlsError::hs)?
-            .ok_or_else(|| MpcTlsError::hs("sf_vd is not decoded"))?;
+                *sf_vd = Some(vd);
 
-        *sf_vd = Some(vd);
-
-        Ok(vd.to_vec())
+                Ok(vd.to_vec())
+            },
+        )
+        .await
     }
 
     #[instrument(level = "debug", skip_all, err)]
@@ -632,20 +658,26 @@ impl Backend for MpcTlsLeader {
             .try_lock()
             .map_err(|_| MpcTlsError::hs("VM lock is held"))?;
         prf.set_cf_hash(hash).map_err(MpcTlsError::hs)?;
+        in_phase(
+            self.telemetry.as_ref(),
+            BenchPhase::HandshakePrfClientFinished,
+            async {
+                while prf.wants_flush() {
+                    prf.flush(&mut *vm).map_err(MpcTlsError::hs)?;
+                    vm.execute_all(ctx).await.map_err(MpcTlsError::hs)?;
+                }
 
-        while prf.wants_flush() {
-            prf.flush(&mut *vm).map_err(MpcTlsError::hs)?;
-            vm.execute_all(ctx).await.map_err(MpcTlsError::hs)?;
-        }
+                let vd = cf_vd_fut
+                    .try_recv()
+                    .map_err(MpcTlsError::hs)?
+                    .ok_or_else(|| MpcTlsError::hs("cf_vd is not decoded"))?;
 
-        let vd = cf_vd_fut
-            .try_recv()
-            .map_err(MpcTlsError::hs)?
-            .ok_or_else(|| MpcTlsError::hs("cf_vd is not decoded"))?;
+                *cf_vd = Some(vd);
 
-        *cf_vd = Some(vd);
-
-        Ok(vd.to_vec())
+                Ok(vd.to_vec())
+            },
+        )
+        .await
     }
 
     #[instrument(level = "debug", skip_all, err)]
@@ -686,31 +718,68 @@ impl Backend for MpcTlsLeader {
         let server_kx_details =
             server_kx_details.ok_or_else(|| MpcTlsError::hs("server kx details is not set"))?;
 
-        ke.set_server_key(
-            p256::PublicKey::from_sec1_bytes(&server_key.key).map_err(MpcTlsError::hs)?,
-        )
-        .map_err(|err| BackendError::InvalidState(err.to_string()))?;
+        in_phase(
+            self.telemetry.as_ref(),
+            BenchPhase::HandshakeKeOnline,
+            async {
+            ke.set_server_key(
+                p256::PublicKey::from_sec1_bytes(&server_key.key).map_err(MpcTlsError::hs)?,
+            )
+            .map_err(|err| BackendError::InvalidState(err.to_string()))?;
 
-        ke.compute_shares(&mut ctx).await.map_err(MpcTlsError::hs)?;
+            ke.compute_shares(&mut ctx).await.map_err(MpcTlsError::hs)?;
 
-        {
             let mut vm_lock = vm
                 .try_lock()
                 .map_err(|_| MpcTlsError::other("VM lock is held"))?;
-
             ke.assign(&mut (*vm_lock)).map_err(MpcTlsError::hs)?;
+                Ok::<_, BackendError>(())
+            },
+        )
+        .await?;
 
-            while prf.wants_flush() {
-                prf.flush(&mut *vm_lock).map_err(MpcTlsError::hs)?;
-                vm_lock
-                    .execute_all(&mut ctx)
-                    .await
-                    .map_err(MpcTlsError::hs)?;
+        in_phase(
+            self.telemetry.as_ref(),
+            BenchPhase::HandshakePrfSessionKeys,
+            async {
+                let mut vm_lock = vm
+                    .try_lock()
+                    .map_err(|_| MpcTlsError::other("VM lock is held"))?;
+
+                while prf.wants_flush() {
+                    prf.flush(&mut *vm_lock).map_err(MpcTlsError::hs)?;
+                    vm_lock
+                        .execute_all(&mut ctx)
+                        .await
+                        .map_err(MpcTlsError::hs)?;
+                }
+
+                Ok::<_, BackendError>(())
+            },
+        )
+        .await?;
+
+        // `ke.finalize()` completes the online key exchange, but it depends on
+        // the equality-check result produced by the VM work above.
+        in_phase(
+            self.telemetry.as_ref(),
+            BenchPhase::HandshakeKeOnline,
+            async {
+                ke.finalize().await.map_err(MpcTlsError::hs)?;
+                Ok::<_, BackendError>(())
             }
+        )
+        .await?;
 
-            ke.finalize().await.map_err(MpcTlsError::hs)?;
-            record_layer.setup(&mut ctx).await?;
-        }
+        in_phase(
+            self.telemetry.as_ref(),
+            BenchPhase::HandshakeRecordSetup,
+            async {
+                record_layer.setup(&mut ctx).await?;
+                Ok::<_, BackendError>(())
+            },
+        )
+        .await?;
 
         debug!("encryption prepared");
 
@@ -989,10 +1058,24 @@ impl Backend for MpcTlsLeader {
             .await
             .map_err(MpcTlsError::from)?;
 
-        record_layer
-            .flush(ctx, vm.clone(), self.is_decrypting)
+        if record_layer.has_effective_flush_work(self.is_decrypting) {
+            in_phase(
+                self.telemetry.as_ref(),
+                BenchPhase::RecordLayerFlush,
+                async {
+                    record_layer
+                        .flush(ctx, vm.clone(), self.is_decrypting)
+                        .await
+                        .map_err(BackendError::from)
+                },
+            )
             .await
-            .map_err(BackendError::from)
+        } else {
+            record_layer
+                .flush(ctx, vm.clone(), self.is_decrypting)
+                .await
+                .map_err(BackendError::from)
+        }
     }
 
     async fn get_notify(&mut self) -> Result<BackendNotify, BackendError> {

--- a/crates/mpc-tls/src/lib.rs
+++ b/crates/mpc-tls/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 pub(crate) mod follower;
 pub(crate) mod leader;
 mod msg;
+mod phase;
 mod record_layer;
 pub(crate) mod utils;
 

--- a/crates/mpc-tls/src/phase.rs
+++ b/crates/mpc-tls/src/phase.rs
@@ -1,0 +1,71 @@
+use std::{fmt, future::Future, sync::Arc};
+
+use tlsn_core::telemetry::{BenchPhase, PhaseEvent, TelemetrySink};
+use tracing::{Instrument, trace};
+
+#[derive(Clone)]
+pub(crate) struct TelemetryHandle(Arc<dyn TelemetrySink + Send + Sync>);
+
+impl TelemetryHandle {
+    pub(crate) fn new(sink: Arc<dyn TelemetrySink + Send + Sync>) -> Self {
+        Self(sink)
+    }
+
+    pub(crate) fn phase_event(&self, phase: BenchPhase, event: PhaseEvent) {
+        self.0.phase_event(phase, event);
+    }
+}
+
+impl fmt::Debug for TelemetryHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("TelemetryHandle(..)")
+    }
+}
+
+pub(crate) struct PhaseGuard {
+    phase: BenchPhase,
+    telemetry: Option<TelemetryHandle>,
+}
+
+impl PhaseGuard {
+    fn from_owned(telemetry: Option<TelemetryHandle>, phase: BenchPhase) -> Self {
+        trace!("start");
+
+        if let Some(telemetry) = &telemetry {
+            telemetry.phase_event(phase, PhaseEvent::Start);
+        }
+
+        Self {
+            phase,
+            telemetry,
+        }
+    }
+}
+
+impl Drop for PhaseGuard {
+    fn drop(&mut self) {
+        trace!("end");
+
+        if let Some(telemetry) = &self.telemetry {
+            telemetry.phase_event(self.phase, PhaseEvent::End);
+        }
+    }
+}
+
+pub(crate) async fn in_phase<F>(
+    telemetry: Option<&TelemetryHandle>,
+    phase: BenchPhase,
+    future: F,
+) -> F::Output
+where
+    F: Future,
+{
+    let telemetry = telemetry.cloned();
+
+    async move {
+        let _phase = PhaseGuard::from_owned(telemetry, phase);
+        future.await
+    }
+    .instrument(tracing::debug_span!("bench_phase", phase = phase.as_str()))
+    .await
+}

--- a/crates/mpc-tls/src/record_layer.rs
+++ b/crates/mpc-tls/src/record_layer.rs
@@ -36,6 +36,26 @@ const MAX_RECORD_SIZE: usize = 1026 * 16;
 // This limits how much the leader can cause the follower to allocate.
 const MAX_BUFFER_SIZE: usize = (16 * (1 << 20)) / MAX_RECORD_SIZE;
 
+fn has_effective_flush_work(
+    has_encrypt_ops: bool,
+    decrypt_ops: &[DecryptOp],
+    is_decrypting: bool,
+) -> bool {
+    if has_encrypt_ops {
+        return true;
+    }
+
+    if is_decrypting {
+        return !decrypt_ops.is_empty();
+    }
+
+    decrypt_ops
+        .iter()
+        .take_while(|op| op.typ != ContentType::ApplicationData)
+        .next()
+        .is_some()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct PlainRecord {
     pub(crate) typ: ContentType,
@@ -276,6 +296,14 @@ impl RecordLayer {
 
     pub(crate) fn wants_flush(&self) -> bool {
         !self.encrypt_buffer.is_empty() || !self.decrypt_buffer.is_empty()
+    }
+
+    pub(crate) fn has_effective_flush_work(&self, is_decrypting: bool) -> bool {
+        has_effective_flush_work(
+            !self.encrypt_buffer.is_empty(),
+            &self.decrypt_buffer,
+            is_decrypting,
+        )
     }
 
     pub(crate) fn start_traffic(&mut self) {
@@ -623,4 +651,82 @@ impl RecordLayer {
 pub(crate) struct TagData {
     pub(crate) explicit_nonce: Vec<u8>,
     pub(crate) aad: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use tls_core::msgs::enums::{ContentType, ProtocolVersion};
+
+    use super::{DecryptMode, DecryptOp, has_effective_flush_work};
+
+    fn decrypt_op(typ: ContentType) -> DecryptOp {
+        DecryptOp::new(
+            0,
+            typ,
+            ProtocolVersion::TLSv1_2,
+            Vec::new(),
+            vec![1, 2, 3],
+            Vec::new(),
+            vec![4; 16],
+            DecryptMode::Public,
+        )
+    }
+
+    #[test]
+    fn effective_flush_work_empty_buffers() {
+        assert!(!has_effective_flush_work(false, &[], false));
+        assert!(!has_effective_flush_work(false, &[], true));
+    }
+
+    #[test]
+    fn effective_flush_work_pending_encrypt_ops() {
+        assert!(has_effective_flush_work(true, &[], false));
+    }
+
+    #[test]
+    fn effective_flush_work_pending_decrypt_when_decrypting() {
+        assert!(has_effective_flush_work(
+            false,
+            &[decrypt_op(ContentType::ApplicationData)],
+            true,
+        ));
+    }
+
+    #[test]
+    fn effective_flush_work_skips_app_data_when_not_decrypting() {
+        assert!(!has_effective_flush_work(
+            false,
+            &[decrypt_op(ContentType::ApplicationData)],
+            false,
+        ));
+    }
+
+    #[test]
+    fn effective_flush_work_keeps_public_handshake_records_when_not_decrypting() {
+        assert!(has_effective_flush_work(
+            false,
+            &[decrypt_op(ContentType::Handshake)],
+            false,
+        ));
+    }
+
+    #[test]
+    fn effective_flush_work_stops_at_first_application_data_record() {
+        assert!(!has_effective_flush_work(
+            false,
+            &[
+                decrypt_op(ContentType::ApplicationData),
+                decrypt_op(ContentType::Handshake),
+            ],
+            false,
+        ));
+        assert!(has_effective_flush_work(
+            false,
+            &[
+                decrypt_op(ContentType::Handshake),
+                decrypt_op(ContentType::ApplicationData),
+            ],
+            false,
+        ));
+    }
 }

--- a/crates/tlsn/src/lib.rs
+++ b/crates/tlsn/src/lib.rs
@@ -47,6 +47,7 @@ pub(crate) mod ghash;
 pub(crate) mod map;
 pub(crate) mod mpz;
 pub(crate) mod msg;
+pub(crate) mod phase;
 pub mod prover;
 mod session;
 pub(crate) mod tag;
@@ -57,7 +58,7 @@ pub use error::Error;
 pub use rangeset;
 pub use session::{Session, SessionDriver, SessionHandle};
 pub use tlsn_attestation as attestation;
-pub use tlsn_core::{config, connection, hash, transcript, webpki};
+pub use tlsn_core::{config, connection, hash, telemetry, transcript, webpki};
 
 /// Result type.
 pub type Result<T, E = Error> = core::result::Result<T, E>;

--- a/crates/tlsn/src/phase.rs
+++ b/crates/tlsn/src/phase.rs
@@ -1,0 +1,75 @@
+use std::{fmt, future::Future, sync::Arc};
+
+use tlsn_core::telemetry::{BenchPhase, PhaseEvent, TelemetrySink};
+use tracing::{Instrument, trace};
+
+#[derive(Clone)]
+pub(crate) struct TelemetryHandle(Arc<dyn TelemetrySink + Send + Sync>);
+
+impl TelemetryHandle {
+    pub(crate) fn new(sink: Arc<dyn TelemetrySink + Send + Sync>) -> Self {
+        Self(sink)
+    }
+
+    pub(crate) fn arc(&self) -> Arc<dyn TelemetrySink + Send + Sync> {
+        self.0.clone()
+    }
+
+    pub(crate) fn phase_event(&self, phase: BenchPhase, event: PhaseEvent) {
+        self.0.phase_event(phase, event);
+    }
+}
+
+impl fmt::Debug for TelemetryHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("TelemetryHandle(..)")
+    }
+}
+
+pub(crate) struct PhaseGuard {
+    phase: BenchPhase,
+    telemetry: Option<TelemetryHandle>,
+}
+
+impl PhaseGuard {
+    fn from_owned(telemetry: Option<TelemetryHandle>, phase: BenchPhase) -> Self {
+        trace!("start");
+
+        if let Some(telemetry) = &telemetry {
+            telemetry.phase_event(phase, PhaseEvent::Start);
+        }
+
+        Self {
+            phase,
+            telemetry,
+        }
+    }
+}
+
+impl Drop for PhaseGuard {
+    fn drop(&mut self) {
+        trace!("end");
+
+        if let Some(telemetry) = &self.telemetry {
+            telemetry.phase_event(self.phase, PhaseEvent::End);
+        }
+    }
+}
+
+pub(crate) async fn in_phase<F>(
+    telemetry: Option<&TelemetryHandle>,
+    phase: BenchPhase,
+    future: F,
+) -> F::Output
+where
+    F: Future,
+{
+    let telemetry = telemetry.cloned();
+
+    async move {
+        let _phase = PhaseGuard::from_owned(telemetry, phase);
+        future.await
+    }
+    .instrument(tracing::debug_span!("bench_phase", phase = phase.as_str()))
+    .await
+}

--- a/crates/tlsn/src/prover.rs
+++ b/crates/tlsn/src/prover.rs
@@ -16,6 +16,7 @@ use crate::{
     Error, Result,
     mpz::{ProverDeps, build_prover_deps, translate_keys},
     msg::{ProveRequestMsg, Response, TlsCommitRequestMsg},
+    phase::TelemetryHandle,
     prover::{
         client::{MpcTlsClient, TlsOutput},
         state::ConnectedProj,
@@ -36,6 +37,7 @@ use tlsn_core::{
         tls_commit::{TlsCommitConfig, TlsCommitProtocolConfig},
     },
     connection::{HandshakeData, ServerName},
+    telemetry::TelemetrySink,
     transcript::{TlsTranscript, Transcript},
 };
 use tracing::{Span, debug, info_span, instrument};
@@ -49,6 +51,7 @@ pub struct Prover<T: state::ProverState = state::Initialized> {
     config: ProverConfig,
     span: Span,
     ctx: Option<Context>,
+    telemetry: Option<TelemetryHandle>,
     state: T,
 }
 
@@ -65,8 +68,21 @@ impl Prover<state::Initialized> {
             config,
             span,
             ctx: Some(ctx),
+            telemetry: None,
             state: state::Initialized,
         }
+    }
+
+    /// Attaches a benchmark telemetry sink to the prover.
+    ///
+    /// Call this before [`Prover::commit`] so the sink is propagated through
+    /// MPC-TLS setup, transcript finalization, and proving.
+    pub fn with_telemetry(
+        mut self,
+        sink: Arc<dyn TelemetrySink + Send + Sync>,
+    ) -> Self {
+        self.telemetry = Some(TelemetryHandle::new(sink));
+        self
     }
 
     /// Starts the TLS commitment protocol.
@@ -121,6 +137,10 @@ impl Prover<state::Initialized> {
 
         let ProverDeps { vm, mut mpc_tls } = build_prover_deps(mpc_tls_config, ctx);
 
+        if let Some(telemetry) = &self.telemetry {
+            mpc_tls.set_telemetry(telemetry.arc());
+        }
+
         // Allocate resources for MPC-TLS in the VM.
         let mut keys = mpc_tls.alloc().map_err(|e| {
             Error::internal()
@@ -145,6 +165,7 @@ impl Prover<state::Initialized> {
             config: self.config,
             span: self.span,
             ctx: None,
+            telemetry: self.telemetry,
             state: state::CommitAccepted { mpc_tls, keys, vm },
         })
     }
@@ -224,7 +245,7 @@ impl Prover<state::CommitAccepted> {
             })?;
 
         let span = self.span.clone();
-        let mpc_tls = MpcTlsClient::new(keys, vm, span, client, decrypt);
+        let mpc_tls = MpcTlsClient::new(keys, vm, span, client, decrypt, self.telemetry.clone());
 
         let (client_io, tlsn_conn) = futures_plex::duplex(BUF_CAP);
         let (client_to_server, server_to_client) = futures_plex::duplex(BUF_CAP);
@@ -233,6 +254,7 @@ impl Prover<state::CommitAccepted> {
             ctx: self.ctx,
             config: self.config,
             span: self.span,
+            telemetry: self.telemetry,
             state: state::Connected {
                 server_name: config.server_name().clone(),
                 tls_client: Box::new(mpc_tls),
@@ -308,6 +330,7 @@ where
             config: self.config,
             span: self.span,
             ctx: Some(ctx),
+            telemetry: self.telemetry,
             state: state::Committed {
                 vm,
                 server_name: self.state.server_name,
@@ -501,7 +524,16 @@ impl Prover<state::Committed> {
                     .with_source(e)
             })?;
 
-        let output = prove::prove(ctx, vm, keys, transcript, tls_transcript, config).await?;
+        let output = prove::prove(
+            ctx,
+            vm,
+            keys,
+            transcript,
+            tls_transcript,
+            config,
+            self.telemetry.as_ref(),
+        )
+        .await?;
 
         Ok(output)
     }

--- a/crates/tlsn/src/prover/client/mpc.rs
+++ b/crates/tlsn/src/prover/client/mpc.rs
@@ -3,6 +3,7 @@
 use crate::{
     error::Error as TlsnError,
     mpz::{ProverMpc, ProverZk},
+    phase::{TelemetryHandle, in_phase},
     prover::client::{DecryptState, TlsClient, TlsOutput},
     tag::verify_tags,
 };
@@ -16,7 +17,7 @@ use std::{
     task::Poll,
 };
 use tls_client::ClientConnection;
-use tlsn_core::transcript::TlsTranscript;
+use tlsn_core::{telemetry::BenchPhase, transcript::TlsTranscript};
 use tlsn_deap::Deap;
 use tokio::sync::Mutex;
 use tracing::{Span, debug, instrument, trace, warn};
@@ -61,6 +62,7 @@ impl MpcTlsClient {
         span: Span,
         tls: ClientConnection,
         decrypt: bool,
+        telemetry: Option<TelemetryHandle>,
     ) -> Self {
         let inner = InnerState {
             span,
@@ -69,6 +71,7 @@ impl MpcTlsClient {
             keys,
             decrypt,
             client_closed: false,
+            telemetry,
         };
 
         let decrypt = DecryptState {
@@ -331,6 +334,7 @@ struct InnerState {
     keys: SessionKeys,
     decrypt: bool,
     client_closed: bool,
+    telemetry: Option<TelemetryHandle>,
 }
 
 impl InnerState {
@@ -402,38 +406,47 @@ impl InnerState {
         mut ctx: Context,
         transcript: TlsTranscript,
     ) -> Result<(Self, Context, TlsTranscript), TlsnError> {
-        {
-            let mut vm = self.vm.try_lock().expect("VM should not be locked");
+        let telemetry = self.telemetry.clone();
 
-            // Finalize DEAP.
-            vm.finalize(&mut ctx)
-                .await
-                .map_err(|err| TlsnError::internal().with_source(err))?;
+        in_phase(
+            telemetry.as_ref(),
+            BenchPhase::FinalizeTlsAuth,
+            async move {
+                {
+                    let mut vm = self.vm.try_lock().expect("VM should not be locked");
 
-            debug!("mpc finalized");
+                    // Finalize DEAP.
+                    vm.finalize(&mut ctx)
+                        .await
+                        .map_err(|err| TlsnError::internal().with_source(err))?;
 
-            // Pull out ZK VM.
-            let mut zk = vm.zk();
+                    debug!("mpc finalized");
 
-            // Prove tag verification of received records.
-            // The prover drops the proof output.
-            let _ = verify_tags(
-                &mut *zk,
-                (self.keys.server_write_key, self.keys.server_write_iv),
-                self.keys.server_write_mac_key,
-                *transcript.version(),
-                transcript.recv().to_vec(),
-            )
-            .map_err(|err| TlsnError::internal().with_source(err))?;
-            debug!("verified tags from server");
+                    // Pull out ZK VM.
+                    let mut zk = vm.zk();
 
-            zk.execute_all(&mut ctx)
-                .await
-                .map_err(|err| TlsnError::internal().with_source(err))?;
-        }
+                    // Prove tag verification of received records.
+                    // The prover drops the proof output.
+                    let _ = verify_tags(
+                        &mut *zk,
+                        (self.keys.server_write_key, self.keys.server_write_iv),
+                        self.keys.server_write_mac_key,
+                        *transcript.version(),
+                        transcript.recv().to_vec(),
+                    )
+                    .map_err(|err| TlsnError::internal().with_source(err))?;
+                    debug!("verified tags from server");
 
-        debug!("MPC-TLS done");
-        Ok((self, ctx, transcript))
+                    zk.execute_all(&mut ctx)
+                        .await
+                        .map_err(|err| TlsnError::internal().with_source(err))?;
+                }
+
+                debug!("MPC-TLS done");
+                Ok((self, ctx, transcript))
+            },
+        )
+        .await
     }
 
     fn is_record_layer_empty(&self) -> bool {

--- a/crates/tlsn/src/prover/prove.rs
+++ b/crates/tlsn/src/prover/prove.rs
@@ -6,6 +6,7 @@ use rangeset::set::RangeSet;
 use tlsn_core::{
     ProverOutput,
     config::prove::ProveConfig,
+    telemetry::BenchPhase,
     transcript::{
         ContentType, Direction, TlsTranscript, Transcript, TranscriptCommitment, TranscriptSecret,
     },
@@ -13,6 +14,7 @@ use tlsn_core::{
 
 use crate::{
     Error, Result,
+    phase::{TelemetryHandle, in_phase},
     transcript_internal::{TranscriptRefs, auth::prove_plaintext, commit::hash::prove_hash},
 };
 
@@ -23,102 +25,106 @@ pub(crate) async fn prove<T: Vm<Binary> + Send + Sync>(
     transcript: &Transcript,
     tls_transcript: &TlsTranscript,
     config: &ProveConfig,
+    telemetry: Option<&TelemetryHandle>,
 ) -> Result<ProverOutput> {
-    let mut output = ProverOutput {
-        transcript_commitments: Vec::default(),
-        transcript_secrets: Vec::default(),
-    };
+    in_phase(telemetry, BenchPhase::ProveTranscript, async {
+        let mut output = ProverOutput {
+            transcript_commitments: Vec::default(),
+            transcript_secrets: Vec::default(),
+        };
 
-    let (reveal_sent, reveal_recv) = config.reveal().cloned().unwrap_or_default();
-    let (mut commit_sent, mut commit_recv) = (RangeSet::default(), RangeSet::default());
-    if let Some(commit_config) = config.transcript_commit() {
-        commit_config
-            .iter_hash()
-            .for_each(|((direction, idx), _)| match direction {
-                Direction::Sent => commit_sent.union_mut(idx),
-                Direction::Received => commit_recv.union_mut(idx),
-            });
-    }
+        let (reveal_sent, reveal_recv) = config.reveal().cloned().unwrap_or_default();
+        let (mut commit_sent, mut commit_recv) = (RangeSet::default(), RangeSet::default());
+        if let Some(commit_config) = config.transcript_commit() {
+            commit_config
+                .iter_hash()
+                .for_each(|((direction, idx), _)| match direction {
+                    Direction::Sent => commit_sent.union_mut(idx),
+                    Direction::Received => commit_recv.union_mut(idx),
+                });
+        }
 
-    let transcript_refs = TranscriptRefs {
-        sent: prove_plaintext(
-            vm,
-            keys.client_write_key,
-            keys.client_write_iv,
-            transcript.sent(),
-            tls_transcript
-                .sent()
-                .iter()
-                .filter(|record| record.typ == ContentType::ApplicationData),
-            &reveal_sent,
-            &commit_sent,
-        )
-        .map_err(|e| {
-            Error::internal()
-                .with_msg("proving failed during sent plaintext commitment")
-                .with_source(e)
-        })?,
-        recv: prove_plaintext(
-            vm,
-            keys.server_write_key,
-            keys.server_write_iv,
-            transcript.received(),
-            tls_transcript
-                .recv()
-                .iter()
-                .filter(|record| record.typ == ContentType::ApplicationData),
-            &reveal_recv,
-            &commit_recv,
-        )
-        .map_err(|e| {
-            Error::internal()
-                .with_msg("proving failed during received plaintext commitment")
-                .with_source(e)
-        })?,
-    };
-
-    let hash_commitments = if let Some(commit_config) = config.transcript_commit()
-        && commit_config.has_hash()
-    {
-        Some(
-            prove_hash(
+        let transcript_refs = TranscriptRefs {
+            sent: prove_plaintext(
                 vm,
-                &transcript_refs,
-                commit_config
-                    .iter_hash()
-                    .map(|((dir, idx), alg)| (*dir, idx.clone(), *alg)),
+                keys.client_write_key,
+                keys.client_write_iv,
+                transcript.sent(),
+                tls_transcript
+                    .sent()
+                    .iter()
+                    .filter(|record| record.typ == ContentType::ApplicationData),
+                &reveal_sent,
+                &commit_sent,
             )
             .map_err(|e| {
                 Error::internal()
-                    .with_msg("proving failed during hash commitment setup")
+                    .with_msg("proving failed during sent plaintext commitment")
                     .with_source(e)
             })?,
-        )
-    } else {
-        None
-    };
+            recv: prove_plaintext(
+                vm,
+                keys.server_write_key,
+                keys.server_write_iv,
+                transcript.received(),
+                tls_transcript
+                    .recv()
+                    .iter()
+                    .filter(|record| record.typ == ContentType::ApplicationData),
+                &reveal_recv,
+                &commit_recv,
+            )
+            .map_err(|e| {
+                Error::internal()
+                    .with_msg("proving failed during received plaintext commitment")
+                    .with_source(e)
+            })?,
+        };
 
-    vm.execute_all(ctx).await.map_err(|e| {
-        Error::internal()
-            .with_msg("proving failed during zk execution")
-            .with_source(e)
-    })?;
+        let hash_commitments = if let Some(commit_config) = config.transcript_commit()
+            && commit_config.has_hash()
+        {
+            Some(
+                prove_hash(
+                    vm,
+                    &transcript_refs,
+                    commit_config
+                        .iter_hash()
+                        .map(|((dir, idx), alg)| (*dir, idx.clone(), *alg)),
+                )
+                .map_err(|e| {
+                    Error::internal()
+                        .with_msg("proving failed during hash commitment setup")
+                        .with_source(e)
+                })?,
+            )
+        } else {
+            None
+        };
 
-    if let Some((hash_fut, hash_secrets)) = hash_commitments {
-        let hash_commitments = hash_fut.try_recv().map_err(|e| {
+        vm.execute_all(ctx).await.map_err(|e| {
             Error::internal()
-                .with_msg("proving failed during hash commitment finalization")
+                .with_msg("proving failed during zk execution")
                 .with_source(e)
         })?;
-        for (commitment, secret) in hash_commitments.into_iter().zip(hash_secrets) {
-            output
-                .transcript_commitments
-                .push(TranscriptCommitment::Hash(commitment));
-            output
-                .transcript_secrets
-                .push(TranscriptSecret::Hash(secret));
-        }
-    }
 
-    Ok(output)
+        if let Some((hash_fut, hash_secrets)) = hash_commitments {
+            let hash_commitments = hash_fut.try_recv().map_err(|e| {
+                Error::internal()
+                    .with_msg("proving failed during hash commitment finalization")
+                    .with_source(e)
+            })?;
+            for (commitment, secret) in hash_commitments.into_iter().zip(hash_secrets) {
+                output
+                    .transcript_commitments
+                    .push(TranscriptCommitment::Hash(commitment));
+                output
+                    .transcript_secrets
+                    .push(TranscriptSecret::Hash(secret));
+            }
+        }
+
+        Ok(output)
+    })
+    .await
 }


### PR DESCRIPTION
Closes #853

## Summary
- add granular per-phase benchmark telemetry for prover benchmarks
- record phase time, uploaded/downloaded bytes, and IO wait in CSV output
- add matching tracing instrumentation and shared telemetry contracts
- harden browser benchmark startup for proxied environments

## What changed
- add stable benchmark phases for preprocess, handshake subphases, record-layer flush, finalization, and transcript proving
- extend harness metrics and CSV schema with flat `phase_*` columns
- upgrade the harness meter to track bytes plus read/write wait time
- wire telemetry through prover, MPC-TLS, and proving paths
- make browser executor startup more robust by fixing DevTools binding, adding startup/RPC timeouts, and bypassing proxies for local DevTools lookup

## Validation
- `cargo test -p tlsn-harness-core -p tlsn-harness-executor -p tlsn-mpc-tls -p tlsn --lib --no-fail-fast`
- `cargo test -p tlsn-harness-runner --no-run`
- native benchmark smoke passed
- browser benchmark smoke passed
- native and browser CSV outputs both contain populated `phase_*` fields with identical headers

Example phase timings from the first `cable` sample:

Native
- `phase_preprocess_setup_time_ms=13174`
- `phase_handshake_ke_online_time_ms=41`
- `phase_handshake_prf_session_keys_time_ms=162`
- `phase_handshake_record_setup_time_ms=21`
- `phase_handshake_prf_server_finished_time_ms=43`
- `phase_handshake_prf_client_finished_time_ms=43`
- `phase_record_layer_flush_time_ms=295`
- `phase_finalize_tls_auth_time_ms=54`
- `phase_prove_transcript_time_ms=415`

Browser
- `phase_preprocess_setup_time_ms=13609`
- `phase_handshake_ke_online_time_ms=96`
- `phase_handshake_prf_session_keys_time_ms=166`
- `phase_handshake_record_setup_time_ms=83`
- `phase_handshake_prf_server_finished_time_ms=54`
- `phase_handshake_prf_client_finished_time_ms=54`
- `phase_record_layer_flush_time_ms=474`
- `phase_finalize_tls_auth_time_ms=63`
- `phase_prove_transcript_time_ms=799`

## Notes
- phase metrics are emitted to CSV in this PR
- plot support remains coarse-only and is not changed here
- the example timings above are from smoke runs and are included to show the new output shape, not as stable performance claims