### PR TITLE
feat(sdk-core,wasm): add hash-commitment support for handlers

### DIFF
--- a/crates/sdk-core/src/handler/mod.rs
+++ b/crates/sdk-core/src/handler/mod.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{Result, SdkError},
-    types::{Commit, CommitRange, Handler, HandlerType, Reveal},
+    types::{Commit, CommitRange, Handler, HandlerAction, HandlerType, Reveal},
 };
 
 /// A byte range annotated with the handler that produced it.
@@ -90,8 +90,6 @@ pub fn compute_reveal(
             HandlerType::Recv => extract::extract_ranges(handler, &recv_msg, recv)?,
         };
 
-        let is_hash = handler.action.is_hash();
-
         let with_handlers_vec = match handler.handler_type {
             HandlerType::Sent => &mut sent_with_handlers,
             HandlerType::Recv => &mut recv_with_handlers,
@@ -105,7 +103,7 @@ pub fn compute_reveal(
             });
         }
 
-        if is_hash {
+        if handler.action == HandlerAction::Hash {
             // Each range carries the handler's algorithm for per-range commit.
             let commit_vec = match handler.handler_type {
                 HandlerType::Sent => &mut commit_sent,

--- a/crates/sdk-core/src/handler/mod.rs
+++ b/crates/sdk-core/src/handler/mod.rs
@@ -109,7 +109,11 @@ pub fn compute_reveal(
                 HandlerType::Recv => &mut commit_recv,
             };
             for range in extracted {
-                commit_vec.push(CommitRange { range, algorithm });
+                commit_vec.push(CommitRange {
+                    start: range.start,
+                    end: range.end,
+                    algorithm,
+                });
             }
         } else {
             let reveal_vec = match handler.handler_type {

--- a/crates/sdk-core/src/handler/mod.rs
+++ b/crates/sdk-core/src/handler/mod.rs
@@ -37,7 +37,7 @@ pub struct RangeWithHandler {
 pub struct ComputeRevealOutput {
     /// The `Reveal` struct ready for `SdkProver::reveal()`.
     pub reveal: Reveal,
-    /// Ranges to hash-commit (not revealed as plaintext).
+    /// Ranges to hash-commit (the verifier receives `H(plaintext, blinder)`).
     /// `None` when no handlers use `action: HASH`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub commit: Option<Commit>,
@@ -109,11 +109,7 @@ pub fn compute_reveal(
                 HandlerType::Recv => &mut commit_recv,
             };
             for range in extracted {
-                commit_vec.push(CommitRange {
-                    start: range.start,
-                    end: range.end,
-                    algorithm: Some(algorithm),
-                });
+                commit_vec.push(CommitRange { range, algorithm });
             }
         } else {
             let reveal_vec = match handler.handler_type {

--- a/crates/sdk-core/src/handler/mod.rs
+++ b/crates/sdk-core/src/handler/mod.rs
@@ -103,8 +103,7 @@ pub fn compute_reveal(
             });
         }
 
-        if handler.action == HandlerAction::Hash {
-            // Each range carries the handler's algorithm for per-range commit.
+        if let HandlerAction::Hash { algorithm } = handler.action {
             let commit_vec = match handler.handler_type {
                 HandlerType::Sent => &mut commit_sent,
                 HandlerType::Recv => &mut commit_recv,
@@ -113,7 +112,7 @@ pub fn compute_reveal(
                 commit_vec.push(CommitRange {
                     start: range.start,
                     end: range.end,
-                    algorithm: handler.algorithm,
+                    algorithm: Some(algorithm),
                 });
             }
         } else {

--- a/crates/sdk-core/src/handler/mod.rs
+++ b/crates/sdk-core/src/handler/mod.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{Result, SdkError},
-    types::{Handler, HandlerType, Reveal},
+    types::{Commit, CommitRange, Handler, HandlerType, Reveal},
 };
 
 /// A byte range annotated with the handler that produced it.
@@ -37,6 +37,10 @@ pub struct RangeWithHandler {
 pub struct ComputeRevealOutput {
     /// The `Reveal` struct ready for `SdkProver::reveal()`.
     pub reveal: Reveal,
+    /// Ranges to hash-commit (not revealed as plaintext).
+    /// `None` when no handlers use `action: HASH`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<Commit>,
     /// Sent ranges annotated with their originating handler.
     pub sent_ranges_with_handlers: Vec<RangeWithHandler>,
     /// Received ranges annotated with their originating handler.
@@ -70,8 +74,10 @@ pub fn compute_reveal(
     let response = spansy::http::parse_response(recv)
         .map_err(|e| SdkError::handler(format!("failed to parse HTTP response: {e}")))?;
 
-    let mut sent_ranges: Vec<Range<usize>> = Vec::new();
-    let mut recv_ranges: Vec<Range<usize>> = Vec::new();
+    let mut reveal_sent: Vec<Range<usize>> = Vec::new();
+    let mut reveal_recv: Vec<Range<usize>> = Vec::new();
+    let mut commit_sent: Vec<CommitRange> = Vec::new();
+    let mut commit_recv: Vec<CommitRange> = Vec::new();
     let mut sent_with_handlers: Vec<RangeWithHandler> = Vec::new();
     let mut recv_with_handlers: Vec<RangeWithHandler> = Vec::new();
 
@@ -84,9 +90,11 @@ pub fn compute_reveal(
             HandlerType::Recv => extract::extract_ranges(handler, &recv_msg, recv)?,
         };
 
-        let (ranges_vec, with_handlers_vec) = match handler.handler_type {
-            HandlerType::Sent => (&mut sent_ranges, &mut sent_with_handlers),
-            HandlerType::Recv => (&mut recv_ranges, &mut recv_with_handlers),
+        let is_hash = handler.action.is_hash();
+
+        let with_handlers_vec = match handler.handler_type {
+            HandlerType::Sent => &mut sent_with_handlers,
+            HandlerType::Recv => &mut recv_with_handlers,
         };
 
         for range in &extracted {
@@ -96,15 +104,45 @@ pub fn compute_reveal(
                 handler: handler.clone(),
             });
         }
-        ranges_vec.extend(extracted);
+
+        if is_hash {
+            // Each range carries the handler's algorithm for per-range commit.
+            let commit_vec = match handler.handler_type {
+                HandlerType::Sent => &mut commit_sent,
+                HandlerType::Recv => &mut commit_recv,
+            };
+            for range in extracted {
+                commit_vec.push(CommitRange {
+                    start: range.start,
+                    end: range.end,
+                    algorithm: handler.algorithm,
+                });
+            }
+        } else {
+            let reveal_vec = match handler.handler_type {
+                HandlerType::Sent => &mut reveal_sent,
+                HandlerType::Recv => &mut reveal_recv,
+            };
+            reveal_vec.extend(extracted);
+        }
     }
+
+    let commit = if commit_sent.is_empty() && commit_recv.is_empty() {
+        None
+    } else {
+        Some(Commit {
+            sent: commit_sent,
+            recv: commit_recv,
+        })
+    };
 
     Ok(ComputeRevealOutput {
         reveal: Reveal {
-            sent: sent_ranges,
-            recv: recv_ranges,
+            sent: reveal_sent,
+            recv: reveal_recv,
             server_identity: true,
         },
+        commit,
         sent_ranges_with_handlers: sent_with_handlers,
         recv_ranges_with_handlers: recv_with_handlers,
     })

--- a/crates/sdk-core/src/handler/tests.rs
+++ b/crates/sdk-core/src/handler/tests.rs
@@ -478,7 +478,7 @@ fn test_handler_serde_roundtrip() {
 #[test]
 fn test_handler_serde_wire_format() {
     // Verify JSON matches what existing TypeScript plugins produce
-    let json_str = r#"{"type":"SENT","part":"BODY","action":"REVEAL","params":{"type":"json","path":"screen_name","hideKey":true}}"#;
+    let json_str = r#"{"type":"SENT","part":"BODY","action":{"kind":"REVEAL"},"params":{"type":"json","path":"screen_name","hideKey":true}}"#;
     let handler: Handler = serde_json::from_str(json_str).unwrap();
 
     assert_eq!(handler.handler_type, HandlerType::Sent);
@@ -596,7 +596,7 @@ fn test_reveal_only_has_no_commit() {
 
 #[test]
 fn test_hash_action_serde_roundtrip() {
-    let json_str = r#"{"type":"RECV","part":"BODY","action":"HASH","algorithm":"SHA256"}"#;
+    let json_str = r#"{"type":"RECV","part":"BODY","action":{"kind":"HASH","algorithm":"SHA256"}}"#;
     let handler: Handler = serde_json::from_str(json_str).unwrap();
 
     assert_eq!(
@@ -615,7 +615,7 @@ fn test_hash_action_serde_roundtrip() {
 #[test]
 fn test_hash_action_without_algorithm_errors() {
     // HASH without algorithm must fail — plugins must specify it explicitly.
-    let json_str = r#"{"type":"RECV","part":"BODY","action":"HASH"}"#;
+    let json_str = r#"{"type":"RECV","part":"BODY","action":{"kind":"HASH"}}"#;
     assert!(serde_json::from_str::<Handler>(json_str).is_err());
 }
 

--- a/crates/sdk-core/src/handler/tests.rs
+++ b/crates/sdk-core/src/handler/tests.rs
@@ -620,13 +620,6 @@ fn test_reveal_only_has_no_commit() {
 }
 
 #[test]
-fn test_pedersen_alias_deserializes_to_hash() {
-    let json_str = r#"{"type":"RECV","part":"BODY","action":"PEDERSEN"}"#;
-    let handler: Handler = serde_json::from_str(json_str).unwrap();
-    assert!(handler.action.is_hash());
-}
-
-#[test]
 fn test_hash_action_serde_roundtrip() {
     let json_str = r#"{"type":"RECV","part":"BODY","action":"HASH","algorithm":"SHA256"}"#;
     let handler: Handler = serde_json::from_str(json_str).unwrap();

--- a/crates/sdk-core/src/handler/tests.rs
+++ b/crates/sdk-core/src/handler/tests.rs
@@ -37,7 +37,6 @@ fn test_start_line_request() {
         part: HandlerPart::StartLine,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -56,7 +55,6 @@ fn test_start_line_response() {
         part: HandlerPart::StartLine,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -74,7 +72,6 @@ fn test_method() {
         part: HandlerPart::Method,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -88,7 +85,6 @@ fn test_request_target() {
         part: HandlerPart::RequestTarget,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -102,7 +98,6 @@ fn test_status_code() {
         part: HandlerPart::StatusCode,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -119,7 +114,6 @@ fn test_method_on_response_errors() {
             part: HandlerPart::Method,
             action: HandlerAction::Reveal,
             params: None,
-            algorithm: None,
         }],
     );
     assert!(result.is_err());
@@ -135,7 +129,6 @@ fn test_status_code_on_request_errors() {
             part: HandlerPart::StatusCode,
             action: HandlerAction::Reveal,
             params: None,
-            algorithm: None,
         }],
     );
     assert!(result.is_err());
@@ -150,7 +143,6 @@ fn test_protocol_request() {
         part: HandlerPart::Protocol,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -172,7 +164,6 @@ fn test_headers_all() {
         part: HandlerPart::Headers,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -193,7 +184,6 @@ fn test_headers_specific_key() {
             key: Some("Host".to_string()),
             ..Default::default()
         }),
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -216,7 +206,6 @@ fn test_headers_hide_key() {
             hide_key: Some(true),
             ..Default::default()
         }),
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -238,7 +227,6 @@ fn test_headers_hide_value() {
             hide_value: Some(true),
             ..Default::default()
         }),
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -264,7 +252,6 @@ fn test_headers_hide_both_errors() {
                 hide_value: Some(true),
                 ..Default::default()
             }),
-            algorithm: None,
         }],
     );
     assert!(result.is_err());
@@ -279,7 +266,6 @@ fn test_body_entire() {
         part: HandlerPart::Body,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -300,7 +286,6 @@ fn test_body_json_path() {
             path: Some("screen_name".to_string()),
             ..Default::default()
         }),
-        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -322,7 +307,6 @@ fn test_body_json_hide_key() {
             hide_key: Some(true),
             ..Default::default()
         }),
-        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -345,7 +329,6 @@ fn test_body_json_hide_value() {
             hide_value: Some(true),
             ..Default::default()
         }),
-        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -365,7 +348,6 @@ fn test_all_entire() {
         part: HandlerPart::All,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     });
 
     assert_eq!(output.reveal.sent.len(), 1);
@@ -383,7 +365,6 @@ fn test_all_regex() {
             regex: Some(r"Bearer [A-Za-z0-9\-]+".to_string()),
             ..Default::default()
         }),
-        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -401,14 +382,12 @@ fn test_multiple_handlers() {
             part: HandlerPart::StartLine,
             action: HandlerAction::Reveal,
             params: None,
-            algorithm: None,
         },
         Handler {
             handler_type: HandlerType::Recv,
             part: HandlerPart::StatusCode,
             action: HandlerAction::Reveal,
             params: None,
-            algorithm: None,
         },
         Handler {
             handler_type: HandlerType::Recv,
@@ -420,7 +399,6 @@ fn test_multiple_handlers() {
                 hide_key: Some(true),
                 ..Default::default()
             }),
-            algorithm: None,
         },
     ];
 
@@ -464,7 +442,6 @@ fn test_json_body_dot_notation_array() {
                 path: Some("items.0.name".to_string()),
                 ..Default::default()
             }),
-            algorithm: None,
         }],
     )
     .unwrap();
@@ -491,7 +468,6 @@ fn test_handler_serde_roundtrip() {
             hide_key: Some(true),
             ..Default::default()
         }),
-        algorithm: None,
     };
 
     let json = serde_json::to_string(&handler).unwrap();
