### PR TITLE
chore: bump remaining crates to Rust edition 2024

### DIFF
--- a/crates/components/cipher/Cargo.toml
+++ b/crates/components/cipher/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["tls", "mpc", "2pc", "aes"]
 categories = ["cryptography"]
 license = "MIT OR Apache-2.0"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/components/cipher/src/aes/mod.rs
+++ b/crates/components/cipher/src/aes/mod.rs
@@ -4,7 +4,7 @@ use crate::{Cipher, CtrBlock, Keystream};
 use async_trait::async_trait;
 use mpz_circuits::{AES128_KS, AES128_POST_KS};
 use mpz_memory_core::binary::{Binary, U8};
-use mpz_vm_core::{prelude::*, Call, Vm};
+use mpz_vm_core::{Call, Vm, prelude::*};
 use std::fmt::Debug;
 
 mod error;
@@ -208,8 +208,8 @@ mod tests {
     use mpz_common::context::test_st_context;
     use mpz_ideal_vm::IdealVm;
     use mpz_memory_core::{
-        binary::{Binary, U8},
         Array, MemoryExt, Vector, ViewExt,
+        binary::{Binary, U8},
     };
     use mpz_vm_core::{Execute, Vm};
 
@@ -221,21 +221,21 @@ mod tests {
         let start_counter = 3u32;
 
         let (mut ctx_a, mut ctx_b) = test_st_context(8);
-        let mut gen = IdealVm::new();
+        let mut gen_vm = IdealVm::new();
         let mut ev = IdealVm::new();
 
-        let mut aes_gen = setup_ctr(key, iv, &mut gen);
+        let mut aes_gen = setup_ctr(key, iv, &mut gen_vm);
         let mut aes_ev = setup_ctr(key, iv, &mut ev);
 
         let msg = vec![42u8; 128];
 
-        let keystream_gen = aes_gen.alloc_keystream(&mut gen, msg.len()).unwrap();
+        let keystream_gen = aes_gen.alloc_keystream(&mut gen_vm, msg.len()).unwrap();
         let keystream_ev = aes_ev.alloc_keystream(&mut ev, msg.len()).unwrap();
 
-        let msg_ref_gen: Vector<U8> = gen.alloc_vec(msg.len()).unwrap();
-        gen.mark_public(msg_ref_gen).unwrap();
-        gen.assign(msg_ref_gen, msg.clone()).unwrap();
-        gen.commit(msg_ref_gen).unwrap();
+        let msg_ref_gen: Vector<U8> = gen_vm.alloc_vec(msg.len()).unwrap();
+        gen_vm.mark_public(msg_ref_gen).unwrap();
+        gen_vm.assign(msg_ref_gen, msg.clone()).unwrap();
+        gen_vm.commit(msg_ref_gen).unwrap();
 
         let msg_ref_ev: Vector<U8> = ev.alloc_vec(msg.len()).unwrap();
         ev.mark_public(msg_ref_ev).unwrap();
@@ -244,22 +244,24 @@ mod tests {
 
         let mut ctr = start_counter..;
         keystream_gen
-            .assign(&mut gen, nonce, move || ctr.next().unwrap().to_be_bytes())
+            .assign(&mut gen_vm, nonce, move || {
+                ctr.next().unwrap().to_be_bytes()
+            })
             .unwrap();
         let mut ctr = start_counter..;
         keystream_ev
             .assign(&mut ev, nonce, move || ctr.next().unwrap().to_be_bytes())
             .unwrap();
 
-        let cipher_out_gen = keystream_gen.apply(&mut gen, msg_ref_gen).unwrap();
+        let cipher_out_gen = keystream_gen.apply(&mut gen_vm, msg_ref_gen).unwrap();
         let cipher_out_ev = keystream_ev.apply(&mut ev, msg_ref_ev).unwrap();
 
         let (ct_gen, ct_ev) = tokio::try_join!(
             async {
-                let out = gen.decode(cipher_out_gen).unwrap();
-                gen.flush(&mut ctx_a).await.unwrap();
-                gen.execute(&mut ctx_a).await.unwrap();
-                gen.flush(&mut ctx_a).await.unwrap();
+                let out = gen_vm.decode(cipher_out_gen).unwrap();
+                gen_vm.flush(&mut ctx_a).await.unwrap();
+                gen_vm.execute(&mut ctx_a).await.unwrap();
+                gen_vm.flush(&mut ctx_a).await.unwrap();
                 out.await
             },
             async {
@@ -284,31 +286,31 @@ mod tests {
         let input = [5_u8; 16];
 
         let (mut ctx_a, mut ctx_b) = test_st_context(8);
-        let mut gen = IdealVm::new();
+        let mut gen_vm = IdealVm::new();
         let mut ev = IdealVm::new();
 
-        let mut aes_gen = setup_block(key, &mut gen);
+        let mut aes_gen = setup_block(key, &mut gen_vm);
         let mut aes_ev = setup_block(key, &mut ev);
 
-        let block_ref_gen: Array<U8, 16> = gen.alloc().unwrap();
-        gen.mark_public(block_ref_gen).unwrap();
-        gen.assign(block_ref_gen, input).unwrap();
-        gen.commit(block_ref_gen).unwrap();
+        let block_ref_gen: Array<U8, 16> = gen_vm.alloc().unwrap();
+        gen_vm.mark_public(block_ref_gen).unwrap();
+        gen_vm.assign(block_ref_gen, input).unwrap();
+        gen_vm.commit(block_ref_gen).unwrap();
 
         let block_ref_ev: Array<U8, 16> = ev.alloc().unwrap();
         ev.mark_public(block_ref_ev).unwrap();
         ev.assign(block_ref_ev, input).unwrap();
         ev.commit(block_ref_ev).unwrap();
 
-        let block_gen = aes_gen.alloc_block(&mut gen, block_ref_gen).unwrap();
+        let block_gen = aes_gen.alloc_block(&mut gen_vm, block_ref_gen).unwrap();
         let block_ev = aes_ev.alloc_block(&mut ev, block_ref_ev).unwrap();
 
         let (ciphertext_gen, ciphetext_ev) = tokio::try_join!(
             async {
-                let out = gen.decode(block_gen).unwrap();
-                gen.flush(&mut ctx_a).await.unwrap();
-                gen.execute(&mut ctx_a).await.unwrap();
-                gen.flush(&mut ctx_a).await.unwrap();
+                let out = gen_vm.decode(block_gen).unwrap();
+                gen_vm.flush(&mut ctx_a).await.unwrap();
+                gen_vm.execute(&mut ctx_a).await.unwrap();
+                gen_vm.flush(&mut ctx_a).await.unwrap();
                 out.await
             },
             async {

--- a/crates/components/cipher/src/lib.rs
+++ b/crates/components/cipher/src/lib.rs
@@ -14,10 +14,10 @@ pub mod aes;
 use async_trait::async_trait;
 use mpz_circuits::circuits::xor;
 use mpz_memory_core::{
-    binary::{Binary, U8},
     MemoryExt, Repr, Slice, StaticSize, ToRaw, Vector,
+    binary::{Binary, U8},
 };
-use mpz_vm_core::{prelude::*, Call, CallBuilder, CallError, Vm};
+use mpz_vm_core::{Call, CallBuilder, CallError, Vm, prelude::*};
 use std::{collections::VecDeque, sync::Arc};
 
 /// Provides computation of 2PC ciphers in counter and ECB mode.

--- a/crates/components/deap/Cargo.toml
+++ b/crates/components/deap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tlsn-deap"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/components/deap/src/lib.rs
+++ b/crates/components/deap/src/lib.rs
@@ -12,8 +12,8 @@ use async_trait::async_trait;
 use mpz_common::Context;
 use mpz_core::bitvec::BitVec;
 use mpz_vm_core::{
-    memory::{binary::Binary, DecodeFuture, Memory, Repr, Slice, View},
     Call, Callable, Execute, Vm, VmError,
+    memory::{DecodeFuture, Memory, Repr, Slice, View, binary::Binary},
 };
 use rangeset::{ops::Set, set::RangeSet};
 use tokio::sync::{Mutex, MutexGuard, OwnedMutexGuard};
@@ -388,7 +388,7 @@ mod tests {
     use mpz_common::context::test_st_context;
     use mpz_ideal_vm::IdealVm;
     use mpz_vm_core::{
-        memory::{binary::U8, Array},
+        memory::{Array, binary::U8},
         prelude::*,
     };
 

--- a/crates/components/deap/src/map.rs
+++ b/crates/components/deap/src/map.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use mpz_vm_core::{memory::Slice, VmError};
+use mpz_vm_core::{VmError, memory::Slice};
 use rangeset::ops::Set;
 
 /// A mapping between the memories of the MPC and ZK VMs.
@@ -23,10 +23,10 @@ impl MemoryMap {
 
         assert_eq!(mpc.len(), zk.len(), "slices must be the same length");
 
-        if let Some(last) = self.mpc.last() {
-            if last.end > mpc.start {
-                panic!("slices must be provided in ascending order");
-            }
+        if let Some(last) = self.mpc.last()
+            && last.end > mpc.start
+        {
+            panic!("slices must be provided in ascending order");
         }
 
         self.mpc.push(mpc);

--- a/crates/components/key-exchange/Cargo.toml
+++ b/crates/components/key-exchange/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["tls", "mpc", "2pc", "pms", "key-exchange"]
 categories = ["cryptography"]
 license = "MIT OR Apache-2.0"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/components/key-exchange/src/circuit.rs
+++ b/crates/components/key-exchange/src/circuit.rs
@@ -1,6 +1,6 @@
 //! This module provides the circuits used in the key exchange protocol.
 
-use mpz_circuits::{ops::add_mod, Circuit, CircuitBuilder, Feed, Node};
+use mpz_circuits::{Circuit, CircuitBuilder, Feed, Node, ops::add_mod};
 use std::sync::Arc;
 
 /// Circuit for combining additive shares of the PMS, twice

--- a/crates/components/key-exchange/src/exchange.rs
+++ b/crates/components/key-exchange/src/exchange.rs
@@ -11,17 +11,17 @@ use tracing::instrument;
 
 use mpz_common::{Context, Flush};
 use mpz_core::bitvec::BitVec;
-use mpz_fields::{p256::P256, Field};
+use mpz_fields::{Field, p256::P256};
 use mpz_memory_core::{
-    binary::{Binary, U8},
     Array, DecodeFutureTyped, MemoryExt, ViewExt,
+    binary::{Binary, U8},
 };
 use mpz_share_conversion::{AdditiveToMultiplicative, MultiplicativeToAdditive, ShareConvert};
 use mpz_vm_core::{CallBuilder, CallableExt, Vm};
 
 use crate::{
-    circuit::build_pms_circuit, point_addition::derive_x_coord_share, KeyExchange,
-    KeyExchangeError, Pms, Role,
+    KeyExchange, KeyExchangeError, Pms, Role, circuit::build_pms_circuit,
+    point_addition::derive_x_coord_share,
 };
 
 /// NIST P-256 prime big-endian.
@@ -461,7 +461,7 @@ mod tests {
     use mpz_fields::UniformRand;
     use mpz_ideal_vm::IdealVm;
     use mpz_share_conversion::ideal::{
-        ideal_share_convert, IdealShareConvertReceiver, IdealShareConvertSender,
+        IdealShareConvertReceiver, IdealShareConvertSender, ideal_share_convert,
     };
     use mpz_vm_core::Execute;
     use p256::{NonZeroScalar, PublicKey, SecretKey};
@@ -482,7 +482,7 @@ mod tests {
     async fn test_key_exchange() {
         let mut rng = StdRng::seed_from_u64(0).compat();
         let (mut ctx_a, mut ctx_b) = test_st_context(8);
-        let mut gen = IdealVm::new();
+        let mut gen_vm = IdealVm::new();
         let mut ev = IdealVm::new();
 
         let leader_private_key = SecretKey::random(&mut rng);
@@ -502,7 +502,7 @@ mod tests {
         leader.private_key = leader_private_key.clone();
         follower.private_key = follower_private_key.clone();
 
-        let leader_pms = leader.alloc(&mut gen).unwrap();
+        let leader_pms = leader.alloc(&mut gen_vm).unwrap();
         let follower_pms = follower.alloc(&mut ev).unwrap();
 
         tokio::try_join!(leader.setup(&mut ctx_a), follower.setup(&mut ctx_b)).unwrap();
@@ -510,7 +510,7 @@ mod tests {
         let client_public_key = leader.client_key().unwrap();
         assert_eq!(client_public_key, expected_client_public_key);
 
-        let mut leader_pms = gen.decode(leader_pms).unwrap();
+        let mut leader_pms = gen_vm.decode(leader_pms).unwrap();
         let mut follower_pms = ev.decode(follower_pms).unwrap();
 
         leader.set_server_key(server_public_key).unwrap();
@@ -519,11 +519,11 @@ mod tests {
         let (leader_pms, follower_pms) = tokio::join!(
             async {
                 leader.compute_shares(&mut ctx_a).await.unwrap();
-                leader.assign(&mut gen).unwrap();
+                leader.assign(&mut gen_vm).unwrap();
 
-                gen.flush(&mut ctx_a).await.unwrap();
-                gen.execute(&mut ctx_a).await.unwrap();
-                gen.flush(&mut ctx_a).await.unwrap();
+                gen_vm.flush(&mut ctx_a).await.unwrap();
+                gen_vm.execute(&mut ctx_a).await.unwrap();
+                gen_vm.flush(&mut ctx_a).await.unwrap();
 
                 leader.finalize().await.unwrap();
 
@@ -624,7 +624,7 @@ mod tests {
     async fn test_malicious_key_exchange(#[case] malicious: Malicious) {
         let mut rng = StdRng::seed_from_u64(0);
         let (mut ctx_a, mut ctx_b) = test_st_context(8);
-        let mut gen = IdealVm::new();
+        let mut gen_vm = IdealVm::new();
         let mut ev = IdealVm::new();
 
         let leader_private_key = SecretKey::random(&mut rng.compat_by_ref());
@@ -642,7 +642,7 @@ mod tests {
         leader.private_key = leader_private_key.clone();
         follower.private_key = follower_private_key.clone();
 
-        leader.alloc(&mut gen).unwrap();
+        leader.alloc(&mut gen_vm).unwrap();
         follower.alloc(&mut ev).unwrap();
 
         tokio::try_join!(leader.setup(&mut ctx_a), follower.setup(&mut ctx_b)).unwrap();
@@ -662,11 +662,11 @@ mod tests {
                     leader.set_pms_0(bad_pms_share);
                 }
 
-                leader.assign(&mut gen).unwrap();
+                leader.assign(&mut gen_vm).unwrap();
 
-                gen.flush(&mut ctx_a).await.unwrap();
-                gen.execute(&mut ctx_a).await.unwrap();
-                gen.flush(&mut ctx_a).await.unwrap();
+                gen_vm.flush(&mut ctx_a).await.unwrap();
+                gen_vm.execute(&mut ctx_a).await.unwrap();
+                gen_vm.flush(&mut ctx_a).await.unwrap();
 
                 leader.finalize().await
             },
@@ -704,7 +704,7 @@ mod tests {
     #[tokio::test]
     async fn test_circuit() {
         let (mut ctx_a, mut ctx_b) = test_st_context(8);
-        let gen = IdealVm::new();
+        let gen_vm = IdealVm::new();
         let ev = IdealVm::new();
 
         let share_a0_bytes = [5_u8; 32];
@@ -715,7 +715,7 @@ mod tests {
 
         let (res_gen, res_ev) = tokio::join!(
             async move {
-                let mut vm = gen;
+                let mut vm = gen_vm;
 
                 let p_constant: Array<U8, 32> = vm.alloc().unwrap();
                 vm.mark_public(p_constant).unwrap();

--- a/crates/components/key-exchange/src/lib.rs
+++ b/crates/components/key-exchange/src/lib.rs
@@ -27,8 +27,8 @@ pub use exchange::MpcKeyExchange;
 use async_trait::async_trait;
 use mpz_common::Context;
 use mpz_memory_core::{
-    binary::{Binary, U8},
     Array,
+    binary::{Binary, U8},
 };
 use mpz_vm_core::Vm;
 use p256::PublicKey;

--- a/crates/components/key-exchange/src/mock.rs
+++ b/crates/components/key-exchange/src/mock.rs
@@ -5,7 +5,7 @@ use crate::{MpcKeyExchange, Role};
 use mpz_core::Block;
 use mpz_fields::p256::P256;
 use mpz_share_conversion::ideal::{
-    ideal_share_convert, IdealShareConvertReceiver, IdealShareConvertSender,
+    IdealShareConvertReceiver, IdealShareConvertSender, ideal_share_convert,
 };
 
 /// A mock key exchange instance.

--- a/crates/components/key-exchange/src/point_addition.rs
+++ b/crates/components/key-exchange/src/point_addition.rs
@@ -8,7 +8,7 @@
 
 use crate::{KeyExchangeError, Role};
 use mpz_common::{Context, Flush};
-use mpz_fields::{p256::P256, Field};
+use mpz_fields::{Field, p256::P256};
 use mpz_share_conversion::{AdditiveToMultiplicative, MultiplicativeToAdditive, ShareConvert};
 use p256::EncodedPoint;
 
@@ -100,13 +100,13 @@ mod tests {
 
     use mpz_common::context::test_st_context;
     use mpz_core::Block;
-    use mpz_fields::{p256::P256, Field};
+    use mpz_fields::{Field, p256::P256};
     use mpz_share_conversion::ideal::ideal_share_convert;
     use p256::{
-        elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
         EncodedPoint, NonZeroScalar, ProjectivePoint, PublicKey,
+        elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
     };
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::{Rng, SeedableRng, rngs::StdRng};
 
     #[tokio::test]
     async fn test_point_addition() {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["tls", "mpc", "2pc", "types"]
 categories = ["cryptography"]
 license = "MIT OR Apache-2.0"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/core/src/connection.rs
+++ b/crates/core/src/connection.rs
@@ -449,15 +449,16 @@ mod tests {
         // Remove the CA cert
         data.server_cert_data.certs.pop();
 
-        assert!(data
-            .server_cert_data
-            .verify(
-                verifier,
-                data.connection_info.time,
-                data.server_ephemeral_key(),
-                &data.server_name,
-            )
-            .is_ok());
+        assert!(
+            data.server_cert_data
+                .verify(
+                    verifier,
+                    data.connection_info.time,
+                    data.server_ephemeral_key(),
+                    &data.server_name,
+                )
+                .is_ok()
+        );
     }
 
     /// Expect chain verification to succeed even when a trusted CA is provided
@@ -469,15 +470,16 @@ mod tests {
         verifier: &ServerCertVerifier,
         #[case] data: ConnectionFixture,
     ) {
-        assert!(data
-            .server_cert_data
-            .verify(
-                verifier,
-                data.connection_info.time,
-                data.server_ephemeral_key(),
-                &data.server_name,
-            )
-            .is_ok());
+        assert!(
+            data.server_cert_data
+                .verify(
+                    verifier,
+                    data.connection_info.time,
+                    data.server_ephemeral_key(),
+                    &data.server_name,
+                )
+                .is_ok()
+        );
     }
 
     /// Expect to fail since the end entity cert was not valid at the time.

--- a/crates/core/src/fixtures/transcript.rs
+++ b/crates/core/src/fixtures/transcript.rs
@@ -1,10 +1,10 @@
 //! Transcript fixtures for testing.
 
 use aead::Payload as AeadPayload;
-use aes_gcm::{aead::Aead, Aes128Gcm, NewAead};
+use aes_gcm::{Aes128Gcm, NewAead, aead::Aead};
 #[allow(deprecated)]
 use generic_array::GenericArray;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use tls_core::msgs::{
     base::Payload,
     codec::Codec,

--- a/crates/core/src/merkle.rs
+++ b/crates/core/src/merkle.rs
@@ -182,9 +182,11 @@ mod test {
 
         let proof = tree.proof(&[2, 3, 4]);
 
-        assert!(proof
-            .verify(&hasher, &tree.root(), choose_leaves([2, 3, 4], &leaves))
-            .is_ok());
+        assert!(
+            proof
+                .verify(&hasher, &tree.root(), choose_leaves([2, 3, 4], &leaves))
+                .is_ok()
+        );
     }
 
     #[rstest]
@@ -266,9 +268,11 @@ mod test {
 
         let proof = tree.proof(&[2, 3, 4]);
 
-        assert!(proof
-            .verify(&hasher, &tree.root(), choose_leaves([2, 2, 3], &leaves))
-            .is_err());
+        assert!(
+            proof
+                .verify(&hasher, &tree.root(), choose_leaves([2, 2, 3], &leaves))
+                .is_err()
+        );
     }
 
     #[rstest]
@@ -291,13 +295,17 @@ mod test {
         proof2.leaf_count -= 1;
 
         // Fail because leaf count is wrong.
-        assert!(proof1
-            .verify(&hasher, &tree.root(), choose_leaves([2, 3, 4], &leaves))
-            .is_err());
+        assert!(
+            proof1
+                .verify(&hasher, &tree.root(), choose_leaves([2, 3, 4], &leaves))
+                .is_err()
+        );
 
-        assert!(proof2
-            .verify(&hasher, &tree.root(), choose_leaves([2, 3, 4], &leaves))
-            .is_err());
+        assert!(
+            proof2
+                .verify(&hasher, &tree.root(), choose_leaves([2, 3, 4], &leaves))
+                .is_err()
+        );
     }
 
     #[rstest]
@@ -334,8 +342,10 @@ mod test {
         let proof = tree.proof(&[2, 3, 4]);
 
         // Trying to verify less leaves than what was included in the proof.
-        assert!(proof
-            .verify(&hasher, &tree.root(), choose_leaves([2, 3], &leaves))
-            .is_err());
+        assert!(
+            proof
+                .verify(&hasher, &tree.root(), choose_leaves([2, 3], &leaves))
+                .is_err()
+        );
     }
 }

--- a/crates/core/src/transcript/commit.rs
+++ b/crates/core/src/transcript/commit.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     hash::HashAlgId,
     transcript::{
-        hash::{PlaintextHash, PlaintextHashSecret},
         Direction, RangeSet, Transcript,
+        hash::{PlaintextHash, PlaintextHashSecret},
     },
 };
 

--- a/crates/core/src/transcript/proof.rs
+++ b/crates/core/src/transcript/proof.rs
@@ -12,9 +12,9 @@ use crate::{
     display::FmtRangeSet,
     hash::{HashAlgId, HashProvider},
     transcript::{
-        commit::{TranscriptCommitment, TranscriptCommitmentKind},
-        hash::{hash_plaintext, PlaintextHash, PlaintextHashSecret},
         Direction, PartialTranscript, RangeSet, Transcript, TranscriptSecret,
+        commit::{TranscriptCommitment, TranscriptCommitmentKind},
+        hash::{PlaintextHash, PlaintextHashSecret, hash_plaintext},
     },
 };
 

--- a/crates/core/src/transcript/tls.rs
+++ b/crates/core/src/transcript/tls.rs
@@ -179,7 +179,7 @@ impl TlsTranscript {
                 typ => {
                     return Err(TlsTranscriptError::validation(format!(
                         "sent unexpected record content type: {typ:?}"
-                    )))
+                    )));
                 }
             }
         }
@@ -212,7 +212,7 @@ impl TlsTranscript {
                 typ => {
                     return Err(TlsTranscriptError::validation(format!(
                         "received unexpected record content type: {typ:?}"
-                    )))
+                    )));
                 }
             }
         }

--- a/crates/data-fixtures/Cargo.toml
+++ b/crates/data-fixtures/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tlsn-data-fixtures"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lints]

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "tlsn-examples"
 publish = false
 version = "0.0.0"

--- a/crates/examples/attestation/present.rs
+++ b/crates/examples/attestation/present.rs
@@ -5,7 +5,7 @@
 use clap::Parser;
 use hyper::header;
 
-use tlsn::attestation::{presentation::Presentation, Attestation, CryptoProvider, Secrets};
+use tlsn::attestation::{Attestation, CryptoProvider, Secrets, presentation::Presentation};
 use tlsn_examples::ExampleType;
 use tlsn_formats::http::HttpTranscript;
 

--- a/crates/examples/attestation/prove.rs
+++ b/crates/examples/attestation/prove.rs
@@ -8,23 +8,24 @@ use anyhow::Result;
 use clap::Parser;
 use futures::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use http_body_util::Empty;
-use hyper::{body::Bytes, Request, StatusCode};
+use hyper::{Request, StatusCode, body::Bytes};
 use hyper_util::rt::TokioIo;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tracing::info;
 
 use tlsn::{
+    Session,
     attestation::{
+        Attestation, AttestationConfig, CryptoProvider,
         request::{Request as AttestationRequest, RequestConfig},
         signing::Secp256k1Signer,
-        Attestation, AttestationConfig, CryptoProvider,
     },
     config::{
         prove::ProveConfig,
         prover::ProverConfig,
         tls::TlsClientConfig,
-        tls_commit::{mpc::MpcTlsConfig, TlsCommitConfig},
+        tls_commit::{TlsCommitConfig, mpc::MpcTlsConfig},
         verifier::VerifierConfig,
     },
     connection::{ConnectionInfo, HandshakeData, ServerName, TranscriptLength},
@@ -32,7 +33,6 @@ use tlsn::{
     transcript::{ContentType, TranscriptCommitConfig},
     verifier::VerifierOutput,
     webpki::{CertificateDer, PrivateKeyDer, RootCertStore},
-    Session,
 };
 use tlsn_examples::ExampleType;
 use tlsn_formats::http::{DefaultHttpCommitter, HttpCommit, HttpTranscript};

--- a/crates/examples/attestation/verify.rs
+++ b/crates/examples/attestation/verify.rs
@@ -8,9 +8,9 @@ use clap::Parser;
 
 use tlsn::{
     attestation::{
+        CryptoProvider,
         presentation::{Presentation, PresentationOutput},
         signing::VerifyingKey,
-        CryptoProvider,
     },
     verifier::ServerCertVerifier,
     webpki::{CertificateDer, RootCertStore},

--- a/crates/examples/basic/basic.rs
+++ b/crates/examples/basic/basic.rs
@@ -5,25 +5,25 @@ use std::{
 
 use anyhow::Result;
 use http_body_util::Empty;
-use hyper::{body::Bytes, Request, StatusCode, Uri};
+use hyper::{Request, StatusCode, Uri, body::Bytes};
 use hyper_util::rt::TokioIo;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tracing::instrument;
 
 use tlsn::{
+    Session,
     config::{
         prove::ProveConfig,
         prover::ProverConfig,
         tls::TlsClientConfig,
-        tls_commit::{mpc::MpcTlsConfig, TlsCommitConfig, TlsCommitProtocolConfig},
+        tls_commit::{TlsCommitConfig, TlsCommitProtocolConfig, mpc::MpcTlsConfig},
         verifier::VerifierConfig,
     },
     connection::ServerName,
     transcript::PartialTranscript,
     verifier::VerifierOutput,
     webpki::{CertificateDer, RootCertStore},
-    Session,
 };
 use tlsn_server_fixture::DEFAULT_FIXTURE_PORT;
 use tlsn_server_fixture_certs::{CA_CERT_DER, SERVER_DOMAIN};

--- a/crates/examples/basic_zk/prover.rs
+++ b/crates/examples/basic_zk/prover.rs
@@ -7,7 +7,7 @@ use super::types::ZKProofBundle;
 use anyhow::Result;
 use chrono::{Datelike, Local, NaiveDate};
 use http_body_util::Empty;
-use hyper::{body::Bytes, header, Request, StatusCode, Uri};
+use hyper::{Request, StatusCode, Uri, body::Bytes, header};
 use hyper_util::rt::TokioIo;
 use k256::sha2::{Digest, Sha256};
 use noir::{
@@ -24,22 +24,22 @@ use spansy::{
 };
 use tls_server_fixture::{CA_CERT_DER, SERVER_DOMAIN};
 use tlsn::{
+    Session,
     config::{
         prove::{ProveConfig, ProveConfigBuilder},
         prover::ProverConfig,
         tls::TlsClientConfig,
-        tls_commit::{mpc::MpcTlsConfig, TlsCommitConfig},
+        tls_commit::{TlsCommitConfig, mpc::MpcTlsConfig},
     },
     connection::ServerName,
     hash::HashAlgId,
     rangeset::iter::{IntoRangeIterator, RangeIterator},
     transcript::{
-        hash::{PlaintextHash, PlaintextHashSecret},
         Direction, TranscriptCommitConfig, TranscriptCommitConfigBuilder, TranscriptCommitmentKind,
         TranscriptSecret,
+        hash::{PlaintextHash, PlaintextHashSecret},
     },
     webpki::{CertificateDer, RootCertStore},
-    Session,
 };
 
 use futures::io::AsyncWriteExt as _;

--- a/crates/examples/basic_zk/types.rs
+++ b/crates/examples/basic_zk/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tlsn::transcript::{hash::PlaintextHash, Direction, TranscriptCommitment};
+use tlsn::transcript::{Direction, TranscriptCommitment, hash::PlaintextHash};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ZKProofBundle {

--- a/crates/examples/basic_zk/verifier.rs
+++ b/crates/examples/basic_zk/verifier.rs
@@ -8,13 +8,13 @@ use noir::barretenberg::verify::{get_ultra_honk_verification_key, verify_ultra_h
 use serde_json::Value;
 use tls_server_fixture::CA_CERT_DER;
 use tlsn::{
+    Session,
     config::{tls_commit::TlsCommitProtocolConfig, verifier::VerifierConfig},
     connection::ServerName,
     hash::HashAlgId,
     transcript::{Direction, PartialTranscript},
     verifier::VerifierOutput,
     webpki::{CertificateDer, RootCertStore},
-    Session,
 };
 use tlsn_examples::{MAX_RECV_DATA, MAX_SENT_DATA};
 use tlsn_server_fixture_certs::SERVER_DOMAIN;

--- a/crates/formats/Cargo.toml
+++ b/crates/formats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tlsn-formats"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/formats/src/http/mod.rs
+++ b/crates/formats/src/http/mod.rs
@@ -8,8 +8,8 @@ pub use commit::{DefaultHttpCommitter, HttpCommit, HttpCommitError};
 pub use spansy::http;
 
 pub use http::{
-    parse_request, parse_response, Body, BodyContent, Header, HeaderName, HeaderValue, Method,
-    Reason, Request, RequestLine, Requests, Response, Responses, Status, Target,
+    Body, BodyContent, Header, HeaderName, HeaderValue, Method, Reason, Request, RequestLine,
+    Requests, Response, Responses, Status, Target, parse_request, parse_response,
 };
 use tlsn_core::transcript::Transcript;
 

--- a/crates/mpc-tls/Cargo.toml
+++ b/crates/mpc-tls/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["tls", "mpc", "2pc"]
 categories = ["cryptography"]
 license = "MIT OR Apache-2.0"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/mpc-tls/src/decode.rs
+++ b/crates/mpc-tls/src/decode.rs
@@ -2,16 +2,16 @@ use std::{
     array::from_fn,
     future::Future,
     pin::Pin,
-    task::{ready, Context, Poll},
+    task::{Context, Poll, ready},
 };
 
 use crate::Role;
 use mpz_core::bitvec::BitVec;
 use mpz_memory_core::{
-    binary::{Binary, U8},
     DecodeError, DecodeFutureTyped,
+    binary::{Binary, U8},
 };
-use mpz_vm_core::{prelude::*, Vm, VmError};
+use mpz_vm_core::{Vm, VmError, prelude::*};
 use pin_project_lite::pin_project;
 use rand::Rng;
 

--- a/crates/mpc-tls/src/follower.rs
+++ b/crates/mpc-tls/src/follower.rs
@@ -1,13 +1,13 @@
 use crate::{
-    msg::{Message, StartHandshake},
-    record_layer::{aead::MpcAesGcm, RecordLayer},
     Config, MpcTlsError, Role, SessionKeys, Vm,
+    msg::{Message, StartHandshake},
+    record_layer::{RecordLayer, aead::MpcAesGcm},
 };
 use hmac_sha256::{MSMode, Prf, PrfConfig, PrfOutput};
 use ke::KeyExchange;
 use key_exchange::{self as ke, MpcKeyExchange};
 use mpz_common::{Context, Flush};
-use mpz_core::{bitvec::BitVec, Block};
+use mpz_core::{Block, bitvec::BitVec};
 use mpz_memory_core::{DecodeFutureTyped, MemoryExt};
 use mpz_ole::{Receiver as OLEReceiver, Sender as OLESender};
 use mpz_ot::{

--- a/crates/mpc-tls/src/leader.rs
+++ b/crates/mpc-tls/src/leader.rs
@@ -1,19 +1,19 @@
 use crate::{
+    Config, Role, SessionKeys, Vm,
     error::MpcTlsError,
     msg::{
         ClientFinishedVd, Decrypt, Encrypt, Message, ServerFinishedVd, SetClientRandom,
         SetServerKey, SetServerRandom, StartHandshake,
     },
-    record_layer::{aead::MpcAesGcm, DecryptMode, EncryptMode, RecordLayer},
+    record_layer::{DecryptMode, EncryptMode, RecordLayer, aead::MpcAesGcm},
     utils::opaque_into_parts,
-    Config, Role, SessionKeys, Vm,
 };
 use async_trait::async_trait;
 use hmac_sha256::{MSMode, Prf, PrfConfig, PrfOutput};
 use ke::KeyExchange;
 use key_exchange::{self as ke, MpcKeyExchange};
 use mpz_common::{Context, Flush};
-use mpz_core::{bitvec::BitVec, Block};
+use mpz_core::{Block, bitvec::BitVec};
 use mpz_memory_core::DecodeFutureTyped;
 use mpz_ole::{Receiver as OLEReceiver, Sender as OLESender};
 use mpz_ot::{
@@ -750,7 +750,7 @@ impl Backend for MpcTlsLeader {
                     "can not push incoming message in state: {}",
                     self.state
                 ))
-                .into())
+                .into());
             }
         };
 
@@ -807,7 +807,7 @@ impl Backend for MpcTlsLeader {
                     "can not pull next incoming message in state: {}",
                     self.state
                 ))
-                .into())
+                .into());
             }
         };
 
@@ -846,7 +846,7 @@ impl Backend for MpcTlsLeader {
                     "can not push outgoing message in state: {}",
                     self.state
                 ))
-                .into())
+                .into());
             }
         };
 
@@ -898,7 +898,7 @@ impl Backend for MpcTlsLeader {
                     "can not pull next outgoing message in state: {}",
                     self.state
                 ))
-                .into())
+                .into());
             }
         };
 
@@ -940,7 +940,7 @@ impl Backend for MpcTlsLeader {
                     "can not start traffic in state: {}",
                     self.state
                 ))
-                .into())
+                .into());
             }
         }
 
@@ -971,7 +971,7 @@ impl Backend for MpcTlsLeader {
                     "can not flush record layer in state: {}",
                     self.state
                 ))
-                .into())
+                .into());
             }
         };
 

