### PR TITLE
Add new Prf mode for providing the master secret as input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7499,7 +7499,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "bcs",
- "bincode 1.3.3",
+ "bincode",
  "blake3",
  "k256 0.13.4",
  "opaque-debug",

--- a/crates/components/hmac-sha256/Cargo.toml
+++ b/crates/components/hmac-sha256/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["tls", "mpc", "2pc", "hmac", "sha256"]
 categories = ["cryptography"]
 license = "MIT OR Apache-2.0"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/components/hmac-sha256/benches/prf.rs
+++ b/crates/components/hmac-sha256/benches/prf.rs
@@ -64,8 +64,8 @@ async fn prf(config: PrfConfig) {
     let mut leader = Prf::new(config);
     let mut follower = Prf::new(config);
 
-    let leader_output = leader.alloc(&mut leader_vm, leader_pms).unwrap();
-    let follower_output = follower.alloc(&mut follower_vm, follower_pms).unwrap();
+    let leader_output = leader.alloc_pms(&mut leader_vm, leader_pms).unwrap();
+    let follower_output = follower.alloc_pms(&mut follower_vm, follower_pms).unwrap();
 
     if matches!(config.ms, MSMode::Extended) {
         leader.set_session_hash(session_hash.to_vec()).unwrap();

--- a/crates/components/hmac-sha256/benches/prf.rs
+++ b/crates/components/hmac-sha256/benches/prf.rs
@@ -1,14 +1,14 @@
 #![allow(clippy::let_underscore_future)]
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use hmac_sha256::{MSMode, NetworkMode, Prf, PrfConfig};
 use mpz_common::context::test_mt_context;
 use mpz_ideal_vm::IdealVm;
 use mpz_vm_core::{
-    memory::{binary::U8, Array},
-    prelude::*,
     Execute,
+    memory::{Array, binary::U8},
+    prelude::*,
 };
 
 #[allow(clippy::unit_arg)]

--- a/crates/components/hmac-sha256/src/config.rs
+++ b/crates/components/hmac-sha256/src/config.rs
@@ -17,6 +17,11 @@ pub enum MSMode {
     Standard,
     /// Extended Master Secret (RFC 7627) using session hash.
     Extended,
+    /// Master secret is supplied directly via [`Prf::alloc_ms`]; no derivation
+    /// from a pre-master secret is performed.
+    ///
+    /// [`Prf::alloc_ms`]: crate::Prf::alloc_ms
+    Direct,
 }
 
 /// PRF configuration.

--- a/crates/components/hmac-sha256/src/hmac.rs
+++ b/crates/components/hmac-sha256/src/hmac.rs
@@ -20,11 +20,11 @@
 
 use mpz_hash::sha256::Sha256;
 use mpz_vm_core::{
-    memory::{
-        binary::{Binary, U8},
-        Array,
-    },
     Vm,
+    memory::{
+        Array,
+        binary::{Binary, U8},
+    },
 };
 
 use crate::PrfError;
@@ -60,11 +60,11 @@ mod tests {
     use mpz_hash::sha256::Sha256;
     use mpz_ideal_vm::IdealVm;
     use mpz_vm_core::{
-        memory::{
-            binary::{U32, U8},
-            Array, MemoryExt, ViewExt,
-        },
         Execute,
+        memory::{
+            Array, MemoryExt, ViewExt,
+            binary::{U8, U32},
+        },
     };
 
     #[test]

--- a/crates/components/hmac-sha256/src/lib.rs
+++ b/crates/components/hmac-sha256/src/lib.rs
@@ -103,6 +103,16 @@ mod tests {
         test_prf(NetworkMode::Normal, MSMode::Extended).await;
     }
 
+    #[tokio::test]
+    async fn test_prf_direct_reduced() {
+        test_prf(NetworkMode::Reduced, MSMode::Direct).await;
+    }
+
+    #[tokio::test]
+    async fn test_prf_direct_normal() {
+        test_prf(NetworkMode::Normal, MSMode::Direct).await;
+    }
+
     async fn test_prf(network: NetworkMode, ms_mode: MSMode) {
         let mut rng = StdRng::seed_from_u64(1);
 
@@ -113,10 +123,9 @@ mod tests {
         let cf_hs_hash: [u8; 32] = rng.random();
         let sf_hs_hash: [u8; 32] = rng.random();
 
-        // Expected output — only the master secret derivation differs for EMS.
         let ms_expected = match ms_mode {
             MSMode::Extended => prf_ems_ms(pms, session_hash),
-            MSMode::Standard => prf_ms(pms, client_random, server_random),
+            MSMode::Standard | MSMode::Direct => prf_ms(pms, client_random, server_random),
         };
 
         let [cwk_expected, swk_expected, civ_expected, siv_expected] =
@@ -135,29 +144,48 @@ mod tests {
         let mut leader = IdealVm::new();
         let mut follower = IdealVm::new();
 
-        let leader_pms: Array<U8, 32> = leader.alloc().unwrap();
-        leader.mark_public(leader_pms).unwrap();
-        leader.assign(leader_pms, pms).unwrap();
-        leader.commit(leader_pms).unwrap();
-
-        let follower_pms: Array<U8, 32> = follower.alloc().unwrap();
-        follower.mark_public(follower_pms).unwrap();
-        follower.assign(follower_pms, pms).unwrap();
-        follower.commit(follower_pms).unwrap();
-
         let config = PrfConfig::new(network, ms_mode);
         let mut prf_leader = Prf::new(config);
         let mut prf_follower = Prf::new(config);
 
-        let leader_prf_out = prf_leader.alloc(&mut leader, leader_pms).unwrap();
-        let follower_prf_out = prf_follower.alloc(&mut follower, follower_pms).unwrap();
+        let (leader_prf_out, follower_prf_out) = if matches!(ms_mode, MSMode::Direct) {
+            let leader_ms: Array<U8, 48> = leader.alloc().unwrap();
+            leader.mark_public(leader_ms).unwrap();
+            leader.assign(leader_ms, ms_expected).unwrap();
+            leader.commit(leader_ms).unwrap();
 
-        if matches!(ms_mode, MSMode::Extended) {
-            prf_leader.set_session_hash(session_hash.to_vec()).unwrap();
-            prf_follower
-                .set_session_hash(session_hash.to_vec())
-                .unwrap();
-        }
+            let follower_ms: Array<U8, 48> = follower.alloc().unwrap();
+            follower.mark_public(follower_ms).unwrap();
+            follower.assign(follower_ms, ms_expected).unwrap();
+            follower.commit(follower_ms).unwrap();
+
+            (
+                prf_leader.alloc_ms(&mut leader, leader_ms).unwrap(),
+                prf_follower.alloc_ms(&mut follower, follower_ms).unwrap(),
+            )
+        } else {
+            let leader_pms: Array<U8, 32> = leader.alloc().unwrap();
+            leader.mark_public(leader_pms).unwrap();
+            leader.assign(leader_pms, pms).unwrap();
+            leader.commit(leader_pms).unwrap();
+
+            let follower_pms: Array<U8, 32> = follower.alloc().unwrap();
+            follower.mark_public(follower_pms).unwrap();
+            follower.assign(follower_pms, pms).unwrap();
+            follower.commit(follower_pms).unwrap();
+
+            let leader_prf_out = prf_leader.alloc_pms(&mut leader, leader_pms).unwrap();
+            let follower_prf_out = prf_follower.alloc_pms(&mut follower, follower_pms).unwrap();
+
+            if matches!(ms_mode, MSMode::Extended) {
+                prf_leader.set_session_hash(session_hash.to_vec()).unwrap();
+                prf_follower
+                    .set_session_hash(session_hash.to_vec())
+                    .unwrap();
+            }
+
+            (leader_prf_out, follower_prf_out)
+        };
 
         prf_leader.set_client_random(client_random);
         prf_follower.set_client_random(client_random);

--- a/crates/components/hmac-sha256/src/lib.rs
+++ b/crates/components/hmac-sha256/src/lib.rs
@@ -17,7 +17,7 @@ pub use error::PrfError;
 mod prf;
 pub use prf::Prf;
 
-use mpz_vm_core::memory::{binary::U8, Array};
+use mpz_vm_core::memory::{Array, binary::U8};
 
 /// PRF output.
 #[derive(Debug, Clone, Copy)]
@@ -72,16 +72,16 @@ fn state_to_bytes(input: [u32; 8]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use crate::{
-        test_utils::{prf_cf_vd, prf_ems_ms, prf_keys, prf_ms, prf_sf_vd},
         MSMode, NetworkMode, Prf, PrfConfig, SessionKeys,
+        test_utils::{prf_cf_vd, prf_ems_ms, prf_keys, prf_ms, prf_sf_vd},
     };
     use mpz_common::context::test_st_context;
     use mpz_ideal_vm::IdealVm;
     use mpz_vm_core::{
-        memory::{binary::U8, Array, MemoryExt, ViewExt},
         Execute,
+        memory::{Array, MemoryExt, ViewExt, binary::U8},
     };
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::{Rng, SeedableRng, rngs::StdRng};
 
     #[tokio::test]
     async fn test_prf_reduced() {

--- a/crates/components/hmac-sha256/src/prf.rs
+++ b/crates/components/hmac-sha256/src/prf.rs
@@ -29,7 +29,9 @@ pub struct Prf {
 pub(crate) enum State {
     Initialized,
     Setup {
-        master_secret: Box<InnerPrf>,
+        /// `None` when running in [`MSMode::Direct`] — the master secret is
+        /// supplied directly by the caller and has no PRF to flush.
+        master_secret: Option<Box<InnerPrf>>,
         key_expansion: Box<InnerPrf>,
         client_finished: Box<InnerPrf>,
         server_finished: Box<InnerPrf>,
@@ -58,18 +60,28 @@ impl Prf {
         }
     }
 
-    /// Allocates resources for the PRF.
+    /// Allocates resources for the PRF, deriving the master secret from a
+    /// pre-master secret.
+    ///
+    /// Use this when [`PrfConfig::ms`] is [`MSMode::Standard`] or
+    /// [`MSMode::Extended`].
     ///
     /// # Arguments
     ///
     /// * `vm` - Virtual machine.
     /// * `pms` - The pre-master secret.
     #[instrument(level = "debug", skip_all, err)]
-    pub fn alloc(
+    pub fn alloc_pms(
         &mut self,
         vm: &mut dyn Vm<Binary>,
         pms: Array<U8, 32>,
     ) -> Result<PrfOutput, PrfError> {
+        if matches!(self.config.ms, MSMode::Direct) {
+            return Err(PrfError::config(
+                "alloc_pms called with MSMode::Direct; use alloc_ms",
+            ));
+        }
+
         let State::Initialized = self.state.take() else {
             return Err(PrfError::state("PRF not in initialized state"));
         };
@@ -84,6 +96,44 @@ impl Prf {
         let ms = master_secret.output();
         let ms = merge_outputs(vm, ms, 48)?;
 
+        self.alloc_post_ms(vm, ms, Some(Box::new(master_secret)))
+    }
+
+    /// Allocates resources for the PRF using a caller-supplied master secret,
+    /// skipping the PMS → MS derivation.
+    ///
+    /// Use this when [`PrfConfig::ms`] is [`MSMode::Direct`].
+    ///
+    /// # Arguments
+    ///
+    /// * `vm` - Virtual machine.
+    /// * `ms` - The master secret.
+    #[instrument(level = "debug", skip_all, err)]
+    pub fn alloc_ms(
+        &mut self,
+        vm: &mut dyn Vm<Binary>,
+        ms: Array<U8, 48>,
+    ) -> Result<PrfOutput, PrfError> {
+        if !matches!(self.config.ms, MSMode::Direct) {
+            return Err(PrfError::config(
+                "alloc_ms called without MSMode::Direct; use alloc_pms",
+            ));
+        }
+
+        let State::Initialized = self.state.take() else {
+            return Err(PrfError::state("PRF not in initialized state"));
+        };
+
+        let ms: Vector<U8> = ms.into();
+        self.alloc_post_ms(vm, ms, None)
+    }
+
+    fn alloc_post_ms(
+        &mut self,
+        vm: &mut dyn Vm<Binary>,
+        ms: Vector<U8>,
+        master_secret: Option<Box<InnerPrf>>,
+    ) -> Result<PrfOutput, PrfError> {
         let outer_partial_ms = compute_partial(vm, ms, OPAD)?;
         let inner_partial_ms = compute_partial(vm, ms, IPAD)?;
 
@@ -113,7 +163,7 @@ impl Prf {
         let output = PrfOutput { keys, cf_vd, sf_vd };
 
         self.state = State::Setup {
-            master_secret: Box::new(master_secret),
+            master_secret,
             key_expansion: Box::new(key_expansion),
             client_finished: Box::new(client_finished),
             server_finished: Box::new(server_finished),
@@ -154,6 +204,9 @@ impl Prf {
         let server_random = random;
 
         if matches!(self.config.ms, MSMode::Standard) {
+            let master_secret = master_secret
+                .as_mut()
+                .expect("master_secret circuit should be set in MSMode::Standard");
             let mut seed_ms = client_random.to_vec();
             seed_ms.extend_from_slice(&server_random);
             master_secret.set_start_seed(seed_ms);
@@ -185,6 +238,9 @@ impl Prf {
             ));
         }
 
+        let master_secret = master_secret
+            .as_mut()
+            .expect("master_secret circuit should be set in MSMode::Extended");
         master_secret.set_start_seed(seed);
         Ok(())
     }
@@ -239,7 +295,7 @@ impl Prf {
                 client_finished,
                 server_finished,
             } => {
-                master_secret.wants_flush()
+                master_secret.as_ref().is_some_and(|ms| ms.wants_flush())
                     || key_expansion.wants_flush()
                     || client_finished.wants_flush()
                     || server_finished.wants_flush()
@@ -258,8 +314,8 @@ impl Prf {
                 mut client_finished,
                 mut server_finished,
             } => {
-                if master_secret.wants_flush() {
-                    master_secret.flush(vm)?;
+                if let Some(ms) = master_secret.as_mut() && ms.wants_flush() {
+                        ms.flush(vm)?;
                 }
                 if key_expansion.wants_flush() {
                     key_expansion.flush(vm)?;
@@ -271,7 +327,8 @@ impl Prf {
                     server_finished.flush(vm)?;
                 }
 
-                if master_secret.is_done()
+                let ms_done = master_secret.as_ref().is_none_or(|ms| ms.is_done());
+                if ms_done
                     && key_expansion.is_done()
                     && client_finished.is_done()
                     && server_finished.is_done()

--- a/crates/components/hmac-sha256/src/prf.rs
+++ b/crates/components/hmac-sha256/src/prf.rs
@@ -1,15 +1,15 @@
 use crate::{
-    hmac::{IPAD, OPAD},
     MSMode, PrfConfig, PrfError, PrfOutput, SessionKeys,
+    hmac::{IPAD, OPAD},
 };
-use mpz_circuits::{circuits::xor, Circuit, CircuitBuilder};
+use mpz_circuits::{Circuit, CircuitBuilder, circuits::xor};
 use mpz_hash::sha256::Sha256;
 use mpz_vm_core::{
-    memory::{
-        binary::{Binary, U8},
-        Array, FromRaw, MemoryExt, StaticSize, ToRaw, Vector, ViewExt,
-    },
     Call, CallableExt, Vm,
+    memory::{
+        Array, FromRaw, MemoryExt, StaticSize, ToRaw, Vector, ViewExt,
+        binary::{Binary, U8},
+    },
 };
 use std::{fmt::Debug, sync::Arc};
 use tracing::instrument;
@@ -314,8 +314,10 @@ impl Prf {
                 mut client_finished,
                 mut server_finished,
             } => {
-                if let Some(ms) = master_secret.as_mut() && ms.wants_flush() {
-                        ms.flush(vm)?;
+                if let Some(ms) = master_secret.as_mut()
+                    && ms.wants_flush()
+                {
+                    ms.flush(vm)?;
                 }
                 if key_expansion.wants_flush() {
                     key_expansion.flush(vm)?;
@@ -477,8 +479,8 @@ mod tests {
     use mpz_common::context::test_st_context;
     use mpz_ideal_vm::IdealVm;
     use mpz_vm_core::{
-        memory::{binary::U8, Array, MemoryExt, ViewExt},
         Execute,
+        memory::{Array, MemoryExt, ViewExt, binary::U8},
     };
 
     #[tokio::test]

--- a/crates/components/hmac-sha256/src/prf/function.rs
+++ b/crates/components/hmac-sha256/src/prf/function.rs
@@ -3,11 +3,11 @@
 use crate::{NetworkMode, PrfConfig, PrfError};
 use mpz_hash::sha256::Sha256;
 use mpz_vm_core::{
-    memory::{
-        binary::{Binary, U8},
-        Array,
-    },
     Vm,
+    memory::{
+        Array,
+        binary::{Binary, U8},
+    },
 };
 
 mod normal;
@@ -150,17 +150,17 @@ impl InnerPrf {
 #[cfg(test)]
 mod tests {
     use crate::{
+        MSMode, NetworkMode, PrfConfig,
         prf::{compute_partial, function::InnerPrf},
         test_utils::phash,
-        MSMode, NetworkMode, PrfConfig,
     };
     use mpz_common::context::test_st_context;
     use mpz_ideal_vm::IdealVm;
     use mpz_vm_core::{
-        memory::{binary::U8, Array, MemoryExt, ViewExt},
         Execute,
+        memory::{Array, MemoryExt, ViewExt, binary::U8},
     };
-    use rand::{rngs::ThreadRng, Rng};
+    use rand::{Rng, rngs::ThreadRng};
 
     const IPAD: [u8; 64] = [0x36; 64];
     const OPAD: [u8; 64] = [0x5c; 64];
@@ -201,6 +201,9 @@ mod tests {
         let (label, seed_len): (&[u8], usize) = match config.ms {
             MSMode::Standard => (b"master secret", 64),
             MSMode::Extended => (b"extended master secret", 32),
+            // irrelevant since [`InnerPrf::alloc_master_secret`] does not exist for
+            // [`MSMode::Direct`]
+            MSMode::Direct => unreachable!("test_phash is never parameterised with MSMode::Direct"),
         };
         let start_seed: Vec<u8> = vec![42; seed_len];
 

--- a/crates/components/hmac-sha256/src/prf/function/normal.rs
+++ b/crates/components/hmac-sha256/src/prf/function/normal.rs
@@ -41,6 +41,9 @@ impl PrfFunction {
             MSMode::Extended => {
                 Self::alloc(vm, Self::EMS_LABEL, outer_partial, inner_partial, 48, 32)
             }
+            MSMode::Direct => {
+                unreachable!("alloc_master_secret is never called in MSMode::Direct")
+            }
         }
     }
 

--- a/crates/components/hmac-sha256/src/prf/function/normal.rs
+++ b/crates/components/hmac-sha256/src/prf/function/normal.rs
@@ -1,13 +1,13 @@
 //! Computes the whole PRF in MPC.
 
-use crate::{hmac::hmac_sha256, MSMode, PrfError};
+use crate::{MSMode, PrfError, hmac::hmac_sha256};
 use mpz_hash::sha256::Sha256;
 use mpz_vm_core::{
-    memory::{
-        binary::{Binary, U8},
-        Array, MemoryExt, Vector, ViewExt,
-    },
     Vm,
+    memory::{
+        Array, MemoryExt, Vector, ViewExt,
+        binary::{Binary, U8},
+    },
 };
 
 #[derive(Debug)]

--- a/crates/components/hmac-sha256/src/prf/function/reduced.rs
+++ b/crates/components/hmac-sha256/src/prf/function/reduced.rs
@@ -59,6 +59,9 @@ impl PrfFunction {
         match ms_mode {
             MSMode::Standard => Self::alloc(vm, Self::MS_LABEL, outer_partial, inner_partial, 48),
             MSMode::Extended => Self::alloc(vm, Self::EMS_LABEL, outer_partial, inner_partial, 48),
+            MSMode::Direct => {
+                unreachable!("alloc_master_secret is never called in MSMode::Direct")
+            }
         }
     }
 

--- a/crates/components/hmac-sha256/src/prf/function/reduced.rs
+++ b/crates/components/hmac-sha256/src/prf/function/reduced.rs
@@ -2,15 +2,15 @@
 
 use std::collections::VecDeque;
 
-use crate::{hmac::hmac_sha256, sha256, state_to_bytes, MSMode, PrfError};
+use crate::{MSMode, PrfError, hmac::hmac_sha256, sha256, state_to_bytes};
 use mpz_core::bitvec::BitVec;
 use mpz_hash::sha256::Sha256;
 use mpz_vm_core::{
-    memory::{
-        binary::{Binary, U8},
-        Array, DecodeFutureTyped, MemoryExt, ViewExt,
-    },
     Vm,
+    memory::{
+        Array, DecodeFutureTyped, MemoryExt, ViewExt,
+        binary::{Binary, U8},
+    },
 };
 
 #[derive(Debug)]

--- a/crates/components/hmac-sha256/src/test_utils.rs
+++ b/crates/components/hmac-sha256/src/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::{sha256, state_to_bytes};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 
 pub(crate) const SHA256_IV: [u32; 8] = [
     0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,

--- a/crates/mpc-tls/src/follower.rs
+++ b/crates/mpc-tls/src/follower.rs
@@ -111,7 +111,7 @@ impl MpcTlsFollower {
                 .map_err(|_| MpcTlsError::other("VM lock is held"))?);
 
             let pms = ke.alloc(vm)?;
-            let PrfOutput { keys, cf_vd, sf_vd } = prf.alloc(vm, pms)?;
+            let PrfOutput { keys, cf_vd, sf_vd } = prf.alloc_pms(vm, pms)?;
             record_layer.set_keys(
                 keys.client_write_key,
                 keys.client_iv,

--- a/crates/mpc-tls/src/leader.rs
+++ b/crates/mpc-tls/src/leader.rs
@@ -142,7 +142,7 @@ impl MpcTlsLeader {
 
         // Allocate.
         let pms = ke.alloc(&mut (*vm_lock))?;
-        let PrfOutput { keys, cf_vd, sf_vd } = prf.alloc(&mut (*vm_lock), pms)?;
+        let PrfOutput { keys, cf_vd, sf_vd } = prf.alloc_pms(&mut (*vm_lock), pms)?;
         record_layer.set_keys(
             keys.client_write_key,
             keys.client_iv,


### PR DESCRIPTION
This PR adds an additional mode `MSMode::Direct` to our PRF, which skips the circuit for computing the master_secret. The master secret needs to be provided as an input now for session keys and verify_data computation.