@@ -534,7 +510,6 @@ fn test_handler_serde_all_parts() {
             part,
             action: HandlerAction::Reveal,
             params: None,
-            algorithm: None,
         };
         let json = serde_json::to_value(&handler).unwrap();
         assert_eq!(
@@ -555,19 +530,19 @@ fn test_hash_action_splits_ranges() {
             part: HandlerPart::StartLine,
             action: HandlerAction::Reveal,
             params: None,
-            algorithm: None,
         },
         Handler {
             handler_type: HandlerType::Recv,
             part: HandlerPart::Body,
-            action: HandlerAction::Hash,
+            action: HandlerAction::Hash {
+                algorithm: HashAlgorithm::Blake3,
+            },
             params: Some(HandlerParams {
                 content_type: Some("json".to_string()),
                 path: Some("screen_name".to_string()),
                 hide_key: Some(true),
                 ..Default::default()
             }),
-            algorithm: None,
         },
     ];
 
@@ -583,8 +558,8 @@ fn test_hash_action_splits_ranges() {
         .expect("commit should be Some when HASH handlers are used");
     assert!(!commit.recv.is_empty());
     assert!(commit.sent.is_empty());
-    // Per-range algorithm is None (BLAKE3 default applied downstream)
-    assert!(commit.recv[0].algorithm.is_none());
+    // Each range carries the handler's algorithm (BLAKE3 default)
+    assert_eq!(commit.recv[0].algorithm, Some(HashAlgorithm::Blake3));
 }
 
 #[test]
