### PR TITLE
refactor(tlsn): feature gate keccak and blake3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ mpz-ot = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
 mpz-share-conversion = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
 mpz-fields = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
 mpz-zk = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
-mpz-hash = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-hash = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547", default-features = false }
 mpz-ideal-vm = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
 
 futures-plex = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "64722f7" }

--- a/crates/tlsn/Cargo.toml
+++ b/crates/tlsn/Cargo.toml
@@ -11,10 +11,12 @@ edition = "2024"
 workspace = true
 
 [features]
-default = ["rayon"]
+default = ["rayon", "hash-blake3"]
 mozilla-certs = ["tlsn-core/mozilla-certs"]
 rayon = ["mpz-zk/rayon", "mpz-garble/rayon"]
 web = ["dep:web-spawn"]
+hash-keccak256 = ["mpz-hash/keccak256"]
+hash-blake3 = ["mpz-hash/blake3"]
 
 [dependencies]
 tlsn-attestation = { workspace = true }
@@ -36,7 +38,7 @@ mpz-common = { workspace = true }
 mpz-core = { workspace = true }
 mpz-garble = { workspace = true }
 mpz-garble-core = { workspace = true }
-mpz-hash = { workspace = true }
+mpz-hash = { workspace = true, features = ["sha256"] }
 mpz-memory-core = { workspace = true }
 mpz-ole = { workspace = true }
 mpz-ot = { workspace = true }

--- a/crates/tlsn/src/transcript_internal/commit/hash.rs
+++ b/crates/tlsn/src/transcript_internal/commit/hash.rs
@@ -3,7 +3,11 @@
 use std::collections::HashMap;
 
 use mpz_core::bitvec::BitVec;
-use mpz_hash::{blake3::Blake3, keccak256::Keccak256, sha256::Sha256};
+#[cfg(feature = "hash-blake3")]
+use mpz_hash::blake3::Blake3;
+#[cfg(feature = "hash-keccak256")]
+use mpz_hash::keccak256::Keccak256;
+use mpz_hash::sha256::Sha256;
 use mpz_memory_core::{
     DecodeFutureTyped, MemoryExt, Vector,
     binary::{Binary, U8},
@@ -22,7 +26,6 @@ use crate::{Role, transcript_internal::TranscriptRefs};
 
 /// Future which will resolve to the committed hash values.
 #[derive(Debug)]
-
 pub(crate) struct HashCommitFuture {
     #[allow(clippy::type_complexity)]
     futs: Vec<(
@@ -110,7 +113,9 @@ pub(crate) fn verify_hash(
 #[derive(Clone)]
 enum Hasher {
     Sha256(Sha256),
+    #[cfg(feature = "hash-blake3")]
     Blake3(Blake3),
+    #[cfg(feature = "hash-keccak256")]
     Keccak256(Keccak256),
 }
 
@@ -162,6 +167,7 @@ fn hash_commit_inner(
                 hasher.update(&blinder);
                 hasher.finalize(vm).map_err(HashCommitError::hasher)?
             }
+            #[cfg(feature = "hash-blake3")]
             HashAlgId::BLAKE3 => {
                 let mut hasher = if let Some(Hasher::Blake3(hasher)) = hashers.get(&alg).cloned() {
                     hasher
@@ -186,6 +192,7 @@ fn hash_commit_inner(
                     .map_err(HashCommitError::hasher)?;
                 hasher.finalize(vm).map_err(HashCommitError::hasher)?
             }
+            #[cfg(feature = "hash-keccak256")]
             HashAlgId::KECCAK256 => {
                 let mut hasher = if let Some(Hasher::Keccak256(hasher)) = hashers.get(&alg).cloned()
                 {


### PR DESCRIPTION
This PR adds feature flags to `tlsn` which allow a user to disable the keccak and blake3 hash functions. This reduces binary size.

Blake3 remains enabled by default as it is currently the default for transcript commitments and I didn't want to introduce a behavioral change.