--- a/crates/mpc-tls/src/lib.rs
+++ b/crates/mpc-tls/src/lib.rs
@@ -21,8 +21,8 @@ pub use leader::MpcTlsLeader;
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use mpz_memory_core::{
-    binary::{Binary, U8},
     Array,
+    binary::{Binary, U8},
 };
 use mpz_vm_core::Vm as VmTrait;
 

--- a/crates/mpc-tls/src/record_layer.rs
+++ b/crates/mpc-tls/src/record_layer.rs
@@ -11,8 +11,8 @@ use aead::MpcAesGcm;
 use futures::TryFutureExt;
 use mpz_common::{Context, Task};
 use mpz_memory_core::{
-    binary::{Binary, U8},
     Array,
+    binary::{Binary, U8},
 };
 use mpz_vm_core::Vm as VmTrait;
 use rand::RngCore;
@@ -26,8 +26,8 @@ use tokio::sync::Mutex;
 use tracing::{debug, instrument};
 
 use crate::{
-    record_layer::{aes_gcm::AesGcm, decrypt::DecryptOp, encrypt::EncryptOp},
     MpcTlsError, Role, Vm,
+    record_layer::{aes_gcm::AesGcm, decrypt::DecryptOp, encrypt::EncryptOp},
 };
 pub(crate) use decrypt::DecryptMode;
 pub(crate) use encrypt::EncryptMode;