@@ -592,9 +567,10 @@ fn test_hash_action_with_algorithm() {
     let handler = Handler {
         handler_type: HandlerType::Recv,
         part: HandlerPart::Body,
-        action: HandlerAction::Hash,
+        action: HandlerAction::Hash {
+            algorithm: HashAlgorithm::Sha256,
+        },
         params: None,
-        algorithm: Some(HashAlgorithm::Sha256),
     };
 
     let output = reveal_one(handler);
@@ -612,7 +588,6 @@ fn test_reveal_only_has_no_commit() {
         part: HandlerPart::Body,
         action: HandlerAction::Reveal,
         params: None,
-        algorithm: None,
     };
 
     let output = reveal_one(handler);
@@ -624,8 +599,12 @@ fn test_hash_action_serde_roundtrip() {
     let json_str = r#"{"type":"RECV","part":"BODY","action":"HASH","algorithm":"SHA256"}"#;
     let handler: Handler = serde_json::from_str(json_str).unwrap();
 
-    assert_eq!(handler.action, HandlerAction::Hash);
-    assert_eq!(handler.algorithm, Some(HashAlgorithm::Sha256));
+    assert_eq!(
+        handler.action,
+        HandlerAction::Hash {
+            algorithm: HashAlgorithm::Sha256,
+        }
+    );
 
     // Roundtrip
     let serialized = serde_json::to_string(&handler).unwrap();
@@ -635,12 +614,16 @@ fn test_hash_action_serde_roundtrip() {
 
 #[test]
 fn test_hash_action_wire_format_without_algorithm() {
-    // Plugins may send HASH without algorithm — should default to None (BLAKE3 at runtime)
+    // Plugins may send HASH without algorithm — should default to BLAKE3.
     let json_str = r#"{"type":"RECV","part":"BODY","action":"HASH"}"#;
     let handler: Handler = serde_json::from_str(json_str).unwrap();
 
-    assert_eq!(handler.action, HandlerAction::Hash);
-    assert!(handler.algorithm.is_none());
+    assert_eq!(
+        handler.action,
+        HandlerAction::Hash {
+            algorithm: HashAlgorithm::Blake3,
+        }
+    );
 }
 
 #[test]
@@ -650,24 +633,26 @@ fn test_mixed_hash_algorithms_per_range() {
         Handler {
             handler_type: HandlerType::Recv,
             part: HandlerPart::Body,
-            action: HandlerAction::Hash,
+            action: HandlerAction::Hash {
+                algorithm: HashAlgorithm::Sha256,
+            },
             params: Some(HandlerParams {
                 content_type: Some("json".to_string()),
                 path: Some("screen_name".to_string()),
                 ..Default::default()
             }),
-            algorithm: Some(HashAlgorithm::Sha256),
         },
         Handler {
             handler_type: HandlerType::Recv,
             part: HandlerPart::Body,
-            action: HandlerAction::Hash,
+            action: HandlerAction::Hash {
+                algorithm: HashAlgorithm::Keccak256,
+            },
             params: Some(HandlerParams {
                 content_type: Some("json".to_string()),
                 path: Some("verified".to_string()),
                 ..Default::default()
             }),
-            algorithm: Some(HashAlgorithm::Keccak256),
         },
     ];
 

--- a/crates/sdk-core/src/handler/tests.rs
+++ b/crates/sdk-core/src/handler/tests.rs
@@ -1,6 +1,6 @@
 //! Tests for handler-based range extraction.
 
-use crate::types::{Handler, HandlerAction, HandlerParams, HandlerPart, HandlerType};
+use crate::types::{Handler, HandlerAction, HandlerParams, HandlerPart, HandlerType, HashAlgorithm};
 
 use super::compute_reveal;
 
@@ -35,6 +35,7 @@ fn test_start_line_request() {
         part: HandlerPart::StartLine,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -53,6 +54,7 @@ fn test_start_line_response() {
         part: HandlerPart::StartLine,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -70,6 +72,7 @@ fn test_method() {
         part: HandlerPart::Method,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -83,6 +86,7 @@ fn test_request_target() {
         part: HandlerPart::RequestTarget,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -96,6 +100,7 @@ fn test_status_code() {
         part: HandlerPart::StatusCode,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -112,6 +117,7 @@ fn test_method_on_response_errors() {
             part: HandlerPart::Method,
             action: HandlerAction::Reveal,
             params: None,
+        algorithm: None,
         }],
     );
     assert!(result.is_err());
@@ -127,6 +133,7 @@ fn test_status_code_on_request_errors() {
             part: HandlerPart::StatusCode,
             action: HandlerAction::Reveal,
             params: None,
+        algorithm: None,
         }],
     );
     assert!(result.is_err());
@@ -141,6 +148,7 @@ fn test_protocol_request() {
         part: HandlerPart::Protocol,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -162,6 +170,7 @@ fn test_headers_all() {
         part: HandlerPart::Headers,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -182,6 +191,7 @@ fn test_headers_specific_key() {
             key: Some("Host".to_string()),
             ..Default::default()
         }),
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -204,6 +214,7 @@ fn test_headers_hide_key() {
             hide_key: Some(true),
             ..Default::default()
         }),
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -225,6 +236,7 @@ fn test_headers_hide_value() {
             hide_value: Some(true),
             ..Default::default()
         }),
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -250,6 +262,7 @@ fn test_headers_hide_both_errors() {
                 hide_value: Some(true),
                 ..Default::default()
             }),
+            algorithm: None,
         }],
     );
     assert!(result.is_err());
@@ -264,6 +277,7 @@ fn test_body_entire() {
         part: HandlerPart::Body,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -284,6 +298,7 @@ fn test_body_json_path() {
             path: Some("screen_name".to_string()),
             ..Default::default()
         }),
+        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -305,6 +320,7 @@ fn test_body_json_hide_key() {
             hide_key: Some(true),
             ..Default::default()
         }),
+        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -327,6 +343,7 @@ fn test_body_json_hide_value() {
             hide_value: Some(true),
             ..Default::default()
         }),
+        algorithm: None,
     });
 
     let bytes = extract_bytes(RESPONSE, &output.reveal.recv);
@@ -346,6 +363,7 @@ fn test_all_entire() {
         part: HandlerPart::All,
         action: HandlerAction::Reveal,
         params: None,
+        algorithm: None,
     });
 
     assert_eq!(output.reveal.sent.len(), 1);
@@ -363,6 +381,7 @@ fn test_all_regex() {
             regex: Some(r"Bearer [A-Za-z0-9\-]+".to_string()),
             ..Default::default()
         }),
+        algorithm: None,
     });
 
     let bytes = extract_bytes(REQUEST, &output.reveal.sent);
@@ -380,12 +399,14 @@ fn test_multiple_handlers() {
             part: HandlerPart::StartLine,
             action: HandlerAction::Reveal,
             params: None,
+        algorithm: None,
         },
         Handler {
             handler_type: HandlerType::Recv,
             part: HandlerPart::StatusCode,
             action: HandlerAction::Reveal,
             params: None,
+        algorithm: None,
         },
         Handler {
             handler_type: HandlerType::Recv,
@@ -397,6 +418,7 @@ fn test_multiple_handlers() {
                 hide_key: Some(true),
                 ..Default::default()
             }),
+            algorithm: None,
         },
     ];
 
@@ -440,6 +462,7 @@ fn test_json_body_dot_notation_array() {
                 path: Some("items.0.name".to_string()),
                 ..Default::default()
             }),
+            algorithm: None,
         }],
     )
     .unwrap();
@@ -466,6 +489,7 @@ fn test_handler_serde_roundtrip() {
             hide_key: Some(true),
             ..Default::default()
         }),
+        algorithm: None,
     };
 
     let json = serde_json::to_string(&handler).unwrap();
@@ -508,6 +532,7 @@ fn test_handler_serde_all_parts() {
             part,
             action: HandlerAction::Reveal,
             params: None,
+        algorithm: None,
         };
         let json = serde_json::to_value(&handler).unwrap();
         assert_eq!(
@@ -515,4 +540,144 @@ fn test_handler_serde_all_parts() {
             "HandlerPart::{part:?} should serialize to {expected}"
         );
     }
