### PR TITLE
docs(tlsn): recommend disabling Nagle's algorithm (TCP_NODELAY)

### DIFF
--- a/crates/examples-zk/prover.rs
+++ b/crates/examples-zk/prover.rs
@@ -90,6 +90,9 @@ pub async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
 
     // Open a TCP connection to the server.
     let client_socket = tokio::net::TcpStream::connect(server_addr).await?;
+    // Disable Nagle's algorithm to reduce protocol latency. See the `tlsn`
+    // crate's performance notes for details.
+    client_socket.set_nodelay(true)?;
 
     // Bind the prover to the server connection.
     let (tls_connection, prover) = prover.connect(

--- a/crates/examples/attestation/prove.rs
+++ b/crates/examples/attestation/prove.rs
@@ -102,6 +102,9 @@ async fn prover<S: AsyncWrite + AsyncRead + Send + Sync + Unpin + 'static>(
 
     // Open a TCP connection to the server.
     let client_socket = tokio::net::TcpStream::connect((server_host, server_port)).await?;
+    // Disable Nagle's algorithm to reduce protocol latency. See the `tlsn`
+    // crate's performance notes for details.
+    client_socket.set_nodelay(true)?;
 
     // Bind the prover to the server connection.
     let (tls_connection, prover) = prover.connect(

--- a/crates/examples/basic/basic.rs
+++ b/crates/examples/basic/basic.rs
@@ -99,6 +99,9 @@ async fn prover<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
 
     // Open a TCP connection to the server.
     let client_socket = tokio::net::TcpStream::connect(server_addr).await?;
+    // Disable Nagle's algorithm to reduce protocol latency. See the `tlsn`
+    // crate's performance notes for details.
+    client_socket.set_nodelay(true)?;
 
     // Bind the prover to the server connection.
     let (tls_connection, prover) = prover.connect(

--- a/crates/examples/proxy/proxy.rs
+++ b/crates/examples/proxy/proxy.rs
@@ -213,6 +213,9 @@ async fn verifier<T: AsyncWrite + AsyncRead + Send + Unpin + 'static>(
             // to obtain the server address, but since this is an example we use the
             // fixed `server_addr`.
             let client_socket = tokio::net::TcpStream::connect(server_addr).await.unwrap();
+            // Disable Nagle's algorithm to reduce protocol latency. See the
+            // `tlsn` crate's performance notes for details.
+            client_socket.set_nodelay(true).unwrap();
             verifier.accept().await?.run(client_socket.compat()).await?
         }
     };

--- a/crates/tlsn/src/lib.rs
+++ b/crates/tlsn/src/lib.rs
@@ -37,6 +37,34 @@
 //!    exchanges data to obtain a commitment to the TLS transcript.
 //! 5. (Optional) Perform selective disclosure: the prover provably reveals
 //!    selected data to the verifier.
+//!
+//! # Performance
+//!
+//! The MPC-TLS protocol is highly interactive: prover and verifier exchange
+//! many small messages, and each one is on the critical path. On such traffic,
+//! Nagle's algorithm — enabled by default on TCP sockets — coalesces small
+//! writes and waits for outstanding ACKs before sending, adding a round-trip's
+//! worth of delay to each exchange and significantly slowing the protocol.
+//!
+//! For this reason you should **disable Nagle's algorithm** by enabling
+//! `TCP_NODELAY` on every TCP socket you hand to this crate, namely:
+//!
+//! - the prover ↔ verifier channel passed to [`Session::new`];
+//! - the connection to the TLS server passed to
+//!   [`Prover::connect`](prover::Prover::connect) (MPC mode);
+//! - the connection to the TLS server passed to
+//!   [`Verifier::run`](verifier::Verifier::run) (proxy mode).
+//!
+//! With [`tokio`](https://docs.rs/tokio) this is done via
+//! [`TcpStream::set_nodelay`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html#method.set_nodelay):
+//!
+//! ```ignore
+//! let socket = tokio::net::TcpStream::connect(addr).await?;
+//! socket.set_nodelay(true)?;
+//! ```
+//!
+//! This setting has no effect on non-TCP transports (e.g. WebSocket relays or
+//! in-memory duplex streams).
 
 #![deny(missing_docs, unreachable_pub, unused_must_use)]
 #![deny(clippy::all)]

--- a/crates/tlsn/src/prover.rs
+++ b/crates/tlsn/src/prover.rs
@@ -155,7 +155,8 @@ impl Prover<state::CommitAccepted<Mpc>> {
     /// # Arguments
     ///
     /// * `config` - The TLS client configuration.
-    /// * `server_socket` - The connection to the server.
+    /// * `server_socket` - The connection to the server. On TCP transports,
+    ///   disable Nagle's algorithm; see [Performance](crate#performance).
     ///
     /// # Returns
     ///

--- a/crates/tlsn/src/session.rs
+++ b/crates/tlsn/src/session.rs
@@ -45,7 +45,10 @@ impl<Io> Session<Io>
 where
     Io: AsyncRead + AsyncWrite + Unpin,
 {
-    /// Creates a new session.
+    /// Creates a new session over `io`, the prover ↔ verifier channel.
+    ///
+    /// On TCP transports, disable Nagle's algorithm; see
+    /// [Performance](crate#performance).
     pub fn new(io: Io) -> Self {
         let mut mux_config = tlsn_mux::Config::default();
 

--- a/crates/tlsn/src/verifier.rs
+++ b/crates/tlsn/src/verifier.rs
@@ -303,7 +303,8 @@ impl Verifier<state::CommitAccepted<Proxy>> {
     ///
     /// # Arguments
     ///
-    /// * `server_socket` - The connection to the server.
+    /// * `server_socket` - The connection to the server. On TCP transports,
+    ///   disable Nagle's algorithm; see [Performance](crate#performance).
     #[instrument(parent = &self.span, level = "info", skip_all, err)]
     pub async fn run<T>(self, server_socket: T) -> Result<Verifier<state::Committed>>
     where


### PR DESCRIPTION
Closes #1028.

The MPC-TLS protocol is highly interactive, so Nagle's algorithm adds a round-trip of latency to each small exchange. The `tlsn` crate receives its transport sockets from the caller and therefore cannot set `TCP_NODELAY` itself (unlike the notary client/server, which were fixed in #911).

## Changes

- **Crate docs** (`crates/tlsn/src/lib.rs`): new `# Performance` section explaining why Nagle hurts the protocol and listing the three caller-supplied TCP sockets to set `TCP_NODELAY` on, with a `tokio` snippet. Notes it's a no-op for non-TCP transports (WebSocket relays, in-memory duplex).
- **Per-method pointers** to that section on the APIs that take a user socket: `Session::new`, `Prover::connect` (MPC mode), and `Verifier::run` (proxy mode).
- **Examples**: demonstrate `socket.set_nodelay(true)` in `basic`, `attestation/prove`, `examples-zk/prover`, and `proxy` (verifier→server).

## Verification

- `cargo doc --no-deps -p tlsn` with `-D rustdoc::broken_intra_doc_links` — clean
- `cargo test --doc -p tlsn` — snippet is `ignore`d as intended
- `cargo check -p tlsn-examples` and `cargo check` in `examples-zk` — both compile