### PR TITLE
chore(lints): bump Rust version to 1.95, fix clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   #   - https://github.com/privacy-ethereum/mpz/issues/178
   # 32 seems to be big enough for the foreseeable future
   RAYON_NUM_THREADS: 32
-  RUST_VERSION: 1.93.0
+  RUST_VERSION: 1.95.0
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/crates/tlsn/src/tag.rs
+++ b/crates/tlsn/src/tag.rs
@@ -128,7 +128,7 @@ impl TagProof {
             if *record_tag
                 != ghash_tag
                     .into_iter()
-                    .zip(j0.into_iter())
+                    .zip(j0)
                     .map(|(a, b)| a ^ b)
                     .collect::<Vec<_>>()
             {


### PR DESCRIPTION
## Summary
- Bump CI Rust toolchain from 1.93.0 to 1.95.0
- Fix new clippy `useless_conversion` lint: remove redundant `.into_iter()` call in `crates/tlsn/src/tag.rs`

## Test plan
- [ ] CI clippy job passes
- [ ] CI build and test jobs pass