### PR TITLE
feat(tlsn): mpz async threadpool integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,8 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "web-spawn"
-version = "0.3.0"
-source = "git+https://github.com/tlsnotary/tlsn-utils?rev=5efe2f0#5efe2f00ee476541529b15508274c65a077e7c6b"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78095800f07cfef735e751ab04b502eebb0c4363c6d84477438c00aed52a2bb"
 dependencies = [
  "crossbeam-channel",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,7 +1592,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clmul"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3606,7 +3612,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 [[package]]
 name = "matrix-transpose"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -3662,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "mpz-circuits-core",
  "mpz-circuits-data",
@@ -3671,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "bincode",
  "itybity 0.3.2",
@@ -3686,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits-data"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "bincode",
  "mpz-circuits-core",
@@ -3696,7 +3702,7 @@ dependencies = [
 [[package]]
 name = "mpz-cointoss"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "futures",
  "mpz-cointoss-core",
@@ -3709,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "mpz-cointoss-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "mpz-core",
  "opaque-debug",
@@ -3720,12 +3726,15 @@ dependencies = [
 [[package]]
 name = "mpz-common"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
+ "async-task",
  "async-trait",
  "bytes",
  "cfg-if",
  "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "futures",
  "pin-project-lite",
  "pollster",
@@ -3739,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "mpz-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "aes 0.9.0",
  "bcs",
@@ -3765,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "mpz-fields"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-secp256r1",
@@ -3786,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "mpz-garble"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "derive_builder 0.11.2",
@@ -3812,7 +3821,7 @@ dependencies = [
 [[package]]
 name = "mpz-garble-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "aes 0.9.0",
  "bitvec",
@@ -3843,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "mpz-hash"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "blake3",
  "itybity 0.3.2",
@@ -3856,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "mpz-ideal-vm"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "futures",
@@ -3873,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "mpz-memory-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "blake3",
  "futures",
@@ -3888,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "mpz-ole"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "futures",
@@ -3906,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "mpz-ole-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "hybrid-array",
  "itybity 0.3.2",
@@ -3922,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "mpz-ot"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3946,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "mpz-ot-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "aes 0.9.0",
  "blake3",
@@ -3977,7 +3986,7 @@ dependencies = [
 [[package]]
 name = "mpz-share-conversion"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "mpz-common",
@@ -3993,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "mpz-share-conversion-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "mpz-common",
  "mpz-core",
@@ -4007,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "mpz-vm-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "futures",
@@ -4020,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "mpz-zk"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4038,7 +4047,7 @@ dependencies = [
 [[package]]
 name = "mpz-zk-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -7123,7 +7132,7 @@ dependencies = [
 [[package]]
 name = "web-spawn"
 version = "0.3.0"
-source = "git+https://github.com/tlsnotary/tlsn-utils?rev=64722f7#64722f7de999cbd41c0cab7312dade306d50ea5f"
+source = "git+https://github.com/tlsnotary/tlsn-utils?rev=5efe2f0#5efe2f00ee476541529b15508274c65a077e7c6b"
 dependencies = [
  "crossbeam-channel",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
-web-spawn = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "5efe2f0" }
+web-spawn = { version = "0.3" }
 web-time = { version = "0.2" }
 webpki-roots = { version = "1.0" }
 webpki-root-certs = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,21 +71,21 @@ tlsn-sdk-core = { path = "crates/sdk-core" }
 tlsn-wasm = { path = "crates/wasm" }
 tlsn = { path = "crates/tlsn" }
 
-mpz-circuits = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-circuits-data = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-memory-core = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-common = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-core = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-vm-core = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-garble = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-garble-core = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-ole = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-ot = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-share-conversion = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-fields = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-zk = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-hash = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
-mpz-ideal-vm = { git = "https://github.com/privacy-ethereum/mpz", rev = "8e9b66165d800635bc57c07bbbcb4a32592a1d7e" }
+mpz-circuits = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-circuits-data = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-memory-core = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-common = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-core = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-vm-core = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-garble = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-garble-core = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-ole = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-ot = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-share-conversion = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-fields = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-zk = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-hash = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
+mpz-ideal-vm = { git = "https://github.com/privacy-ethereum/mpz", rev = "3c78547" }
 
 futures-plex = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "64722f7" }
 rangeset = { version = "0.4" }
@@ -170,7 +170,7 @@ tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
-web-spawn = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "64722f7" }
+web-spawn = { git = "https://github.com/tlsnotary/tlsn-utils", rev = "5efe2f0" }
 web-time = { version = "0.2" }
 webpki-roots = { version = "1.0" }
 webpki-root-certs = { version = "1.0" }

--- a/crates/components/deap/src/lib.rs
+++ b/crates/components/deap/src/lib.rs
@@ -335,8 +335,8 @@ where
         let mut zk = self.zk.clone().try_lock_owned().unwrap();
         let mut mpc = self.mpc.clone().try_lock_owned().unwrap();
         ctx.try_join(
-            async move |ctx| zk.flush(ctx).await,
-            async move |ctx| mpc.flush(ctx).await,
+            move |ctx| Box::pin(async move { zk.flush(ctx).await }),
+            move |ctx| Box::pin(async move { mpc.flush(ctx).await }),
         )
         .await
         .map_err(VmError::execute)??;
@@ -353,8 +353,8 @@ where
         let mut zk = self.zk.clone().try_lock_owned().unwrap();
         let mut mpc = self.mpc.clone().try_lock_owned().unwrap();
         ctx.try_join(
-            async move |ctx| zk.preprocess(ctx).await,
-            async move |ctx| mpc.preprocess(ctx).await,
+            move |ctx| Box::pin(async move { zk.preprocess(ctx).await }),
+            move |ctx| Box::pin(async move { mpc.preprocess(ctx).await }),
         )
         .await
         .map_err(VmError::execute)??;

--- a/crates/components/hmac-sha256/benches/prf.rs
+++ b/crates/components/hmac-sha256/benches/prf.rs
@@ -44,7 +44,7 @@ async fn prf(config: PrfConfig) {
     let server_random: [u8; 32] = [96u8; 32];
     let session_hash = [55u8; 32];
 
-    let (mut leader_exec, mut follower_exec) = test_mt_context(8);
+    let (leader_exec, follower_exec) = test_mt_context(8);
     let mut leader_ctx = leader_exec.new_context().unwrap();
     let mut follower_ctx = follower_exec.new_context().unwrap();
 

--- a/crates/components/key-exchange/src/exchange.rs
+++ b/crates/components/key-exchange/src/exchange.rs
@@ -252,26 +252,32 @@ where
 
         let (follower_key, _, _) = ctx
             .try_join3(
-                async move |ctx| {
-                    Ok(match role {
-                        Role::Leader => ctx.io_mut().expect_next().await?,
-                        Role::Follower => {
-                            ctx.io_mut().send(public_key).await?;
-                            public_key
-                        }
+                move |ctx| {
+                    Box::pin(async move {
+                        Ok::<_, KeyExchangeError>(match role {
+                            Role::Leader => ctx.io_mut().expect_next().await?,
+                            Role::Follower => {
+                                ctx.io_mut().send(public_key).await?;
+                                public_key
+                            }
+                        })
                     })
                 },
-                async move |ctx| {
-                    converter_0
-                        .flush(ctx)
-                        .await
-                        .map_err(KeyExchangeError::share_conversion)
+                move |ctx| {
+                    Box::pin(async move {
+                        converter_0
+                            .flush(ctx)
+                            .await
+                            .map_err(KeyExchangeError::share_conversion)
+                    })
                 },
-                async move |ctx| {
-                    converter_1
-                        .flush(ctx)
-                        .await
-                        .map_err(KeyExchangeError::share_conversion)
+                move |ctx| {
+                    Box::pin(async move {
+                        converter_1
+                            .flush(ctx)
+                            .await
+                            .map_err(KeyExchangeError::share_conversion)
+                    })
                 },
             )
             .await??;
@@ -440,11 +446,15 @@ where
     let mut converter_1 = converter_1.try_lock_owned().unwrap();
     let (pms_share_0, pms_share_1) = ctx
         .try_join(
-            async move |ctx| {
-                derive_x_coord_share(ctx, role, &mut *converter_0, encoded_point).await
+            move |ctx| {
+                Box::pin(async move {
+                    derive_x_coord_share(ctx, role, &mut *converter_0, encoded_point).await
+                })
             },
-            async move |ctx| {
-                derive_x_coord_share(ctx, role, &mut *converter_1, encoded_point).await
+            move |ctx| {
+                Box::pin(async move {
+                    derive_x_coord_share(ctx, role, &mut *converter_1, encoded_point).await
+                })
             },
         )
         .await??;

--- a/crates/examples-zk/Cargo.lock
+++ b/crates/examples-zk/Cargo.lock
@@ -114,7 +114,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
 ]
@@ -489,6 +489,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -901,11 +907,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -952,7 +958,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clmul"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1139,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
@@ -1398,7 +1404,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1497,7 +1503,7 @@ checksum = "cda94f31325c4275e9706adecbb6f0650dee2f904c915a98e3d81adaaaa757aa"
 dependencies = [
  "base16ct 1.0.0",
  "crypto-bigint 0.7.3",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "digest 0.11.3",
  "hybrid-array",
  "once_cell",
@@ -2465,7 +2471,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 [[package]]
 name = "matrix-transpose"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -2506,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "mpz-circuits-core",
  "mpz-circuits-data",
@@ -2515,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "bincode",
  "itybity 0.3.3",
@@ -2530,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits-data"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "bincode",
  "mpz-circuits-core",
@@ -2540,7 +2546,7 @@ dependencies = [
 [[package]]
 name = "mpz-cointoss"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "futures",
  "mpz-cointoss-core",
@@ -2553,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "mpz-cointoss-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "mpz-core",
  "opaque-debug",
@@ -2564,12 +2570,15 @@ dependencies = [
 [[package]]
 name = "mpz-common"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
+ "async-task",
  "async-trait",
  "bytes",
  "cfg-if",
  "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "futures",
  "pin-project-lite",
  "pollster",
@@ -2583,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "mpz-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "aes 0.9.0",
  "bcs",
@@ -2591,7 +2600,7 @@ dependencies = [
  "blake3",
  "bytemuck",
  "cfg-if",
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "clmul",
  "hybrid-array",
  "itybity 0.3.3",
@@ -2609,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "mpz-fields"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-secp256r1",
@@ -2630,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "mpz-garble"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "derive_builder 0.11.2",
@@ -2656,13 +2665,13 @@ dependencies = [
 [[package]]
 name = "mpz-garble-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "aes 0.9.0",
  "bitvec",
  "blake3",
  "cfg-if",
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "derive_builder 0.11.2",
  "itybity 0.3.3",
  "mpz-circuits",
@@ -2687,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "mpz-hash"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "blake3",
  "itybity 0.3.3",
@@ -2700,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "mpz-ideal-vm"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "futures",
@@ -2717,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "mpz-memory-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "blake3",
  "futures",
@@ -2732,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "mpz-ole"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "futures",
@@ -2750,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "mpz-ole-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "hybrid-array",
  "itybity 0.3.3",
@@ -2766,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "mpz-ot"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2789,13 +2798,13 @@ dependencies = [
 [[package]]
 name = "mpz-ot-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "aes 0.9.0",
  "blake3",
  "bytemuck",
  "cfg-if",
- "cipher 0.5.1",
+ "cipher 0.5.2",
  "clmul",
  "ctr 0.9.2",
  "curve25519-dalek",
@@ -2820,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "mpz-share-conversion"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "mpz-common",
@@ -2836,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "mpz-share-conversion-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "mpz-common",
  "mpz-core",
@@ -2850,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "mpz-vm-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "futures",
@@ -2863,7 +2872,7 @@ dependencies = [
 [[package]]
 name = "mpz-zk"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "async-trait",
  "blake3",
@@ -2881,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "mpz-zk-core"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=8e9b66165d800635bc57c07bbbcb4a32592a1d7e#8e9b66165d800635bc57c07bbbcb4a32592a1d7e"
+source = "git+https://github.com/privacy-ethereum/mpz?rev=3c78547#3c7854708d3ca8be5e4fb049c2bc3842e88c7ca4"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -3151,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3349,18 +3358,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3464,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b52e6ee42db392378a95622b463c9740631171d1efce43fa445a569c1600cb6"
 dependencies = [
  "crypto-bigint 0.7.3",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
@@ -5205,7 +5214,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5214,7 +5223,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5235,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -5867,9 +5876,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -6028,9 +6037,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/crates/mpc-tls/src/follower.rs
+++ b/crates/mpc-tls/src/follower.rs
@@ -179,24 +179,30 @@ impl MpcTlsFollower {
                 .map_err(|_| MpcTlsError::other("VM lock is held"))?;
             self.ctx
                 .try_join3(
-                    async move |ctx| {
-                        ke.setup(ctx)
-                            .await
-                            .map(|_| ke)
-                            .map_err(MpcTlsError::preprocess)
+                    move |ctx| {
+                        Box::pin(async move {
+                            ke.setup(ctx)
+                                .await
+                                .map(|_| ke)
+                                .map_err(MpcTlsError::preprocess)
+                        })
                     },
-                    async move |ctx| {
-                        record_layer
-                            .preprocess(ctx)
-                            .await
-                            .map(|_| record_layer)
-                            .map_err(MpcTlsError::preprocess)
+                    move |ctx| {
+                        Box::pin(async move {
+                            record_layer
+                                .preprocess(ctx)
+                                .await
+                                .map(|_| record_layer)
+                                .map_err(MpcTlsError::preprocess)
+                        })
                     },
-                    async move |ctx| {
-                        vm.preprocess(ctx).await.map_err(MpcTlsError::preprocess)?;
-                        vm.flush(ctx).await.map_err(MpcTlsError::preprocess)?;
+                    move |ctx| {
+                        Box::pin(async move {
+                            vm.preprocess(ctx).await.map_err(MpcTlsError::preprocess)?;
+                            vm.flush(ctx).await.map_err(MpcTlsError::preprocess)?;
 
-                        Ok::<_, MpcTlsError>(())
+                            Ok::<_, MpcTlsError>(())
+                        })
                     },
                 )
                 .await

--- a/crates/mpc-tls/src/leader.rs
+++ b/crates/mpc-tls/src/leader.rs
@@ -210,27 +210,33 @@ impl MpcTlsLeader {
 
         let (ke, record_layer, _) = ctx
             .try_join3(
-                async move |ctx| {
-                    ke.setup(ctx)
-                        .await
-                        .map(|_| ke)
-                        .map_err(MpcTlsError::preprocess)
+                move |ctx| {
+                    Box::pin(async move {
+                        ke.setup(ctx)
+                            .await
+                            .map(|_| ke)
+                            .map_err(MpcTlsError::preprocess)
+                    })
                 },
-                async move |ctx| {
-                    record_layer
-                        .preprocess(ctx)
-                        .await
-                        .map(|_| record_layer)
-                        .map_err(MpcTlsError::preprocess)
+                move |ctx| {
+                    Box::pin(async move {
+                        record_layer
+                            .preprocess(ctx)
+                            .await
+                            .map(|_| record_layer)
+                            .map_err(MpcTlsError::preprocess)
+                    })
                 },
-                async move |ctx| {
-                    vm_lock
-                        .preprocess(ctx)
-                        .await
-                        .map_err(MpcTlsError::preprocess)?;
-                    vm_lock.flush(ctx).await.map_err(MpcTlsError::preprocess)?;
+                move |ctx| {
+                    Box::pin(async move {
+                        vm_lock
+                            .preprocess(ctx)
+                            .await
+                            .map_err(MpcTlsError::preprocess)?;
+                        vm_lock.flush(ctx).await.map_err(MpcTlsError::preprocess)?;
 
-                    Ok::<_, MpcTlsError>(())
+                        Ok::<_, MpcTlsError>(())
+                    })
                 },
             )
             .await

--- a/crates/mpc-tls/src/record_layer.rs
+++ b/crates/mpc-tls/src/record_layer.rs
@@ -206,8 +206,8 @@ impl RecordLayer {
 
         // Preprocesses GHASH keys in parallel.
         ctx.try_join(
-            async move |ctx| encrypt.preprocess(ctx).await,
-            async move |ctx| decrypt.preprocess(ctx).await,
+            move |ctx| Box::pin(async move { encrypt.preprocess(ctx).await }),
+            move |ctx| Box::pin(async move { decrypt.preprocess(ctx).await }),
         )
         .await
         .map_err(MpcTlsError::record_layer)?
@@ -257,8 +257,8 @@ impl RecordLayer {
 
         // Computes GHASH keys in parallel.
         ctx.try_join(
-            async move |ctx| encrypt.setup(ctx).await,
-            async move |ctx| decrypt.setup(ctx).await,
+            move |ctx| Box::pin(async move { encrypt.setup(ctx).await }),
+            move |ctx| Box::pin(async move { decrypt.setup(ctx).await }),
         )
         .await
         .map_err(MpcTlsError::record_layer)?
@@ -454,18 +454,24 @@ impl RecordLayer {
         // Run tag computation and VM in parallel.
         let (mut tags, _) = ctx
             .try_join(
-                async move |ctx| {
-                    verify_tags
-                        .run(ctx)
-                        .map_err(MpcTlsError::record_layer)
-                        .await?;
+                move |ctx| {
+                    Box::pin(async move {
+                        verify_tags
+                            .run(ctx)
+                            .map_err(MpcTlsError::record_layer)
+                            .await?;
 
-                    compute_tags
-                        .run(ctx)
-                        .map_err(MpcTlsError::record_layer)
-                        .await
+                        compute_tags
+                            .run(ctx)
+                            .map_err(MpcTlsError::record_layer)
+                            .await
+                    })
                 },
-                async move |ctx| vm.execute_all(ctx).map_err(MpcTlsError::record_layer).await,
+                move |ctx| {
+                    Box::pin(
+                        async move { vm.execute_all(ctx).map_err(MpcTlsError::record_layer).await },
+                    )
+                },
             )
             .await
             .map_err(MpcTlsError::record_layer)??;

--- a/crates/tlsn/src/deps/prover.rs
+++ b/crates/tlsn/src/deps/prover.rs
@@ -1,5 +1,5 @@
 use mpc_tls::{MpcTlsLeader, SessionKeys};
-use mpz_common::{Context, ThreadId};
+use mpz_common::{Context, ContextId};
 use mpz_core::Block;
 use mpz_garble_core::Delta;
 use mpz_ot::{
@@ -128,7 +128,7 @@ impl ProverMpcDeps {
 /// Protocol dependencies for Proxy.
 pub(crate) struct ProverProxyDeps {
     pub(crate) prover: Box<ProxyProver>,
-    pub(crate) id: ThreadId,
+    pub(crate) id: ContextId,
 }
 
 impl std::fmt::Debug for ProverProxyDeps {

--- a/crates/tlsn/src/deps/verifier.rs
+++ b/crates/tlsn/src/deps/verifier.rs
@@ -1,6 +1,6 @@
 use hmac_sha256::{MSMode, NetworkMode, Prf, PrfConfig};
 use mpc_tls::{MpcTlsFollower, SessionKeys};
-use mpz_common::{Context, ThreadId};
+use mpz_common::{Context, ContextId};
 use mpz_core::Block;
 use mpz_garble_core::Delta;
 use mpz_ot::{
@@ -126,7 +126,7 @@ impl VerifierMpcDeps {
 /// Protocol dependencies for Proxy.
 pub(crate) struct VerifierProxyDeps {
     pub(crate) verifier: Box<ProxyVerifier>,
-    pub(crate) id: ThreadId,
+    pub(crate) id: ContextId,
 }
 
 impl std::fmt::Debug for VerifierProxyDeps {

--- a/crates/tlsn/src/session.rs
+++ b/crates/tlsn/src/session.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use futures::{AsyncRead, AsyncWrite};
-use mpz_common::{ThreadId, context::Multithread, io::Io, mux::Mux};
+use mpz_common::{Executor, io::Io, mux::Mux};
 use tlsn_core::config::{prover::ProverConfig, verifier::VerifierConfig};
 use tlsn_mux::{Connection, Handle};
 
@@ -18,9 +18,6 @@ use crate::{
     prover::{Prover, state as prover_state},
     verifier::{Verifier, state as verifier_state},
 };
-
-/// Maximum concurrency for multi-threaded context.
-const MAX_CONCURRENCY: usize = 8;
 
 /// A TLSNotary session over a communication channel.
 ///
@@ -40,7 +37,7 @@ const MAX_CONCURRENCY: usize = 8;
 #[must_use = "session must be polled continuously to make progress, including during closing."]
 pub struct Session<Io> {
     conn: Option<Connection<Io>>,
-    mt: Multithread,
+    executor: Executor,
     handle: Handle,
 }
 
@@ -52,19 +49,18 @@ where
     pub fn new(io: Io) -> Self {
         let mut mux_config = tlsn_mux::Config::default();
 
-        mux_config.set_max_num_streams(36);
         mux_config.set_keep_alive(true);
         mux_config.set_close_sync(true);
 
         let conn = tlsn_mux::Connection::new(io, mux_config);
         let handle = conn.handle().expect("handle should be available");
-        let mt = build_mt_context(MuxHandle {
+        let executor = build_executor(MuxHandle {
             handle: handle.clone(),
         });
 
         Self {
             conn: Some(conn),
-            mt,
+            executor,
             handle,
         }
     }
@@ -74,7 +70,7 @@ where
         &mut self,
         config: ProverConfig,
     ) -> Result<Prover<prover_state::Initialized>> {
-        let ctx = self.mt.new_context().map_err(|e| {
+        let ctx = self.executor.new_context().map_err(|e| {
             Error::internal()
                 .with_msg("failed to create new prover")
                 .with_source(e)
@@ -88,7 +84,7 @@ where
         &mut self,
         config: VerifierConfig,
     ) -> Result<Verifier<verifier_state::Initialized>> {
-        let ctx = self.mt.new_context().map_err(|e| {
+        let ctx = self.executor.new_context().map_err(|e| {
             Error::internal()
                 .with_msg("failed to create new verifier")
                 .with_source(e)
@@ -162,7 +158,7 @@ where
                 waker: waker.clone(),
             },
             SessionHandle {
-                mt: self.mt,
+                executor: self.executor,
                 should_close,
                 waker,
                 handle: self.handle,
@@ -247,7 +243,7 @@ where
 ///
 /// Used to create provers/verifiers and control the session lifecycle.
 pub struct SessionHandle {
-    mt: Multithread,
+    executor: Executor,
     should_close: Arc<AtomicBool>,
     waker: Arc<Mutex<Option<Waker>>>,
     handle: Handle,
@@ -259,7 +255,7 @@ impl SessionHandle {
         &mut self,
         config: ProverConfig,
     ) -> Result<Prover<prover_state::Initialized>> {
-        let ctx = self.mt.new_context().map_err(|e| {
+        let ctx = self.executor.new_context().map_err(|e| {
             Error::internal()
                 .with_msg("failed to create new prover")
                 .with_source(e)
@@ -273,7 +269,7 @@ impl SessionHandle {
         &mut self,
         config: VerifierConfig,
     ) -> Result<Verifier<verifier_state::Initialized>> {
-        let ctx = self.mt.new_context().map_err(|e| {
+        let ctx = self.executor.new_context().map_err(|e| {
             Error::internal()
                 .with_msg("failed to create new verifier")
                 .with_source(e)
@@ -305,28 +301,29 @@ impl std::fmt::Debug for MuxHandle {
 }
 
 impl Mux for MuxHandle {
-    fn open(&self, id: ThreadId) -> Result<Io, std::io::Error> {
-        let stream = self
-            .handle
-            .new_stream(id.as_ref())
-            .map_err(std::io::Error::other)?;
+    fn open(&self, id: &[u8]) -> Result<Io, std::io::Error> {
+        let stream = self.handle.new_stream(id).map_err(std::io::Error::other)?;
         let io = Io::from_io(stream);
 
         Ok(io)
     }
 }
 
-/// Builds a multi-threaded context with the given muxer.
-fn build_mt_context(mux: MuxHandle) -> Multithread {
-    let builder = Multithread::builder()
-        .mux(Box::new(mux) as Box<_>)
-        .concurrency(MAX_CONCURRENCY);
+/// Builds a work-stealing executor with the given muxer.
+fn build_executor(mux: MuxHandle) -> Executor {
+    #[cfg(all(feature = "web", target_arch = "wasm32"))]
+    let cores = web_spawn::available_parallelism().map(|n| n.get());
+
+    #[cfg(not(all(feature = "web", target_arch = "wasm32")))]
+    let cores = std::thread::available_parallelism().map(|n| n.get());
+
+    let builder = Executor::builder().num_threads(cores.unwrap_or(8));
 
     #[cfg(all(feature = "web", target_arch = "wasm32"))]
-    let builder = builder.spawn_handler(|f| {
+    let builder = builder.spawn(|f| {
         let _ = web_spawn::spawn(f);
         Ok(())
     });
 
-    builder.build().unwrap()
+    builder.build(mux)
 }


### PR DESCRIPTION
This PR integrates the new async-yielding threadpool, using the fix of  https://github.com/privacy-ethereum/mpz/pull/398

Has been benched against main and the regression is gone.

**Browser benches**
```
main
[00:01:43] ████████████████████████████████████████ 12/12 Benchmarks complete
================================================================================
TLSNotary Benchmark Results
================================================================================

cable [mpc] (20 Mbps, 20ms latency, 1KB↑ 2KB↓):
  Median:  15.51s

fiber [mpc] (100 Mbps, 15ms latency, 1KB↑ 2KB↓):
  Median:  4.78s

mobile_5g [mpc] (30 Mbps, 30ms latency, 1KB↑ 2KB↓):
  Median:  11.49s


feat/async-threadpool-integration
[00:01:41] ████████████████████████████████████████ 12/12 Benchmarks complete
================================================================================
TLSNotary Benchmark Results
================================================================================

cable [mpc] (20 Mbps, 20ms latency, 1KB↑ 2KB↓):
  Median:  15.40s

fiber [mpc] (100 Mbps, 15ms latency, 1KB↑ 2KB↓):
  Median:  4.54s

mobile_5g [mpc] (30 Mbps, 30ms latency, 1KB↑ 2KB↓):
  Median:  11.23s
```