@@ -330,7 +330,9 @@ impl RecordLayer {
         } else if self.recv + ciphertext.len() > self.max_recv {
             return Err(MpcTlsError::record_layer(format!(
                 "attempted to receive more data than was configured, increase `max_recv` in the config: current={}, additional={}, max={}",
-                self.recv, ciphertext.len(), self.max_recv
+                self.recv,
+                ciphertext.len(),
+                self.max_recv
             )));
         }
 

--- a/crates/mpc-tls/src/record_layer/aead.rs
+++ b/crates/mpc-tls/src/record_layer/aead.rs
@@ -2,10 +2,10 @@ mod aes_gcm;
 mod ghash;
 
 pub(crate) use aes_gcm::MpcAesGcm;
-use cipher::{aes::AesError, CipherError};
+use cipher::{CipherError, aes::AesError};
 pub(crate) use ghash::{ComputeTags, VerifyTags};
 
-use mpz_memory_core::{binary::U8, Array};
+use mpz_memory_core::{Array, binary::U8};
 use mpz_vm_core::VmError;
 
 type Nonce = Array<U8, 8>;

--- a/crates/mpc-tls/src/record_layer/aead/aes_gcm.rs
+++ b/crates/mpc-tls/src/record_layer/aead/aes_gcm.rs
@@ -1,26 +1,26 @@
 use std::{future::Future, sync::Arc};
 
