### PR TITLE
ci: replace apt chromium-chromedriver with setup-chrome action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           components: rust-src
 
       - name: Install Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@v2
         with:
           chrome-version: stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,10 @@ jobs:
           toolchain: nightly
           components: rust-src
 
-      - name: Install chromedriver
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y chromium-chromedriver
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
 
       - name: Install wasm-pack
         # we need 0.14.0+ which supports custom profiles


### PR DESCRIPTION
## Summary

- The `chromium-chromedriver` apt package on Ubuntu noble is a snap shim — `apt install` triggers `snap install chromium`, which has been failing on `ubuntu-latest` runners with `==> Unable to contact the store`. This blocked the wasm CI job (e.g. [run 25205208928](https://github.com/tlsnotary/tlsn/actions/runs/25205208928)).
- The harness drives the browser with [chromiumoxide](https://github.com/mattsse/chromiumoxide) over CDP, not WebDriver — it only needs a Chrome/Chromium binary that `chromiumoxide::detection::default_executable` can find on PATH. No chromedriver involved.
- Switch the install step to [`browser-actions/setup-chrome@v1`](https://github.com/browser-actions/setup-chrome), which fetches Google Chrome stable directly and avoids the snap store.

## Test plan

- [x] `Build and Test wasm` job completes the `Install Chrome` step successfully
- [x] Harness browser tests run to completion (this PR doesn't change the harness or test code)