+}
+
+// ---- HASH action ----
+
+#[test]
+fn test_hash_action_splits_ranges() {
+    // Mix of REVEAL and HASH handlers: HASH ranges go to commit, REVEAL to reveal.
+    let handlers = vec![
+        Handler {
+            handler_type: HandlerType::Sent,
+            part: HandlerPart::StartLine,
+            action: HandlerAction::Reveal,
+            params: None,
+            algorithm: None,
+        },
+        Handler {
+            handler_type: HandlerType::Recv,
+            part: HandlerPart::Body,
+            action: HandlerAction::Hash,
+            params: Some(HandlerParams {
+                content_type: Some("json".to_string()),
+                path: Some("screen_name".to_string()),
+                hide_key: Some(true),
+                ..Default::default()
+            }),
+            algorithm: None,
+        },
+    ];
+
+    let output = compute_reveal(REQUEST, RESPONSE, &handlers).unwrap();
+
+    // Sent start line should be in reveal (action: REVEAL)
+    assert!(!output.reveal.sent.is_empty());
+    // Recv body should NOT be in reveal (action: HASH)
+    assert!(output.reveal.recv.is_empty());
+    // Commit should be present with recv ranges
+    let commit = output.commit.expect("commit should be Some when HASH handlers are used");
+    assert!(!commit.recv.is_empty());
+    assert!(commit.sent.is_empty());
+    // Per-range algorithm is None (BLAKE3 default applied downstream)
+    assert!(commit.recv[0].algorithm.is_none());
+}
+
+#[test]
+fn test_hash_action_with_algorithm() {
+    let handler = Handler {
+        handler_type: HandlerType::Recv,
+        part: HandlerPart::Body,
+        action: HandlerAction::Hash,
+        params: None,
+        algorithm: Some(HashAlgorithm::Sha256),
+    };
+
+    let output = reveal_one(handler);
+
+    let commit = output.commit.expect("commit should be Some");
+    assert!(!commit.recv.is_empty());
+    // Each range carries its handler's algorithm
+    assert_eq!(commit.recv[0].algorithm, Some(HashAlgorithm::Sha256));
+}
+
+#[test]
+fn test_reveal_only_has_no_commit() {
+    let handler = Handler {
+        handler_type: HandlerType::Recv,
+        part: HandlerPart::Body,
+        action: HandlerAction::Reveal,
+        params: None,
+        algorithm: None,
+    };
+
+    let output = reveal_one(handler);
+    assert!(output.commit.is_none());
+}
+
+#[test]
+fn test_pedersen_alias_deserializes_to_hash() {
+    let json_str = r#"{"type":"RECV","part":"BODY","action":"PEDERSEN"}"#;
+    let handler: Handler = serde_json::from_str(json_str).unwrap();
+    assert!(handler.action.is_hash());
+}
+
+#[test]
+fn test_hash_action_serde_roundtrip() {
+    let json_str = r#"{"type":"RECV","part":"BODY","action":"HASH","algorithm":"SHA256"}"#;
+    let handler: Handler = serde_json::from_str(json_str).unwrap();
+
+    assert_eq!(handler.action, HandlerAction::Hash);
+    assert_eq!(handler.algorithm, Some(HashAlgorithm::Sha256));
+
+    // Roundtrip
+    let serialized = serde_json::to_string(&handler).unwrap();
+    let deserialized: Handler = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(handler, deserialized);
+}
+
+#[test]
+fn test_hash_action_wire_format_without_algorithm() {
+    // Plugins may send HASH without algorithm — should default to None (BLAKE3 at runtime)
+    let json_str = r#"{"type":"RECV","part":"BODY","action":"HASH"}"#;
+    let handler: Handler = serde_json::from_str(json_str).unwrap();
+
+    assert_eq!(handler.action, HandlerAction::Hash);
+    assert!(handler.algorithm.is_none());
+}
+
+#[test]
+fn test_mixed_hash_algorithms_per_range() {
+    // Two HASH handlers with different algorithms produce per-range algorithms.
+    let handlers = vec![
+        Handler {
+            handler_type: HandlerType::Recv,
+            part: HandlerPart::Body,
+            action: HandlerAction::Hash,
+            params: Some(HandlerParams {
+                content_type: Some("json".to_string()),
+                path: Some("screen_name".to_string()),
+                ..Default::default()
+            }),
+            algorithm: Some(HashAlgorithm::Sha256),
+        },
+        Handler {
+            handler_type: HandlerType::Recv,
+            part: HandlerPart::Body,
+            action: HandlerAction::Hash,
+            params: Some(HandlerParams {
+                content_type: Some("json".to_string()),
+                path: Some("verified".to_string()),
+                ..Default::default()
+            }),
+            algorithm: Some(HashAlgorithm::Keccak256),
+        },
+    ];
+
+    let output = compute_reveal(REQUEST, RESPONSE, &handlers).unwrap();
+    let commit = output.commit.expect("commit should be Some");
+
+    assert_eq!(commit.recv.len(), 2);
+    assert_eq!(commit.recv[0].algorithm, Some(HashAlgorithm::Sha256));
+    assert_eq!(commit.recv[1].algorithm, Some(HashAlgorithm::Keccak256));
 }

--- a/crates/sdk-core/src/handler/tests.rs
+++ b/crates/sdk-core/src/handler/tests.rs
@@ -1,6 +1,8 @@
 //! Tests for handler-based range extraction.
 
-use crate::types::{Handler, HandlerAction, HandlerParams, HandlerPart, HandlerType, HashAlgorithm};
+use crate::types::{
+    Handler, HandlerAction, HandlerParams, HandlerPart, HandlerType, HashAlgorithm,
+};
 
 use super::compute_reveal;
 
@@ -117,7 +119,7 @@ fn test_method_on_response_errors() {
             part: HandlerPart::Method,
             action: HandlerAction::Reveal,
             params: None,
-        algorithm: None,
+            algorithm: None,
         }],
     );
     assert!(result.is_err());
@@ -133,7 +135,7 @@ fn test_status_code_on_request_errors() {
             part: HandlerPart::StatusCode,
             action: HandlerAction::Reveal,
             params: None,
-        algorithm: None,
+            algorithm: None,
         }],
     );
     assert!(result.is_err());
