### PR TITLE
fix(tlsn): raise mux max_num_streams to 2048

### DIFF
--- a/crates/tlsn/src/session.rs
+++ b/crates/tlsn/src/session.rs
@@ -51,6 +51,13 @@ where
 
         mux_config.set_keep_alive(true);
         mux_config.set_close_sync(true);
+        // The threading design opens roughly ~24 streams per TLS record during
+        // preprocessing; a max_recv of 70000 was measured to peak at 555
+        // concurrent streams, exceeding the mux default of 512. Raise the limit
+        // to 2048 for headroom (~3.7x the measured peak) while keeping a 512 MiB
+        // auto-tuning pool within the default 1 GiB connection receive window
+        // (the window must stay >= 256 KiB * max_num_streams).
+        mux_config.set_max_num_streams(2048);
 
         let conn = tlsn_mux::Connection::new(io, mux_config);
         let handle = conn.handle().expect("handle should be available");
@@ -326,4 +333,36 @@ fn build_executor(mux: MuxHandle) -> Executor {
     });
 
     builder.build(mux)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_util::compat::TokioAsyncReadCompatExt;
+
+    /// Regression test: the threading design opens many more concurrent streams
+    /// than the mux default limit of 512. A session's mux must be configured to
+    /// allow significantly more, otherwise preprocessing fails with
+    /// `TooManyStreams`.
+    #[test]
+    fn test_session_allows_many_concurrent_streams() {
+        // Keep the peer half alive; `Session::new` does not touch the IO.
+        let (io, _peer) = tokio::io::duplex(1 << 16);
+        let session = Session::new(io.compat());
+
+        // Open more streams than the previous default limit of 512, holding
+        // each one open so it counts against the connection's stream limit.
+        const NUM_STREAMS: usize = 1024;
+        let mut streams = Vec::with_capacity(NUM_STREAMS);
+        for i in 0..NUM_STREAMS {
+            let id = format!("stream-{i}");
+            let stream = session
+                .handle
+                .new_stream(id.as_bytes())
+                .unwrap_or_else(|e| panic!("failed to open stream {i}: {e}"));
+            streams.push(stream);
+        }
+
+        assert_eq!(streams.len(), NUM_STREAMS);
+    }
 }


### PR DESCRIPTION
## Problem

MPC preprocessing fails with `TooManyStreams` on realistic transcript sizes:

```
INFO  tlsn_verifier_server::verifier: Accepting MPC TLS commitment with max_sent=8192, max_recv=70000
ERROR tlsn_mux::connection::active: maximum number of streams reached
ERROR mpc_tls::follower: error=preprocess error: execution error: context mux error
```

The mux's default limit is **512** concurrent streams. The threading design opens many more during preprocessing — roughly **~24 streams per TLS record** — so a moderately-sized transcript tips it over. The existing integration tests use a smaller config and never reached the limit, so this wasn't caught.

## Measurement

Instrumented the pinned mux rev to record peak concurrent streams during the real end-to-end MPC flow:

| `max_sent` | `max_recv` | Peak concurrent streams |
|---|---|---|
| 4096 | 16384 | 285 |
| 8192 | 70000 | **555** (the production failure) |

The peak scales with transcript size; 512 sat right in the middle of the realistic range.

## Fix

Raise `max_num_streams` to **2048** (~3.7× the measured peak).

This deliberately stays below 4096: the mux requires `max_connection_receive_window >= 256 KiB * max_num_streams`, and the default window is 1 GiB. At 2048 the reserved minimum is 512 MiB, leaving a **512 MiB auto-tuning pool** so per-stream receive windows can still grow — whereas 4096 would consume the entire window and pin every stream to 256 KiB, hurting throughput. Memory is allocated lazily per opened stream, so the higher ceiling itself costs nothing.

## Test

Adds `test_session_allows_many_concurrent_streams`, which opens 1024 concurrent streams through a session's mux. It fails at the old 512 default and passes with this change.

## Follow-up

The peak scales with transcript size. If deployments support substantially larger transcripts than `max_recv=70000`, both `max_num_streams` and `max_connection_receive_window` should be raised together (keeping the `window >= 256 KiB * max_num_streams` invariant) rather than bumping the stream cap alone.