-use cipher::{aes::Aes128, Cipher, CtrBlock, Keystream};
+use cipher::{Cipher, CtrBlock, Keystream, aes::Aes128};
 use mpz_common::{Context, Flush};
 use mpz_fields::gf2_128::Gf2_128;
 use mpz_memory_core::{
-    binary::{Binary, U8},
     Vector,
+    binary::{Binary, U8},
 };
 use mpz_share_conversion::ShareConvert;
-use mpz_vm_core::{prelude::*, Vm};
+use mpz_vm_core::{Vm, prelude::*};
 use tracing::instrument;
 
 use crate::{
+    Role,
     decode::OneTimePadShared,
     record_layer::{
-        aead::{
-            ghash::{ComputeTagData, ComputeTags, Ghash, MpcGhash, VerifyTagData, VerifyTags},
-            AeadError, Block, Ctr, Nonce,
-        },
         TagData,
+        aead::{
+            AeadError, Block, Ctr, Nonce,
+            ghash::{ComputeTagData, ComputeTags, Ghash, MpcGhash, VerifyTagData, VerifyTags},
+        },
     },
-    Role,
 };
 
 const START_CTR: u32 = 2;
@@ -315,7 +315,7 @@ impl MpcAesGcm {
             _ => {
                 return Err(AeadError::state(
                     "must be in setup or ready state to return ghash key",
-                ))
+                ));
             }
         };
 
