### PR TITLE
feat(sdk): log transcript size vs configured max at session end

### DIFF
--- a/crates/sdk-core/src/logging.rs
+++ b/crates/sdk-core/src/logging.rs
@@ -126,3 +126,24 @@ pub fn filter(config: LoggingConfig) -> impl Fn(&Metadata) -> bool {
         meta.level() <= &Level::from(logging_level)
     }
 }
+
+/// Logs the transcript size against the configured maxima, including the
+/// percentage of each limit used.
+///
+/// Emitted at the end of a session (by both prover and verifier) to help tune
+/// `max_sent_data` / `max_recv_data` to be just large enough.
+pub(crate) fn log_transcript_size(sent: usize, max_sent: usize, recv: usize, max_recv: usize) {
+    let pct = |used: usize, max: usize| {
+        if max == 0 {
+            0.0
+        } else {
+            used as f64 / max as f64 * 100.0
+        }
+    };
+
+    tracing::info!(
+        "transcript size: sent {sent}/{max_sent} bytes ({:.1}%), recv {recv}/{max_recv} bytes ({:.1}%)",
+        pct(sent, max_sent),
+        pct(recv, max_recv),
+    );
+}

--- a/crates/sdk-core/src/prover.rs
+++ b/crates/sdk-core/src/prover.rs
@@ -241,6 +241,7 @@ impl SdkProver {
         info!("response received, prover transitioning to Committed state");
 
         self.state = State::Committed { prover, handle };
+        self.log_transcript_usage();
 
         Ok(response)
     }
@@ -301,8 +302,26 @@ impl SdkProver {
         info!("response received, prover transitioning to Committed state");
 
         self.state = State::Committed { prover, handle };
+        self.log_transcript_usage();
 
         Ok(response)
+    }
+
+    /// Logs how much transcript data was actually sent/received versus the
+    /// configured `max_sent_data` / `max_recv_data`, to help tune the limits
+    /// to be just large enough.
+    fn log_transcript_usage(&self) {
+        let State::Committed { prover, .. } = &self.state else {
+            return;
+        };
+
+        let transcript = prover.transcript();
+        crate::logging::log_transcript_size(
+            transcript.sent().len(),
+            self.config.max_sent_data,
+            transcript.received().len(),
+            self.config.max_recv_data,
+        );
     }
 
     fn build_tls_config(&self) -> Result<TlsClientConfig> {

--- a/crates/sdk-core/src/verifier.rs
+++ b/crates/sdk-core/src/verifier.rs
@@ -262,6 +262,13 @@ impl SdkVerifier {
             .map(|record| record.ciphertext.len())
             .sum::<usize>();
 
+        crate::logging::log_transcript_size(
+            sent,
+            self.config.max_sent_data,
+            received,
+            self.config.max_recv_data,
+        );
+
         let connection_info = ConnectionInfo {
             time: verifier.tls_transcript().time(),
             version: verifier.tls_transcript().version(),


### PR DESCRIPTION
## What

At the end of a session, log how much application data was actually sent/received versus the configured `max_sent_data` / `max_recv_data`, including the percentage used. This makes it easy to tune the limits to be *just large enough*.

Example output:

```
transcript size: sent 312/4096 bytes (7.6%), recv 14820/16384 bytes (90.5%)
```

A low sent % suggests `max_sent_data` can shrink; a recv % near 100% means the limit is well-fitted.

## Where

Logged on **both** sides at `info` level, in the SDK layer (`tlsn-sdk-core`), so the native servers/examples and the wasm build (extension) both inherit it automatically:

- **Prover** (`sdk-core/src/prover.rs`): a `log_transcript_usage()` helper called after each request commits (MPC and proxy modes). Reads actual plaintext lengths from `prover.transcript()` and compares against `config.max_sent_data` / `max_recv_data`.
- **Verifier** (`sdk-core/src/verifier.rs`): logged in `verify()`, reusing the `sent`/`received` byte sums already computed from the authenticated `TlsTranscript`, against the verifier's own configured maxima (which are enforced separately from the prover's).

The two sides' numbers are directly comparable: the protocol enforces that the verifier's application-data payload length equals the prover's plaintext length.

## Notes

- Compared against `max_recv_data` (the total cap), not `max_recv_data_online`.
- A shared private `usage_pct()` helper guards against divide-by-zero.