@@ -399,14 +401,14 @@ fn test_multiple_handlers() {
             part: HandlerPart::StartLine,
             action: HandlerAction::Reveal,
             params: None,
-        algorithm: None,
+            algorithm: None,
         },
         Handler {
             handler_type: HandlerType::Recv,
             part: HandlerPart::StatusCode,
             action: HandlerAction::Reveal,
             params: None,
-        algorithm: None,
+            algorithm: None,
         },
         Handler {
             handler_type: HandlerType::Recv,
@@ -532,7 +534,7 @@ fn test_handler_serde_all_parts() {
             part,
             action: HandlerAction::Reveal,
             params: None,
-        algorithm: None,
+            algorithm: None,
         };
         let json = serde_json::to_value(&handler).unwrap();
         assert_eq!(
@@ -576,7 +578,9 @@ fn test_hash_action_splits_ranges() {
     // Recv body should NOT be in reveal (action: HASH)
     assert!(output.reveal.recv.is_empty());
     // Commit should be present with recv ranges
-    let commit = output.commit.expect("commit should be Some when HASH handlers are used");
+    let commit = output
+        .commit
+        .expect("commit should be Some when HASH handlers are used");
     assert!(!commit.recv.is_empty());
     assert!(commit.sent.is_empty());
     // Per-range algorithm is None (BLAKE3 default applied downstream)

--- a/crates/sdk-core/src/handler/tests.rs
+++ b/crates/sdk-core/src/handler/tests.rs
@@ -559,7 +559,7 @@ fn test_hash_action_splits_ranges() {
     assert!(!commit.recv.is_empty());
     assert!(commit.sent.is_empty());
     // Each range carries the handler's algorithm (BLAKE3 default)
-    assert_eq!(commit.recv[0].algorithm, Some(HashAlgorithm::Blake3));
+    assert_eq!(commit.recv[0].algorithm, HashAlgorithm::Blake3);
 }
 
 #[test]
@@ -578,7 +578,7 @@ fn test_hash_action_with_algorithm() {
     let commit = output.commit.expect("commit should be Some");
     assert!(!commit.recv.is_empty());
     // Each range carries its handler's algorithm
-    assert_eq!(commit.recv[0].algorithm, Some(HashAlgorithm::Sha256));
+    assert_eq!(commit.recv[0].algorithm, HashAlgorithm::Sha256);
 }
 
 #[test]
@@ -613,17 +613,10 @@ fn test_hash_action_serde_roundtrip() {
 }
 
 #[test]
-fn test_hash_action_wire_format_without_algorithm() {
-    // Plugins may send HASH without algorithm — should default to BLAKE3.
+fn test_hash_action_without_algorithm_errors() {
+    // HASH without algorithm must fail — plugins must specify it explicitly.
     let json_str = r#"{"type":"RECV","part":"BODY","action":"HASH"}"#;
-    let handler: Handler = serde_json::from_str(json_str).unwrap();
-
-    assert_eq!(
-        handler.action,
-        HandlerAction::Hash {
-            algorithm: HashAlgorithm::Blake3,
-        }
-    );
+    assert!(serde_json::from_str::<Handler>(json_str).is_err());
 }
 
 #[test]
@@ -660,6 +653,6 @@ fn test_mixed_hash_algorithms_per_range() {
     let commit = output.commit.expect("commit should be Some");
 
     assert_eq!(commit.recv.len(), 2);
-    assert_eq!(commit.recv[0].algorithm, Some(HashAlgorithm::Sha256));
-    assert_eq!(commit.recv[1].algorithm, Some(HashAlgorithm::Keccak256));
+    assert_eq!(commit.recv[0].algorithm, HashAlgorithm::Sha256);
+    assert_eq!(commit.recv[1].algorithm, HashAlgorithm::Keccak256);
 }

--- a/crates/sdk-core/src/lib.rs
+++ b/crates/sdk-core/src/lib.rs
@@ -58,8 +58,8 @@ pub use handler::compute_reveal;
 pub use io::{HyperIo, Io};
 pub use prover::SdkProver;
 pub use types::{
-    Body, ConnectionInfo, Handler, HandlerAction, HandlerParams, HandlerPart, HandlerType,
-    HttpRequest, HttpResponse, Method, PartialTranscript, Reveal, TlsVersion, Transcript,
-    TranscriptLength, VerifierOutput,
+    Body, Commit, CommitRange, ConnectionInfo, Handler, HandlerAction, HandlerParams, HandlerPart,
+    HandlerType, HashAlgorithm, HttpRequest, HttpResponse, Method, PartialTranscript, Reveal,
+    TlsVersion, Transcript, TranscriptLength, VerifierOutput,
 };
 pub use verifier::SdkVerifier;

--- a/crates/sdk-core/src/lib.rs
+++ b/crates/sdk-core/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! // Get transcript and reveal data.
 //! let transcript = prover.transcript()?;
-//! prover.reveal(Reveal::new().recv(0..100).server_identity(true)).await?;
+//! prover.reveal(Reveal::new().recv(0..100).server_identity(true), None).await?;
 //! ```
 
 #![deny(missing_docs, unreachable_pub, unused_must_use, clippy::all)]

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -290,7 +290,7 @@ impl SdkProver {
                     let alg: tlsn_core::hash::HashAlgId = cr.algorithm.into();
                     let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
                     commit_builder
-                        .commit_with_kind(cr.range.clone(), direction, kind)
+                        .commit_with_kind(cr.range(), direction, kind)
                         .map_err(|e| SdkError::handler(e.to_string()))?;
                 }
             }

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -284,22 +284,22 @@ impl SdkProver {
                 tlsn_core::transcript::TranscriptCommitConfig::builder(prover.transcript());
 
             for cr in &commit.sent {
-                let alg: tlsn_core::hash::HashAlgId = cr.algorithm.unwrap_or_default().into();
+                let alg: tlsn_core::hash::HashAlgId = cr.algorithm.into();
                 let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
                 commit_builder
                     .commit_with_kind(
-                        cr.start..cr.end,
+                        cr.range.clone(),
                         tlsn_core::transcript::Direction::Sent,
                         kind,
                     )
                     .map_err(|e| SdkError::handler(e.to_string()))?;
             }
             for cr in &commit.recv {
-                let alg: tlsn_core::hash::HashAlgId = cr.algorithm.unwrap_or_default().into();
+                let alg: tlsn_core::hash::HashAlgId = cr.algorithm.into();
                 let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
                 commit_builder
                     .commit_with_kind(
-                        cr.start..cr.end,
+                        cr.range.clone(),
                         tlsn_core::transcript::Direction::Received,
                         kind,
                     )

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -284,10 +284,8 @@ impl SdkProver {
                 tlsn_core::transcript::TranscriptCommitConfig::builder(prover.transcript());
 
             for cr in &commit.sent {
-                let alg: tlsn_core::hash::HashAlgId =
-                    cr.algorithm.unwrap_or_default().into();
-                let kind =
-                    tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
+                let alg: tlsn_core::hash::HashAlgId = cr.algorithm.unwrap_or_default().into();
+                let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
                 commit_builder
                     .commit_with_kind(
                         cr.start..cr.end,
@@ -297,10 +295,8 @@ impl SdkProver {
                     .map_err(|e| SdkError::handler(e.to_string()))?;
             }
             for cr in &commit.recv {
-                let alg: tlsn_core::hash::HashAlgId =
-                    cr.algorithm.unwrap_or_default().into();
-                let kind =
-                    tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
+                let alg: tlsn_core::hash::HashAlgId = cr.algorithm.unwrap_or_default().into();
+                let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
                 commit_builder
                     .commit_with_kind(
                         cr.start..cr.end,

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -252,7 +252,11 @@ impl SdkProver {
     }
 
     /// Reveals data to the verifier and finalizes the protocol.
-    pub async fn reveal(&mut self, reveal: Reveal) -> Result<()> {
+    ///
+    /// Optionally accepts a [`Commit`] with ranges to hash-commit (blinded,
+    /// not revealed as plaintext). The commit ranges are processed via the
+    /// TLSNotary hash-commitment path (`prove_hash`).
+    pub async fn reveal(&mut self, reveal: Reveal, commit: Option<Commit>) -> Result<()> {
         let State::Committed { mut prover, handle } = self.state.take() else {
             return Err(SdkError::invalid_state("prover is not in committed state"));
         };
@@ -271,6 +275,46 @@ impl SdkProver {
 
         if reveal.server_identity {
             builder.server_identity();
+        }
+
+        // Build transcript commit config for hash-commitment ranges.
+        // Each range carries its own algorithm (defaulting to BLAKE3).
+        if let Some(commit) = commit {
+            let mut commit_builder =
+                tlsn_core::transcript::TranscriptCommitConfig::builder(prover.transcript());
+
+            for cr in &commit.sent {
+                let alg: tlsn_core::hash::HashAlgId =
+                    cr.algorithm.unwrap_or_default().into();
+                let kind =
+                    tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
+                commit_builder
+                    .commit_with_kind(
+                        cr.start..cr.end,
+                        tlsn_core::transcript::Direction::Sent,
+                        kind,
+                    )
+                    .map_err(|e| SdkError::handler(e.to_string()))?;
+            }
+            for cr in &commit.recv {
+                let alg: tlsn_core::hash::HashAlgId =
+                    cr.algorithm.unwrap_or_default().into();
+                let kind =
+                    tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
+                commit_builder
+                    .commit_with_kind(
+                        cr.start..cr.end,
+                        tlsn_core::transcript::Direction::Received,
+                        kind,
+                    )
+                    .map_err(|e| SdkError::handler(e.to_string()))?;
+            }
+
+            builder.transcript_commit(
+                commit_builder
+                    .build()
+                    .map_err(|e| SdkError::handler(e.to_string()))?,
+            );
         }
 
         let config = builder.build()?;

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -291,14 +291,14 @@ impl SdkProver {
                     let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
                     commit_builder
                         .commit_with_kind(cr.range(), direction, kind)
-                        .map_err(|e| SdkError::handler(e.to_string()))?;
+                        .map_err(|e| SdkError::config(e.to_string()))?;
                 }
             }
 
             builder.transcript_commit(
                 commit_builder
                     .build()
-                    .map_err(|e| SdkError::handler(e.to_string()))?,
+                    .map_err(|e| SdkError::config(e.to_string()))?,
             );
         }
 

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -278,32 +278,21 @@ impl SdkProver {
         }
 
         // Build transcript commit config for hash-commitment ranges.
-        // Each range carries its own algorithm (defaulting to BLAKE3).
         if let Some(commit) = commit {
             let mut commit_builder =
                 tlsn_core::transcript::TranscriptCommitConfig::builder(prover.transcript());
 
-            for cr in &commit.sent {
-                let alg: tlsn_core::hash::HashAlgId = cr.algorithm.into();
-                let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
-                commit_builder
-                    .commit_with_kind(
-                        cr.range.clone(),
-                        tlsn_core::transcript::Direction::Sent,
-                        kind,
-                    )
-                    .map_err(|e| SdkError::handler(e.to_string()))?;
-            }
-            for cr in &commit.recv {
-                let alg: tlsn_core::hash::HashAlgId = cr.algorithm.into();
-                let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
-                commit_builder
-                    .commit_with_kind(
-                        cr.range.clone(),
-                        tlsn_core::transcript::Direction::Received,
-                        kind,
-                    )
-                    .map_err(|e| SdkError::handler(e.to_string()))?;
+            for (ranges, direction) in [
+                (&commit.sent, tlsn_core::transcript::Direction::Sent),
+                (&commit.recv, tlsn_core::transcript::Direction::Received),
+            ] {
+                for cr in ranges {
+                    let alg: tlsn_core::hash::HashAlgId = cr.algorithm.into();
+                    let kind = tlsn_core::transcript::TranscriptCommitmentKind::Hash { alg };
+                    commit_builder
+                        .commit_with_kind(cr.range.clone(), direction, kind)
+                        .map_err(|e| SdkError::handler(e.to_string()))?;
+                }
             }
 
             builder.transcript_commit(

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -370,7 +370,7 @@ impl From<HashAlgorithm> for tlsn_core::hash::HashAlgId {
 
 /// What action to take with the matched ranges.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "action", rename_all = "UPPERCASE")]
+#[serde(tag = "kind", rename_all = "UPPERCASE")]
 pub enum HandlerAction {
     /// Reveal the data in plaintext.
     Reveal,
@@ -420,8 +420,10 @@ pub struct Handler {
     pub handler_type: HandlerType,
     /// Which part of the HTTP message to target.
     pub part: HandlerPart,
-    /// What action to take (reveal plaintext or hash-commit).
-    #[serde(flatten)]
+    /// What action to take (reveal plaintext or hash-commit). Serialized as a
+    /// nested object with a `kind` discriminant so that action-specific fields
+    /// (e.g. `algorithm` for hash) are namespaced under `action` rather than
+    /// scattered across the handler.
     pub action: HandlerAction,
     /// Optional parameters for fine-grained control.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -240,8 +240,8 @@ impl From<tlsn::transcript::PartialTranscript> for PartialTranscript {
 
 /// A byte range paired with a hash algorithm for commitment.
 ///
-/// Uses flat `start`/`end` fields so the JS wire format matches
-/// [`crate::wasm::CommitRange`] in the wasm crate without conversion.
+/// Uses flat `start`/`end` fields so the JS wire format matches the wasm
+/// crate's `CommitRange` without conversion.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitRange {
     /// Start of the byte range (inclusive).

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -368,17 +368,8 @@ pub enum HandlerAction {
     Reveal,
     /// Hash-commit to the data (blinded, never revealed as plaintext).
     Hash,
-    /// Deprecated alias for `Hash`. Kept for backward compatibility.
-    #[serde(alias = "PEDERSEN")]
-    Pedersen,
 }
 
-impl HandlerAction {
-    /// Returns `true` if this action is a hash commitment (Hash or Pedersen).
-    pub fn is_hash(&self) -> bool {
-        matches!(self, Self::Hash | Self::Pedersen)
-    }
-}
 
 /// Optional parameters for a handler.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -241,14 +241,10 @@ impl From<tlsn::transcript::PartialTranscript> for PartialTranscript {
 /// A byte range paired with a hash algorithm for commitment.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitRange {
-    /// Start of the byte range (inclusive).
-    pub start: usize,
-    /// End of the byte range (exclusive).
-    pub end: usize,
-    /// Hash algorithm to use for this range. Defaults to BLAKE3 if not
-    /// specified.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub algorithm: Option<HashAlgorithm>,
+    /// Byte range to commit.
+    pub range: Range<usize>,
+    /// Hash algorithm to use for this range.
+    pub algorithm: HashAlgorithm,
 }
 
 /// Ranges of data to hash-commit.
@@ -339,11 +335,10 @@ pub enum HandlerPart {
 }
 
 /// Hash algorithm for hash-commitment actions.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum HashAlgorithm {
-    /// BLAKE3 hash algorithm (default).
-    #[default]
+    /// BLAKE3 hash algorithm.
     Blake3,
     /// SHA-256 hash algorithm.
     Sha256,
@@ -369,8 +364,7 @@ pub enum HandlerAction {
     Reveal,
     /// Hash-commit to the data (blinded, never revealed as plaintext).
     Hash {
-        /// Hash algorithm. Defaults to BLAKE3.
-        #[serde(default)]
+        /// Hash algorithm.
         algorithm: HashAlgorithm,
     },
 }

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -239,12 +239,24 @@ impl From<tlsn::transcript::PartialTranscript> for PartialTranscript {
 }
 
 /// A byte range paired with a hash algorithm for commitment.
+///
+/// Uses flat `start`/`end` fields so the JS wire format matches
+/// [`crate::wasm::CommitRange`] in the wasm crate without conversion.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitRange {
-    /// Byte range to commit.
-    pub range: Range<usize>,
+    /// Start of the byte range (inclusive).
+    pub start: usize,
+    /// End of the byte range (exclusive).
+    pub end: usize,
     /// Hash algorithm to use for this range.
     pub algorithm: HashAlgorithm,
+}
+
+impl CommitRange {
+    /// Returns the byte range as a [`Range<usize>`].
+    pub fn range(&self) -> Range<usize> {
+        self.start..self.end
+    }
 }
 
 /// Ranges of data to hash-commit.

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -238,13 +238,25 @@ impl From<tlsn::transcript::PartialTranscript> for PartialTranscript {
     }
 }
 
-/// Ranges of data to commit.
+/// A byte range paired with a hash algorithm for commitment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitRange {
+    /// Start of the byte range (inclusive).
+    pub start: usize,
+    /// End of the byte range (exclusive).
+    pub end: usize,
+    /// Hash algorithm to use for this range. Defaults to BLAKE3 if not specified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub algorithm: Option<HashAlgorithm>,
+}
+
+/// Ranges of data to hash-commit.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Commit {
-    /// Ranges of sent data to commit.
-    pub sent: Vec<Range<usize>>,
-    /// Ranges of received data to commit.
-    pub recv: Vec<Range<usize>>,
+    /// Ranges of sent data to commit, each with its own algorithm.
+    pub sent: Vec<CommitRange>,
+    /// Ranges of received data to commit, each with its own algorithm.
+    pub recv: Vec<CommitRange>,
 }
 
 /// Ranges of data to reveal.
@@ -325,14 +337,52 @@ pub enum HandlerPart {
     All,
 }
 
+/// Hash algorithm for hash-commitment actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HashAlgorithm {
+    /// BLAKE3 hash algorithm (default).
+    Blake3,
+    /// SHA-256 hash algorithm.
+    Sha256,
+    /// Keccak-256 hash algorithm.
+    Keccak256,
+}
+
+impl Default for HashAlgorithm {
+    fn default() -> Self {
+        Self::Blake3
+    }
+}
+
+impl From<HashAlgorithm> for tlsn_core::hash::HashAlgId {
+    fn from(alg: HashAlgorithm) -> Self {
+        match alg {
+            HashAlgorithm::Blake3 => tlsn_core::hash::HashAlgId::BLAKE3,
+            HashAlgorithm::Sha256 => tlsn_core::hash::HashAlgId::SHA256,
+            HashAlgorithm::Keccak256 => tlsn_core::hash::HashAlgId::KECCAK256,
+        }
+    }
+}
+
 /// What action to take with the matched ranges.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum HandlerAction {
     /// Reveal the data in plaintext.
     Reveal,
-    /// Commit to the data with a Pedersen hash.
+    /// Hash-commit to the data (blinded, never revealed as plaintext).
+    Hash,
+    /// Deprecated alias for `Hash`. Kept for backward compatibility.
+    #[serde(alias = "PEDERSEN")]
     Pedersen,
+}
+
+impl HandlerAction {
+    /// Returns `true` if this action is a hash commitment (Hash or Pedersen).
+    pub fn is_hash(&self) -> bool {
+        matches!(self, Self::Hash | Self::Pedersen)
+    }
 }
 
 /// Optional parameters for a handler.
@@ -366,7 +416,7 @@ pub struct HandlerParams {
 ///
 /// Handlers are used by plugins to control selective disclosure in TLS proofs.
 /// Each handler targets a specific part of the HTTP message and specifies
-/// whether to reveal or commit to the data.
+/// whether to reveal or hash-commit the data.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Handler {
     /// Direction: sent (request) or received (response).
@@ -374,11 +424,15 @@ pub struct Handler {
     pub handler_type: HandlerType,
     /// Which part of the HTTP message to target.
     pub part: HandlerPart,
-    /// What action to take (reveal or Pedersen commitment).
+    /// What action to take (reveal plaintext or hash-commit).
     pub action: HandlerAction,
     /// Optional parameters for fine-grained control.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<HandlerParams>,
+    /// Hash algorithm for HASH actions. Ignored when action is Reveal.
+    /// Defaults to BLAKE3.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub algorithm: Option<HashAlgorithm>,
 }
 
 /// Output from the verifier.

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -245,7 +245,8 @@ pub struct CommitRange {
     pub start: usize,
     /// End of the byte range (exclusive).
     pub end: usize,
-    /// Hash algorithm to use for this range. Defaults to BLAKE3 if not specified.
+    /// Hash algorithm to use for this range. Defaults to BLAKE3 if not
+    /// specified.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub algorithm: Option<HashAlgorithm>,
 }
@@ -362,14 +363,17 @@ impl From<HashAlgorithm> for tlsn_core::hash::HashAlgId {
 
 /// What action to take with the matched ranges.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
+#[serde(tag = "action", rename_all = "UPPERCASE")]
 pub enum HandlerAction {
     /// Reveal the data in plaintext.
     Reveal,
     /// Hash-commit to the data (blinded, never revealed as plaintext).
-    Hash,
+    Hash {
+        /// Hash algorithm. Defaults to BLAKE3.
+        #[serde(default)]
+        algorithm: HashAlgorithm,
+    },
 }
-
 
 /// Optional parameters for a handler.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -411,14 +415,11 @@ pub struct Handler {
     /// Which part of the HTTP message to target.
     pub part: HandlerPart,
     /// What action to take (reveal plaintext or hash-commit).
+    #[serde(flatten)]
     pub action: HandlerAction,
     /// Optional parameters for fine-grained control.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<HandlerParams>,
-    /// Hash algorithm for HASH actions. Ignored when action is Reveal.
-    /// Defaults to BLAKE3.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub algorithm: Option<HashAlgorithm>,
 }
 
 /// Output from the verifier.

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -338,21 +338,16 @@ pub enum HandlerPart {
 }
 
 /// Hash algorithm for hash-commitment actions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum HashAlgorithm {
     /// BLAKE3 hash algorithm (default).
+    #[default]
     Blake3,
     /// SHA-256 hash algorithm.
     Sha256,
     /// Keccak-256 hash algorithm.
     Keccak256,
-}
-
-impl Default for HashAlgorithm {
-    fn default() -> Self {
-        Self::Blake3
-    }
 }
 
 impl From<HashAlgorithm> for tlsn_core::hash::HashAlgId {

--- a/crates/wasm/src/handler.rs
+++ b/crates/wasm/src/handler.rs
@@ -31,8 +31,7 @@ pub fn compute_reveal(sent: &[u8], recv: &[u8], handlers: JsValue) -> Result<JsV
     let output = tlsn_sdk_core::compute_reveal(sent, recv, &handlers)
         .map_err(|e| JsError::new(&e.to_string()))?;
 
-    // Use the JSON-compatible serializer so Handler (which uses
-    // `#[serde(flatten)]` on its action field) produces plain JS Objects
+    // Use the JSON-compatible serializer so Handler produces plain JS Objects
     // instead of `Map` instances. `JSON.stringify(Map)` returns "{}", so a
     // non-Object handler would silently lose all its fields when the
     // extension forwards the reveal_config to the verifier over WebSocket.

--- a/crates/wasm/src/handler.rs
+++ b/crates/wasm/src/handler.rs
@@ -3,6 +3,7 @@
 //! Exposes [`compute_reveal`] to JavaScript, which parses HTTP transcripts
 //! and maps plugin handlers to byte ranges for selective disclosure.
 
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 /// Parses HTTP request/response transcripts and maps handlers to byte ranges.
@@ -30,5 +31,13 @@ pub fn compute_reveal(sent: &[u8], recv: &[u8], handlers: JsValue) -> Result<JsV
     let output = tlsn_sdk_core::compute_reveal(sent, recv, &handlers)
         .map_err(|e| JsError::new(&e.to_string()))?;
 
-    serde_wasm_bindgen::to_value(&output).map_err(|e| JsError::new(&e.to_string()))
+    // Use the JSON-compatible serializer so Handler (which uses
+    // `#[serde(flatten)]` on its action field) produces plain JS Objects
+    // instead of `Map` instances. `JSON.stringify(Map)` returns "{}", so a
+    // non-Object handler would silently lose all its fields when the
+    // extension forwards the reveal_config to the verifier over WebSocket.
+    let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+    output
+        .serialize(&serializer)
+        .map_err(|e| JsError::new(&e.to_string()))
 }

--- a/crates/wasm/src/handler.rs
+++ b/crates/wasm/src/handler.rs
@@ -21,6 +21,7 @@ use wasm_bindgen::prelude::*;
 /// - `sentRanges` / `recvRanges`: byte ranges for `Prover.reveal()`
 /// - `sentRangesWithHandlers` / `recvRangesWithHandlers`: ranges annotated with
 ///   handlers
+/// - `commit` (optional): ranges to hash-commit, with per-range algorithm
 #[wasm_bindgen(js_name = compute_reveal)]
 pub fn compute_reveal(sent: &[u8], recv: &[u8], handlers: JsValue) -> Result<JsValue, JsError> {
     let handlers: Vec<tlsn_sdk_core::Handler> = serde_wasm_bindgen::from_value(handlers)

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -120,17 +120,11 @@ impl JsProver {
     ///
     /// Optionally accepts a `Commit` object with ranges to hash-commit.
     /// Pass `undefined` or omit the second argument for reveal-only proofs.
-    pub async fn reveal(&mut self, reveal: Reveal, commit: JsValue) -> Result<()> {
+    pub async fn reveal(&mut self, reveal: Reveal, commit: Option<Commit>) -> Result<()> {
         self.emit_progress("REVEAL", 0.7, "Proving and revealing data...");
 
         let core_reveal = convert_reveal(reveal);
-        let core_commit = if commit.is_undefined() || commit.is_null() {
-            None
-        } else {
-            let wasm_commit: Commit = serde_wasm_bindgen::from_value(commit)
-                .map_err(|e| JsError::new(&format!("invalid commit: {e}")))?;
-            Some(convert_commit(wasm_commit))
-        };
+        let core_commit = commit.map(convert_commit);
 
         self.inner
             .reveal(core_reveal, core_commit)

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -117,12 +117,23 @@ impl JsProver {
     }
 
     /// Reveals data to the verifier and finalizes the protocol.
-    pub async fn reveal(&mut self, reveal: Reveal) -> Result<()> {
+    ///
+    /// Optionally accepts a `Commit` object with ranges to hash-commit.
+    /// Pass `undefined` or omit the second argument for reveal-only proofs.
+    pub async fn reveal(&mut self, reveal: Reveal, commit: JsValue) -> Result<()> {
         self.emit_progress("REVEAL", 0.7, "Proving and revealing data...");
 
         let core_reveal = convert_reveal(reveal);
+        let core_commit = if commit.is_undefined() || commit.is_null() {
+            None
+        } else {
+            let wasm_commit: Commit = serde_wasm_bindgen::from_value(commit)
+                .map_err(|e| JsError::new(&format!("invalid commit: {e}")))?;
+            Some(convert_commit(wasm_commit))
+        };
+
         self.inner
-            .reveal(core_reveal)
+            .reveal(core_reveal, core_commit)
             .await
             .map_err(|e| JsError::new(&e.to_string()))?;
 
@@ -215,6 +226,29 @@ fn convert_transcript(transcript: tlsn_sdk_core::Transcript) -> Transcript {
     Transcript {
         sent: transcript.sent,
         recv: transcript.recv,
+    }
+}
+
+fn convert_hash_algorithm(alg: HashAlgorithm) -> tlsn_sdk_core::HashAlgorithm {
+    match alg {
+        HashAlgorithm::BLAKE3 => tlsn_sdk_core::HashAlgorithm::Blake3,
+        HashAlgorithm::SHA256 => tlsn_sdk_core::HashAlgorithm::Sha256,
+        HashAlgorithm::KECCAK256 => tlsn_sdk_core::HashAlgorithm::Keccak256,
+    }
+}
+
+fn convert_commit_range(cr: CommitRange) -> tlsn_sdk_core::CommitRange {
+    tlsn_sdk_core::CommitRange {
+        start: cr.start,
+        end: cr.end,
+        algorithm: cr.algorithm.map(convert_hash_algorithm),
+    }
+}
+
+fn convert_commit(commit: Commit) -> tlsn_sdk_core::Commit {
+    tlsn_sdk_core::Commit {
+        sent: commit.sent.into_iter().map(convert_commit_range).collect(),
+        recv: commit.recv.into_iter().map(convert_commit_range).collect(),
     }
 }
 

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -239,7 +239,8 @@ fn convert_hash_algorithm(alg: HashAlgorithm) -> tlsn_sdk_core::HashAlgorithm {
 
 fn convert_commit_range(cr: CommitRange) -> tlsn_sdk_core::CommitRange {
     tlsn_sdk_core::CommitRange {
-        range: cr.start..cr.end,
+        start: cr.start,
+        end: cr.end,
         algorithm: convert_hash_algorithm(cr.algorithm),
     }
 }

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -239,9 +239,8 @@ fn convert_hash_algorithm(alg: HashAlgorithm) -> tlsn_sdk_core::HashAlgorithm {
 
 fn convert_commit_range(cr: CommitRange) -> tlsn_sdk_core::CommitRange {
     tlsn_sdk_core::CommitRange {
-        start: cr.start,
-        end: cr.end,
-        algorithm: cr.algorithm.map(convert_hash_algorithm),
+        range: cr.start..cr.end,
+        algorithm: convert_hash_algorithm(cr.algorithm),
     }
 }
 

--- a/crates/wasm/src/tests.rs
+++ b/crates/wasm/src/tests.rs
@@ -74,7 +74,7 @@ pub async fn test_prove() -> Result<(), JsValue> {
                 recv: vec![0..10],
                 server_identity: true,
             },
-            JsValue::UNDEFINED,
+            None,
         )
         .await?;
 

--- a/crates/wasm/src/tests.rs
+++ b/crates/wasm/src/tests.rs
@@ -68,11 +68,14 @@ pub async fn test_prove() -> Result<(), JsValue> {
         .await?;
 
     prover
-        .reveal(Reveal {
-            sent: vec![0..10],
-            recv: vec![0..10],
-            server_identity: true,
-        })
+        .reveal(
+            Reveal {
+                sent: vec![0..10],
+                recv: vec![0..10],
+                server_identity: true,
+            },
+            JsValue::UNDEFINED,
+        )
         .await?;
 
     Ok(())

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -114,7 +114,7 @@ pub struct PartialTranscript {
 #[derive(Debug, Clone, Copy, Tsify, Deserialize)]
 #[tsify(from_wasm_abi)]
 pub enum HashAlgorithm {
-    /// BLAKE3 hash algorithm (default).
+    /// BLAKE3 hash algorithm.
     BLAKE3,
     /// SHA-256 hash algorithm.
     SHA256,
@@ -130,9 +130,8 @@ pub struct CommitRange {
     pub start: usize,
     /// End of the byte range (exclusive).
     pub end: usize,
-    /// Hash algorithm to use for this range. Defaults to BLAKE3 if not
-    /// specified.
-    pub algorithm: Option<HashAlgorithm>,
+    /// Hash algorithm to use for this range.
+    pub algorithm: HashAlgorithm,
 }
 
 /// Ranges of data to hash-commit.

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -123,6 +123,10 @@ pub enum HashAlgorithm {
 }
 
 /// A byte range paired with a hash algorithm for commitment.
+///
+/// Uses explicit `start`/`end` fields (rather than `Range<usize>`) for
+/// clean JS/TS interop via tsify. Converted to the sdk-core `CommitRange`
+/// (which uses `Range<usize>`) in [`super::prover::convert_commit_range`].
 #[derive(Debug, Tsify, Deserialize)]
 #[tsify(from_wasm_abi)]
 pub struct CommitRange {

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -130,7 +130,8 @@ pub struct CommitRange {
     pub start: usize,
     /// End of the byte range (exclusive).
     pub end: usize,
-    /// Hash algorithm to use for this range. Defaults to BLAKE3 if not specified.
+    /// Hash algorithm to use for this range. Defaults to BLAKE3 if not
+    /// specified.
     pub algorithm: Option<HashAlgorithm>,
 }
 

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -110,14 +110,38 @@ pub struct PartialTranscript {
     pub recv_authed: Vec<Range<usize>>,
 }
 
-/// Ranges of data to commit.
+/// Hash algorithm for hash-commitment actions.
+#[derive(Debug, Clone, Copy, Tsify, Deserialize)]
+#[tsify(from_wasm_abi)]
+pub enum HashAlgorithm {
+    /// BLAKE3 hash algorithm (default).
+    BLAKE3,
+    /// SHA-256 hash algorithm.
+    SHA256,
+    /// Keccak-256 hash algorithm.
+    KECCAK256,
+}
+
+/// A byte range paired with a hash algorithm for commitment.
+#[derive(Debug, Tsify, Deserialize)]
+#[tsify(from_wasm_abi)]
+pub struct CommitRange {
+    /// Start of the byte range (inclusive).
+    pub start: usize,
+    /// End of the byte range (exclusive).
+    pub end: usize,
+    /// Hash algorithm to use for this range. Defaults to BLAKE3 if not specified.
+    pub algorithm: Option<HashAlgorithm>,
+}
+
+/// Ranges of data to hash-commit.
 #[derive(Debug, Tsify, Deserialize)]
 #[tsify(from_wasm_abi)]
 pub struct Commit {
-    /// Ranges of sent data to commit.
-    pub sent: Vec<Range<usize>>,
-    /// Ranges of received data to commit.
-    pub recv: Vec<Range<usize>>,
+    /// Ranges of sent data to commit, each with its own algorithm.
+    pub sent: Vec<CommitRange>,
+    /// Ranges of received data to commit, each with its own algorithm.
+    pub recv: Vec<CommitRange>,
 }
 
 /// Ranges of data to reveal.


### PR DESCRIPTION
## Summary

- Wire the `prove_hash()` path through the SDK layer so plugins can use `action: "HASH"` on handlers to hash-commit transcript ranges instead of revealing them as plaintext
- Add `HashAlgorithm` enum (Blake3/Sha256/Keccak256) — required on HASH handlers, no default
- `CommitRange` uses `Range<usize>` with non-optional `HashAlgorithm`
- `HandlerAction` is a data-carrying enum: `Reveal` or `Hash { algorithm }` — uses `serde(tag)` + `flatten` to keep the flat wire format
- Branch `compute_reveal()` by handler action: REVEAL ranges go to reveal set, HASH ranges go to commit set
- Extend `SdkProver::reveal()` to accept `Option<Commit>` and build `TranscriptCommitConfig` with per-range hash algorithms
- Update WASM `JsProver::reveal()` to accept optional commit parameter

## Design

Each `CommitRange { range, algorithm }` carries its own hash algorithm, matching tlsn-core's `TranscriptCommitConfig` which stores per-range `TranscriptCommitmentKind`. Different handlers can use different algorithms in the same proof.

`HandlerAction` is an internally-tagged enum (`#[serde(tag = "action")]`) flattened into `Handler`. This makes invalid states unrepresentable — `algorithm` only exists on the `Hash` variant and must be specified explicitly.

## Test plan

- [x] 7 new unit tests in `sdk-core/src/handler/tests.rs`
  - Mixed REVEAL/HASH handler splitting
  - Per-range algorithm propagation (SHA256, Keccak256 on different ranges)
  - HASH without algorithm fails deserialization
  - HASH action serde roundtrip with algorithm
- [x] Integration test: full prove flow with mixed reveal + commit handlers
- [ ] Plugin smoke test: ID.me plugin with `action: 'HASH'` on `full_name`