@@ -451,15 +451,15 @@ fn assign_j0(
 mod tests {
     use super::*;
     use aes_gcm::{
-        aead::{AeadInPlace, NewAead},
         Aes128Gcm,
+        aead::{AeadInPlace, NewAead},
     };
     use mpz_common::context::test_st_context;
     use mpz_core::Block;
     use mpz_ideal_vm::IdealVm;
     use mpz_memory_core::binary::U8;
     use mpz_share_conversion::ideal::ideal_share_convert;
-    use rand::{rngs::StdRng, SeedableRng};
+    use rand::{SeedableRng, rngs::StdRng};
     use rstest::*;
 
     static SHORT_MSG: &[u8] = b"hello world";

--- a/crates/mpc-tls/src/record_layer/aead/ghash.rs
+++ b/crates/mpc-tls/src/record_layer/aead/ghash.rs
@@ -7,9 +7,9 @@ pub(crate) use verify::{VerifyTagData, VerifyTags};
 use std::{fmt::Debug, ops::Add};
 
 use async_trait::async_trait;
-use mpz_common::{future::Output, Context, Flush};
+use mpz_common::{Context, Flush, future::Output};
 use mpz_core::Block;
-use mpz_fields::{gf2_128::Gf2_128, Field};
+use mpz_fields::{Field, gf2_128::Gf2_128};
 use mpz_share_conversion::{AdditiveToMultiplicative, MultiplicativeToAdditive};
 use serde::{Deserialize, Serialize};
 
@@ -337,16 +337,16 @@ impl From<GhashError> for AeadError {
 mod tests {
     use super::*;
     use ghash_rc::{
-        universal_hash::{KeyInit, UniversalHash as UniversalHashReference},
         GHash as GhashReference,
+        universal_hash::{KeyInit, UniversalHash as UniversalHashReference},
     };
     use mpz_common::context::test_st_context;
     use mpz_core::Block;
-    use mpz_fields::{gf2_128::Gf2_128, UniformRand};
+    use mpz_fields::{UniformRand, gf2_128::Gf2_128};
     use mpz_share_conversion::ideal::{
-        ideal_share_convert, IdealShareConvertReceiver, IdealShareConvertSender,
+        IdealShareConvertReceiver, IdealShareConvertSender, ideal_share_convert,
     };
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::{Rng, SeedableRng, rngs::StdRng};
 
     fn create_pair() -> (
         MpcGhash<IdealShareConvertSender<Gf2_128>>,

--- a/crates/mpc-tls/src/record_layer/aead/ghash/compute.rs
+++ b/crates/mpc-tls/src/record_layer/aead/ghash/compute.rs
@@ -1,17 +1,17 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
-use futures::{stream::FuturesOrdered, StreamExt as _};
+use futures::{StreamExt as _, stream::FuturesOrdered};
 use mpz_common::{Context, Task};
-use serio::{stream::IoStreamExt, SinkExt};
+use serio::{SinkExt, stream::IoStreamExt};
 
 use crate::{
+    Role,
     decode::OneTimePadShared,
     record_layer::aead::{
-        ghash::{build_ghash_data, Ghash, TagShare},
         AeadError,
+        ghash::{Ghash, TagShare, build_ghash_data},
     },
-    Role,
 };
 
 pub(crate) struct ComputeTagData {

--- a/crates/mpc-tls/src/record_layer/aead/ghash/verify.rs
+++ b/crates/mpc-tls/src/record_layer/aead/ghash/verify.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::{stream::FuturesOrdered, StreamExt};
+use futures::{StreamExt, stream::FuturesOrdered};
 use mpz_common::{Context, Task};
-use serio::{stream::IoStreamExt, SinkExt};
+use serio::{SinkExt, stream::IoStreamExt};
 
 use crate::{
+    Role,
     decode::OneTimePadShared,
     record_layer::aead::{
-        ghash::{build_ghash_data, Ghash, TagShare},
         AeadError,
+        ghash::{Ghash, TagShare, build_ghash_data},
     },
-    Role,
 };
 
 pub(crate) struct VerifyTagData {

--- a/crates/mpc-tls/src/record_layer/aes_gcm.rs
+++ b/crates/mpc-tls/src/record_layer/aes_gcm.rs
@@ -1,10 +1,10 @@
-use aes_gcm::{aead::AeadMutInPlace, Aes128Gcm, NewAead};
+use aes_gcm::{Aes128Gcm, NewAead, aead::AeadMutInPlace};
 use mpz_core::bitvec::BitVec;
 use mpz_memory_core::{
-    binary::{Binary, U8},
     Array, DecodeFutureTyped,
+    binary::{Binary, U8},
 };
-use mpz_vm_core::{prelude::*, Vm};
+use mpz_vm_core::{Vm, prelude::*};
 use rand::RngCore;
 
 use crate::{MpcTlsError, Role};
@@ -222,7 +222,7 @@ impl AesGcm {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aes_gcm::{aead::AeadMutInPlace, Aes128Gcm, NewAead};
+    use aes_gcm::{Aes128Gcm, NewAead, aead::AeadMutInPlace};
 
     #[test]
     fn test_aes_gcm_local() {

--- a/crates/mpc-tls/src/record_layer/decrypt.rs
+++ b/crates/mpc-tls/src/record_layer/decrypt.rs
@@ -1,16 +1,16 @@
 use mpz_core::bitvec::BitVec;
-use mpz_memory_core::{binary::Binary, DecodeFutureTyped};
-use mpz_vm_core::{prelude::*, Vm};
+use mpz_memory_core::{DecodeFutureTyped, binary::Binary};
+use mpz_vm_core::{Vm, prelude::*};
 use serde::{Deserialize, Serialize};
 use tls_core::msgs::enums::{ContentType, ProtocolVersion};
 
 use crate::{
+    MpcTlsError, Role,
     record_layer::{
+        TagData,
         aead::{MpcAesGcm, VerifyTags},
         aes_gcm::AesGcm,
-        TagData,
     },
-    MpcTlsError, Role,
 };
 
 pub(crate) fn private_mpc(
@@ -19,14 +19,14 @@ pub(crate) fn private_mpc(
     otp: Option<&mut Vec<u8>>,
     op: &DecryptOp,
 ) -> Result<DecryptOutput, MpcTlsError> {
-    if let Some(otp) = otp.as_ref() {
-        if op.ciphertext.len() > otp.len() {
-            return Err(MpcTlsError::record_layer(format!(
-                "ciphertext length exceeds allocated: {} > {}",
-                op.ciphertext.len(),
-                otp.len()
-            )));
-        }
+    if let Some(otp) = otp.as_ref()
+        && op.ciphertext.len() > otp.len()
+    {
+        return Err(MpcTlsError::record_layer(format!(
+            "ciphertext length exceeds allocated: {} > {}",
+            op.ciphertext.len(),
+            otp.len()
+        )));
     }
 
     let (otp_ref, masked_keystream) = decrypter

--- a/crates/mpc-tls/src/record_layer/encrypt.rs
+++ b/crates/mpc-tls/src/record_layer/encrypt.rs
@@ -1,16 +1,16 @@
 use futures::TryFutureExt as _;
 use mpz_core::bitvec::BitVec;
-use mpz_memory_core::{binary::Binary, DecodeFutureTyped};
-use mpz_vm_core::{prelude::*, Vm};
+use mpz_memory_core::{DecodeFutureTyped, binary::Binary};
+use mpz_vm_core::{Vm, prelude::*};
 use serde::{Deserialize, Serialize};
 use tls_core::msgs::enums::{ContentType, ProtocolVersion};
 
 use crate::{
-    record_layer::{
-        aead::{AeadError, ComputeTags, MpcAesGcm},
-        TagData,
-    },
     BoxFut, MpcTlsError,
+    record_layer::{
+        TagData,
+        aead::{AeadError, ComputeTags, MpcAesGcm},
+    },
 };
 
 #[allow(clippy::type_complexity)]
@@ -144,14 +144,14 @@ impl EncryptOp {
         aad: Vec<u8>,
         mode: EncryptMode,
     ) -> Result<Self, MpcTlsError> {
-        if let Some(plaintext) = &plaintext {
-            if plaintext.len() != len {
-                return Err(MpcTlsError::record_layer(format!(
-                    "inconsistent plaintext length: {} != {}",
-                    plaintext.len(),
-                    len
-                )));
-            }
+        if let Some(plaintext) = &plaintext
+            && plaintext.len() != len
+        {
+            return Err(MpcTlsError::record_layer(format!(
+                "inconsistent plaintext length: {} != {}",
+                plaintext.len(),
+                len
+            )));
         }
 
         if mode == EncryptMode::Public && plaintext.is_none() {

--- a/crates/sdk-core/Cargo.toml
+++ b/crates/sdk-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tlsn-sdk-core"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/tlsnotary/tlsn.git"
 description = "Platform-agnostic core SDK for TLSNotary."
 license = "MIT OR Apache-2.0"

--- a/crates/sdk-core/src/handler/extract.rs
+++ b/crates/sdk-core/src/handler/extract.rs
@@ -4,9 +4,9 @@ use std::ops::Range;
 
 use rangeset::{iter::RangeIterator, ops::Set, set::RangeSet};
 use spansy::{
+    Store,
     http::{Body, BodyContent, Header, Request, Response},
     json::{JsonValue, KeyValue},
-    Store,
 };
 
 use crate::{
@@ -242,22 +242,22 @@ fn extract_json_body<S: Store>(
 
     // For hideKey/hideValue, we need the parent object's key-value pair.
     // Otherwise we just need the value itself.
-    if hide_key || hide_value {
-        if let Some((parent_path, key)) = split_json_path(path) {
-            let parent: Option<&JsonValue<S>> = if parent_path.is_empty() {
-                Some(&doc.root)
-            } else {
-                doc.get(parent_path)
-            };
+    if (hide_key || hide_value)
+        && let Some((parent_path, key)) = split_json_path(path)
+    {
+        let parent: Option<&JsonValue<S>> = if parent_path.is_empty() {
+            Some(&doc.root)
+        } else {
+            doc.get(parent_path)
+        };
 
-            if let Some(JsonValue::Object(obj)) = parent {
-                if let Some(kv) = obj.elems.iter().find(|kv| kv.key == key) {
-                    return extract_kv_ranges(kv, hide_key, hide_value);
-                }
-            }
-            // If parent is an array, ignore hideKey/hideValue — return value
-            // only
+        if let Some(JsonValue::Object(obj)) = parent
+            && let Some(kv) = obj.elems.iter().find(|kv| kv.key == key)
+        {
+            return extract_kv_ranges(kv, hide_key, hide_value);
         }
+        // If parent is an array, ignore hideKey/hideValue — return value
+        // only
     }
 
     // Return the value's ranges directly (full key-value pair for objects, or just
@@ -268,19 +268,20 @@ fn extract_json_body<S: Store>(
 
     // If no hide options and this is an object field, return the whole key-value
     // pair.
-    if !hide_key && !hide_value {
-        if let Some((parent_path, key)) = split_json_path(path) {
-            let parent: Option<&JsonValue<S>> = if parent_path.is_empty() {
-                Some(&doc.root)
-            } else {
-                doc.get(parent_path)
-            };
+    if !hide_key
+        && !hide_value
+        && let Some((parent_path, key)) = split_json_path(path)
+    {
+        let parent: Option<&JsonValue<S>> = if parent_path.is_empty() {
+            Some(&doc.root)
+        } else {
+            doc.get(parent_path)
+        };
 
-            if let Some(JsonValue::Object(obj)) = parent {
-                if let Some(kv) = obj.elems.iter().find(|kv| kv.key == key) {
-                    return Ok(rangeset_to_vec(kv.view().indices()));
-                }
-            }
+        if let Some(JsonValue::Object(obj)) = parent
+            && let Some(kv) = obj.elems.iter().find(|kv| kv.key == key)
+        {
+            return Ok(rangeset_to_vec(kv.view().indices()));
         }
     }
 
@@ -326,12 +327,11 @@ fn split_json_path(path: &str) -> Option<(&str, &str)> {
 fn extract_all(handler: &Handler, raw: &[u8]) -> Result<Vec<Range<usize>>> {
     let params = handler.params.as_ref();
 
-    if let Some(params) = params {
-        if params.content_type.as_deref() == Some("regex") {
-            if let Some(pattern) = params.regex.as_deref() {
-                return extract_regex(raw, pattern);
-            }
-        }
+    if let Some(params) = params
+        && params.content_type.as_deref() == Some("regex")
+        && let Some(pattern) = params.regex.as_deref()
+    {
+        return extract_regex(raw, pattern);
     }
 
     // Return entire transcript as a single range.

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -3,15 +3,15 @@
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
 use tlsn::{
+    Session, SessionHandle,
     config::{
         prove::ProveConfig,
         tls::TlsClientConfig,
-        tls_commit::{mpc::MpcTlsConfig, TlsCommitConfig},
+        tls_commit::{TlsCommitConfig, mpc::MpcTlsConfig},
     },
     connection::ServerName,
-    prover::{state, Prover, TlsConnection},
+    prover::{Prover, TlsConnection, state},
     webpki::{CertificateDer, PrivateKeyDer, RootCertStore},
-    Session, SessionHandle,
 };
 use tracing::{error, info};
 

--- a/crates/sdk-core/src/verifier.rs
+++ b/crates/sdk-core/src/verifier.rs
@@ -1,12 +1,12 @@
 //! SDK Verifier implementation.
 
 use tlsn::{
+    Session, SessionHandle,
     config::tls_commit::TlsCommitProtocolConfig,
     connection::{ConnectionInfo, ServerName, TranscriptLength},
     transcript::ContentType,
-    verifier::{state, Verifier},
+    verifier::{Verifier, state},
     webpki::RootCertStore,
-    Session, SessionHandle,
 };
 use tracing::info;
 

--- a/crates/server-fixture/certs/Cargo.toml
+++ b/crates/server-fixture/certs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tlsn-server-fixture-certs"
 publish = false
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/server-fixture/server/Cargo.toml
+++ b/crates/server-fixture/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tlsn-server-fixture"
 publish = false
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/server-fixture/server/bin/main.rs
+++ b/crates/server-fixture/server/bin/main.rs
@@ -1,6 +1,6 @@
 use std::{env, io};
 
-use tlsn_server_fixture::{bind, DEFAULT_FIXTURE_PORT};
+use tlsn_server_fixture::{DEFAULT_FIXTURE_PORT, bind};
 use tokio::net::TcpListener;
 use tokio_util::compat::TokioAsyncWriteCompatExt;
 use tracing::info;

--- a/crates/server-fixture/server/src/lib.rs
+++ b/crates/server-fixture/server/src/lib.rs
@@ -4,23 +4,23 @@ use std::{
 };
 
 use axum::{
+    Json, Router,
     extract::{Query, State},
     response::Html,
     routing::get,
-    Json, Router,
 };
 use tower_http::trace::TraceLayer;
 
-use futures::{channel::oneshot, AsyncRead, AsyncWrite};
+use futures::{AsyncRead, AsyncWrite, channel::oneshot};
 use futures_rustls::{
-    pki_types::{CertificateDer, PrivateKeyDer},
-    rustls::{server::WebPkiClientVerifier, RootCertStore, ServerConfig},
     TlsAcceptor,
+    pki_types::{CertificateDer, PrivateKeyDer},
+    rustls::{RootCertStore, ServerConfig, server::WebPkiClientVerifier},
 };
 use hyper::{
+    Request, StatusCode,
     body::{Bytes, Incoming},
     server::conn::http1,
-    Request, StatusCode,
 };
 use hyper_util::rt::TokioIo;
 

--- a/crates/tls/client/Cargo.toml
+++ b/crates/tls/client/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["tls", "mpc", "2pc", "client", "sync"]
 categories = ["cryptography"]
 license = "Apache-2.0 OR ISC OR MIT"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 autobenches = false
 
 [lints]

--- a/crates/tls/client/src/check.rs
+++ b/crates/tls/client/src/check.rs
@@ -11,7 +11,7 @@ use tls_core::msgs::{
 /// has the given $payload_type.  If not, return Err(rustls::Error) quoting
 /// $handshake_type as the expected handshake type.
 macro_rules! require_handshake_msg(
-  ( $m:expr, $handshake_type:path, $payload_type:path ) => (
+  ( $m:expr_2021, $handshake_type:path, $payload_type:path ) => (
     match &$m.payload {
         MessagePayload::Handshake($crate::tls_core::msgs::handshake::HandshakeMessagePayload {
             payload: $payload_type(hm),
@@ -28,7 +28,7 @@ macro_rules! require_handshake_msg(
 /// Like require_handshake_msg, but moves the payload out of $m.
 #[cfg(feature = "tls12")]
 macro_rules! require_handshake_msg_move(
-  ( $m:expr, $handshake_type:path, $payload_type:path ) => (
+  ( $m:expr_2021, $handshake_type:path, $payload_type:path ) => (
     match $m.payload {
         MessagePayload::Handshake($crate::tls_core::msgs::handshake::HandshakeMessagePayload {
             payload: $payload_type(hm),

--- a/crates/tls/client/tests/api.rs
+++ b/crates/tls/client/tests/api.rs
@@ -557,14 +557,14 @@ impl ResolvesServerCert for ServerCheckCertResolve {
             assert_eq!(expected_sni, sni);
         }
 
-        if let Some(expected_sigalgs) = &self.expected_sigalgs {
-            if expected_sigalgs != client_hello.signature_schemes() {
-                panic!(
-                    "unexpected signature schemes (wanted {:?} got {:?})",
-                    self.expected_sigalgs,
-                    client_hello.signature_schemes()
-                );
-            }
+        if let Some(expected_sigalgs) = &self.expected_sigalgs
+            && expected_sigalgs != client_hello.signature_schemes()
+        {
+            panic!(
+                "unexpected signature schemes (wanted {:?} got {:?})",
+                self.expected_sigalgs,
+                client_hello.signature_schemes()
+            );
         }
 
         if let Some(expected_alpn) = &self.expected_alpn {

--- a/crates/tls/client/tests/common/mod.rs
+++ b/crates/tls/client/tests/common/mod.rs
@@ -21,7 +21,7 @@ use webpki::anchor_from_trusted_cert;
 macro_rules! embed_files {
     (
         $(
-            ($name:ident, $keytype:expr, $path:expr);
+            ($name:ident, $keytype:expr_2021, $path:expr_2021);
         )+
     ) => {
         $(

--- a/crates/tls/core/Cargo.toml
+++ b/crates/tls/core/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["tls", "mpc", "2pc"]
 categories = ["cryptography"]
 license = "Apache-2.0 OR ISC OR MIT"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/crates/tls/core/src/msgs/handshake.rs
+++ b/crates/tls/core/src/msgs/handshake.rs
@@ -514,7 +514,7 @@ pub enum CertificateStatusRequest {
 impl Codec for CertificateStatusRequest {
     fn encode(&self, bytes: &mut Vec<u8>) {
         match self {
-            Self::OCSP(ref r) => r.encode(bytes),
+            Self::OCSP(r) => r.encode(bytes),
             Self::Unknown((typ, payload)) => {
                 typ.encode(bytes);
                 payload.encode(bytes);
@@ -1030,7 +1030,7 @@ impl ClientHelloPayload {
 
     pub fn set_psk_binder(&mut self, binder: impl Into<Vec<u8>>) {
         let last_extension = self.extensions.last_mut();
-        if let Some(ClientExtension::PresharedKey(ref mut offer)) = last_extension {
+        if let Some(ClientExtension::PresharedKey(offer)) = last_extension {
             offer.binders[0] = PresharedKeyBinder::new(binder.into());
         }
     }
@@ -2291,7 +2291,7 @@ impl HandshakeMessagePayload {
 
         let binder_len = match self.payload {
             HandshakePayload::ClientHello(ref ch) => match ch.extensions.last() {
-                Some(ClientExtension::PresharedKey(ref offer)) => {
+                Some(ClientExtension::PresharedKey(offer)) => {
                     let mut binders_encoding = Vec::new();
                     offer.binders.encode(&mut binders_encoding);
                     binders_encoding.len()

--- a/crates/tls/core/src/msgs/macros.rs
+++ b/crates/tls/core/src/msgs/macros.rs
@@ -4,7 +4,7 @@ macro_rules! enum_builder {
     $(#[$comment:meta])*
     @U8
         EnumName: $enum_name: ident;
-        EnumVal { $( $enum_var: ident => $enum_val: expr ),* }
+        EnumVal { $( $enum_var: ident => $enum_val: expr_2021 ),* }
     ) => {
         $(#[$comment])*
         #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -44,7 +44,7 @@ macro_rules! enum_builder {
     $(#[$comment:meta])*
     @U16
         EnumName: $enum_name: ident;
-        EnumVal { $( $enum_var: ident => $enum_val: expr ),* }
+        EnumVal { $( $enum_var: ident => $enum_val: expr_2021 ),* }
     ) => {
         $(#[$comment])*
         #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/crates/tls/server-fixture/Cargo.toml
+++ b/crates/tls/server-fixture/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["tls", "fixture"]
 categories = ["cryptography"]
 license = "MIT OR Apache-2.0"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lints]

--- a/crates/tls/server-fixture/src/lib.rs
+++ b/crates/tls/server-fixture/src/lib.rs
@@ -7,16 +7,16 @@
 use bytes::Bytes;
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use futures_rustls::{
+    TlsAcceptor,
     pki_types::{CertificateDer, PrivateKeyDer},
     rustls::ServerConfig,
-    TlsAcceptor,
 };
-use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};
+use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
 use hyper::{
+    Method, Request, Response, StatusCode,
     body::{Frame, Incoming},
     server::conn::http1,
     service::service_fn,
-    Method, Request, Response, StatusCode,
 };
 use hyper_util::rt::TokioIo;
 use std::{io::Write, sync::Arc};

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tlsn-wasm"
 version = "0.1.0-alpha.15-pre"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/tlsnotary/tlsn.git"
 description = "A core WebAssembly package for TLSNotary."
 license = "MIT OR Apache-2.0"

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -7,7 +7,7 @@ pub use config::ProverConfig;
 use tlsn_sdk_core::{
     NetworkSetting as CoreNetworkSetting, ProverConfig as CoreProverConfig, SdkProver,
 };
-use wasm_bindgen::{prelude::*, JsError};
+use wasm_bindgen::{JsError, prelude::*};
 
 use crate::{
     io::{JsIo, JsIoAdapter},


### PR DESCRIPTION
Closes #1132.

Bumps the 15 workspace crates still on edition 2021 to 2024 so the workspace targets a single edition.

- `cargo fix --edition` migrations: `expr` -> `expr_2021` macro fragments and `ref` pattern cleanup.
- Bare `gen` test bindings in `cipher/aes` and `key-exchange/exchange` renamed to `gen_vm` since `gen` is now reserved.
- `clippy::collapsible_if` lints (stable let-chains) collapsed in `deap`, `mpc-tls`, `sdk-core`, and `tls/client` tests.
- `cargo +nightly fmt` re-sorts in-group imports under the 2024 style edition; that accounts for most of the diff.

## Test plan

- [x] `./pre-commit-check.sh` passes locally
- [ ] CI run, especially the `wasm32-unknown-unknown` build