### PR TITLE
fix(harness): steady-tick progress bar

### DIFF
--- a/crates/harness/runner/src/lib.rs
+++ b/crates/harness/runner/src/lib.rs
@@ -343,6 +343,7 @@ pub async fn main() -> Result<()> {
                     .expect("valid template")
                     .progress_chars("█▓▒░ "),
             );
+            pb.enable_steady_tick(Duration::from_millis(250));
 
             // Collect measurements for stats
             let mut measurements_by_config: HashMap<String, Vec<u64>> = HashMap::new();


### PR DESCRIPTION
## Summary

- Enable a 250ms steady tick on the bench progress bar so the `[{elapsed_precise}]` clock advances during a run instead of freezing until the next `inc`/`set_message`.

## Test plan

- [ ] `cargo check -p tlsn-harness-runner`
- [ ] Run a bench config and confirm the elapsed clock ticks every ~250ms during a single iteration
- [ ] Confirm a normal bench run still finishes cleanly (progress bar reaches 100%)