### PR TITLE
fix: prover close connection handles on error

### DIFF
--- a/crates/tlsn/src/prover/future.rs
+++ b/crates/tlsn/src/prover/future.rs
@@ -1,6 +1,6 @@
 //! Future used by the [Prover].
 
-use futures::{AsyncRead, AsyncWrite, Future, FutureExt, future::FusedFuture};
+use futures::{AsyncRead, AsyncWrite, AsyncWriteExt, Future, FutureExt, future::FusedFuture};
 use std::{pin::Pin, task::Poll};
 
 use crate::{
@@ -34,10 +34,31 @@ where
         let state = std::mem::replace(&mut self.state, FutureState::Error);
 
         match state {
-            FutureState::Connected { mut prover } => match prover.poll(cx)? {
-                Poll::Ready(_) => {
+            FutureState::Connected { mut prover } => match prover.poll(cx) {
+                Poll::Ready(Ok(_)) => {
                     self.state = FutureState::Finishing {
                         fut: Box::pin(prover.finish()),
+                    };
+                    self.poll(cx)
+                }
+                // Close the connection handles before yielding the error, so
+                // that readers of the `TlsConnection` and the server socket
+                // observe closure instead of waiting indefinitely. Closing is
+                // best-effort: close errors are ignored in favor of the
+                // original error.
+                Poll::Ready(Err(error)) => {
+                    let state::Connected {
+                        mut client_io,
+                        mut server_socket,
+                        ..
+                    } = prover.state;
+
+                    self.state = FutureState::Finishing {
+                        fut: Box::pin(async move {
+                            let _ = client_io.close().await;
+                            let _ = server_socket.close().await;
+                            Err(error)
+                        }),
                     };
                     self.poll(cx)
                 }

--- a/crates/tlsn/tests/closure.rs
+++ b/crates/tlsn/tests/closure.rs
@@ -245,7 +245,7 @@ async fn run_prover(
             .unwrap(),
         client_socket.compat(),
     )?;
-    let mut prover_task = tokio::spawn(prover.into_future());
+    let prover_task = tokio::spawn(prover.into_future());
 
     if scenario.echo_first {
         // Any unrecognized payload makes the server respond with "hello".
@@ -263,14 +263,21 @@ async fn run_prover(
         tls_connection.close().await?;
     }
 
-    // Drain the connection while driving the prover. If MPC-TLS fails, the
-    // prover future errors without closing the connection handle, so the
-    // read may never resolve: race the two.
+    // Drain the connection while the prover drives it. The read must
+    // terminate on its own: on success the prover closes the connection
+    // handle after finalizing, and on error it closes the handle while
+    // surfacing the error. Either way the read observes EOF instead of
+    // hanging, so a regression that drops the handle without closing it
+    // would trip this timeout.
     let mut buf = Vec::new();
-    let prover = tokio::select! {
-        res = &mut prover_task => res.unwrap()?,
-        _ = tls_connection.read_to_end(&mut buf) => prover_task.await.unwrap()?,
-    };
+    tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        tls_connection.read_to_end(&mut buf),
+    )
+    .await
+    .expect("connection read should terminate once the prover closes the handle")?;
+
+    let prover = prover_task.await.unwrap()?;
     prover.close().await?;
 
     Ok(())


### PR DESCRIPTION
  ### Problem
  When the MPC-TLS prover future errored, it propagated the error and dropped the   `Connected` state without closing the connection handles. Any reader parked on the `TlsConnection` — and the server socket — was never woken  and could wait indefinitely.

  ### Fix
  On `Prover::poll` returning `Err`, extract `client_io` and `server_socket` from   the `Connected` state and `close()` both before yielding the error. Closing the   prover's write half sets EOF on the peer simplex and wakes its reader, so   consumers observe closure instead of hanging. Closing is best-effort: close   errors are ignored in favor of the original error. The success path is   unchanged (handles are already closed in `Prover::poll`). 