### PR TITLE
feat(sdk-core,wasm): return hash-commit blinders from reveal()

### DIFF
--- a/crates/sdk-core/src/lib.rs
+++ b/crates/sdk-core/src/lib.rs
@@ -59,7 +59,7 @@ pub use io::{HyperIo, Io};
 pub use prover::SdkProver;
 pub use types::{
     Body, Commit, CommitRange, ConnectionInfo, Handler, HandlerAction, HandlerParams, HandlerPart,
-    HandlerType, HashAlgorithm, HttpRequest, HttpResponse, Method, PartialTranscript, Reveal,
-    TlsVersion, Transcript, TranscriptLength, VerifierOutput,
+    HandlerType, HashAlgorithm, HashOpening, HttpRequest, HttpResponse, Method, PartialTranscript,
+    Reveal, RevealOutput, TlsVersion, Transcript, TranscriptLength, VerifierOutput,
 };
 pub use verifier::SdkVerifier;

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -355,11 +355,7 @@ impl SdkProver {
     /// hash-committed range (in the same order as the input [`Commit`] —
     /// sent ranges first, then recv). When `commit` is `None`, the
     /// `commitments` vector is empty.
-    pub async fn reveal(
-        &mut self,
-        reveal: Reveal,
-        commit: Option<Commit>,
-    ) -> Result<RevealOutput> {
+    pub async fn reveal(&mut self, reveal: Reveal, commit: Option<Commit>) -> Result<RevealOutput> {
         let State::Committed { mut prover, handle } = self.state.take() else {
             return Err(SdkError::invalid_state("prover is not in committed state"));
         };

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -13,6 +13,10 @@ use tlsn::{
     prover::{Prover, TlsConnection, state},
     webpki::{CertificateDer, PrivateKeyDer},
 };
+use tlsn_core::{
+    ProverOutput,
+    transcript::{Direction, TranscriptCommitment, TranscriptSecret},
+};
 use tracing::{error, info};
 
 use crate::{
@@ -346,7 +350,16 @@ impl SdkProver {
     /// Optionally accepts a [`Commit`] with ranges to hash-commit (blinded,
     /// not revealed as plaintext). The commit ranges are processed via the
     /// TLSNotary hash-commitment path (`prove_hash`).
-    pub async fn reveal(&mut self, reveal: Reveal, commit: Option<Commit>) -> Result<()> {
+    ///
+    /// Returns a [`RevealOutput`] containing one [`CommitmentOpening`] per
+    /// hash-committed range (in the same order as the input [`Commit`] —
+    /// sent ranges first, then recv). When `commit` is `None`, the
+    /// `commitments` vector is empty.
+    pub async fn reveal(
+        &mut self,
+        reveal: Reveal,
+        commit: Option<Commit>,
+    ) -> Result<RevealOutput> {
         let State::Committed { mut prover, handle } = self.state.take() else {
             return Err(SdkError::invalid_state("prover is not in committed state"));
         };
@@ -394,7 +407,7 @@ impl SdkProver {
 
         let config = builder.build()?;
 
-        prover
+        let prover_output = prover
             .prove(&config)
             .await
             .map_err(|e| SdkError::protocol(e.to_string()))?;
@@ -409,13 +422,59 @@ impl SdkProver {
 
         self.state = State::Complete;
 
-        Ok(())
+        build_reveal_output(prover_output)
     }
 
     /// Returns true if the prover has completed the protocol.
     pub fn is_complete(&self) -> bool {
         matches!(self.state, State::Complete)
     }
+}
+
+fn build_reveal_output(output: ProverOutput) -> Result<RevealOutput> {
+    let ProverOutput {
+        transcript_commitments,
+        transcript_secrets,
+    } = output;
+
+    if transcript_commitments.len() != transcript_secrets.len() {
+        return Err(SdkError::protocol(format!(
+            "prover output mismatch: {} commitments vs {} secrets",
+            transcript_commitments.len(),
+            transcript_secrets.len()
+        )));
+    }
+
+    let mut sent = Vec::new();
+    let mut recv = Vec::new();
+    for (commitment, secret) in transcript_commitments.into_iter().zip(transcript_secrets) {
+        let (commitment, secret) = match (commitment, secret) {
+            (TranscriptCommitment::Hash(c), TranscriptSecret::Hash(s)) => (c, s),
+            _ => {
+                return Err(SdkError::protocol(
+                    "prover output contained an unsupported commitment kind",
+                ));
+            }
+        };
+
+        if commitment.direction != secret.direction || commitment.idx != secret.idx {
+            return Err(SdkError::protocol(
+                "prover output mismatch: commitment/secret direction or range disagree",
+            ));
+        }
+
+        let opening = HashOpening {
+            hash: commitment.hash.value.as_bytes().to_vec(),
+            blinder: secret.blinder.as_bytes().to_vec(),
+        };
+
+        match commitment.direction {
+            Direction::Sent => sent.push(opening),
+            Direction::Received => recv.push(opening),
+        }
+    }
+
+    Ok(RevealOutput { sent, recv })
 }
 
 async fn send_request(conn: TlsConnection, request: HttpRequest) -> Result<HttpResponse> {

--- a/crates/sdk-core/src/types.rs
+++ b/crates/sdk-core/src/types.rs
@@ -368,6 +368,35 @@ impl From<HashAlgorithm> for tlsn_core::hash::HashAlgId {
     }
 }
 
+/// Opening for a single hash-committed range.
+///
+/// Pairs the commitment hash digest with the blinder used to produce it, so
+/// the holder can later prove `H(plaintext || blinder) == hash` to a third
+/// party without re-running the MPC-TLS protocol. The committed range and
+/// algorithm come from the input [`CommitRange`] at the same index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HashOpening {
+    /// The commitment hash digest.
+    pub hash: Vec<u8>,
+    /// The blinder (16 bytes) used to compute the commitment.
+    pub blinder: Vec<u8>,
+}
+
+/// Output of [`SdkProver::reveal`].
+///
+/// Mirrors the shape of the input [`Commit`]: `sent[i]` opens `commit.sent[i]`
+/// and likewise for `recv`. Both vectors are empty when no commit was
+/// supplied.
+///
+/// [`SdkProver::reveal`]: crate::prover::SdkProver::reveal
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RevealOutput {
+    /// Openings for `commit.sent`, in input order.
+    pub sent: Vec<HashOpening>,
+    /// Openings for `commit.recv`, in input order.
+    pub recv: Vec<HashOpening>,
+}
+
 /// What action to take with the matched ranges.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "UPPERCASE")]

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -130,20 +130,30 @@ impl JsProver {
     ///
     /// Optionally accepts a `Commit` object with ranges to hash-commit.
     /// Pass `undefined` or omit the second argument for reveal-only proofs.
-    pub async fn reveal(&mut self, reveal: Reveal, commit: Option<Commit>) -> Result<()> {
+    ///
+    /// Returns a `RevealOutput` with one `CommitmentOpening` per
+    /// hash-committed range (`{ direction, ranges, algorithm, hash, blinder }`),
+    /// in the same order as the input `Commit`. The `commitments` array is
+    /// empty when no commit was supplied.
+    pub async fn reveal(
+        &mut self,
+        reveal: Reveal,
+        commit: Option<Commit>,
+    ) -> Result<RevealOutput> {
         self.emit_progress("REVEAL", 0.7, "Proving and revealing data...");
 
         let core_reveal = convert_reveal(reveal);
         let core_commit = commit.map(convert_commit);
 
-        self.inner
+        let output = self
+            .inner
             .reveal(core_reveal, core_commit)
             .await
             .map_err(|e| JsError::new(&e.to_string()))?;
 
         self.emit_progress("FINALIZED", 0.95, "Protocol finalized");
 
-        Ok(())
+        Ok(convert_reveal_output(output))
     }
 }
 
@@ -262,6 +272,20 @@ fn convert_commit(commit: Commit) -> tlsn_sdk_core::Commit {
     tlsn_sdk_core::Commit {
         sent: commit.sent.into_iter().map(convert_commit_range).collect(),
         recv: commit.recv.into_iter().map(convert_commit_range).collect(),
+    }
+}
+
+fn convert_reveal_output(output: tlsn_sdk_core::RevealOutput) -> RevealOutput {
+    RevealOutput {
+        sent: output.sent.into_iter().map(convert_hash_opening).collect(),
+        recv: output.recv.into_iter().map(convert_hash_opening).collect(),
+    }
+}
+
+fn convert_hash_opening(opening: tlsn_sdk_core::HashOpening) -> HashOpening {
+    HashOpening {
+        hash: opening.hash,
+        blinder: opening.blinder,
     }
 }
 

--- a/crates/wasm/src/prover/mod.rs
+++ b/crates/wasm/src/prover/mod.rs
@@ -132,14 +132,10 @@ impl JsProver {
     /// Pass `undefined` or omit the second argument for reveal-only proofs.
     ///
     /// Returns a `RevealOutput` with one `CommitmentOpening` per
-    /// hash-committed range (`{ direction, ranges, algorithm, hash, blinder }`),
-    /// in the same order as the input `Commit`. The `commitments` array is
-    /// empty when no commit was supplied.
-    pub async fn reveal(
-        &mut self,
-        reveal: Reveal,
-        commit: Option<Commit>,
-    ) -> Result<RevealOutput> {
+    /// hash-committed range (`{ direction, ranges, algorithm, hash, blinder
+    /// }`), in the same order as the input `Commit`. The `commitments`
+    /// array is empty when no commit was supplied.
+    pub async fn reveal(&mut self, reveal: Reveal, commit: Option<Commit>) -> Result<RevealOutput> {
         self.emit_progress("REVEAL", 0.7, "Proving and revealing data...");
 
         let core_reveal = convert_reveal(reveal);

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -160,6 +160,34 @@ pub struct Reveal {
     pub server_identity: bool,
 }
 
+/// Opening for a single hash-committed range.
+///
+/// Pairs the commitment hash with the blinder used to produce it, so the
+/// caller can later prove `H(plaintext || blinder) == hash` without rerunning
+/// MPC-TLS. Range and algorithm are not repeated — they live on the input
+/// `CommitRange` at the same index.
+#[derive(Debug, Tsify, Serialize)]
+#[tsify(into_wasm_abi)]
+pub struct HashOpening {
+    /// The commitment hash digest.
+    pub hash: Vec<u8>,
+    /// The blinder (16 bytes) used to compute the commitment.
+    pub blinder: Vec<u8>,
+}
+
+/// Output of `Prover.reveal()`.
+///
+/// Mirrors the input `Commit`: `sent[i]` opens `commit.sent[i]`, likewise for
+/// `recv`. Both arrays are empty when no commit was supplied.
+#[derive(Debug, Tsify, Serialize)]
+#[tsify(into_wasm_abi)]
+pub struct RevealOutput {
+    /// Openings for `commit.sent`, in input order.
+    pub sent: Vec<HashOpening>,
+    /// Openings for `commit.recv`, in input order.
+    pub recv: Vec<HashOpening>,
+}
+
 /// Output from the verifier.
 #[derive(Debug, Tsify, Serialize)]
 #[tsify(into_wasm_abi)]


### PR DESCRIPTION
## Summary

Follow-up to #1127. That PR wired hash-commit handlers through `SdkProver::reveal()` but discarded the resulting `ProverOutput`, so callers had no way to later prove `H(plaintext || blinder) == commitment` to a third party. This change surfaces the per-range `(hash, blinder)` openings.

## Design

`SdkProver::reveal()` and `JsProver.reveal()` now return a `RevealOutput` whose shape mirrors the input `Commit`:

```rust
struct HashOpening { hash: Vec<u8>, blinder: Vec<u8> }
struct RevealOutput { sent: Vec<HashOpening>, recv: Vec<HashOpening> }
```

`output.sent[i]` opens `commit.sent[i]` and likewise for `recv` — order matches the input, so the caller correlates by index. Both arrays are empty when no commit was supplied. Range and algorithm aren't repeated in the output because the caller already has them on the input `CommitRange`.

Internally, `build_reveal_output()` zips `ProverOutput.transcript_commitments` with `transcript_secrets` (the prover pushes them in lockstep at `crates/tlsn/src/prover/prove.rs:113-120`), verifies their `direction`/`idx` agree, and routes each `HashOpening` into the `sent`/`recv` bucket based on the commitment direction.

## API change

This is a breaking change to the SDK: `reveal()` returns `Result<RevealOutput>` instead of `Result<()>`. The only in-tree caller is `crates/wasm/src/prover/mod.rs` (updated).

## Test plan

- [x] `cargo check -p tlsn-sdk-core -p tlsn-wasm --tests`
- [x] `cargo test -p tlsn-sdk-core --lib` — 36 existing tests pass
- [ ] Plugin smoke test: verify `H(plaintext || blinder) == hash` for a real `action: 'HASH'` handler end-to-end