### PR TITLE
fix(tlsn): do not write into a closed `client_io`

### DIFF
--- a/crates/tlsn/src/prover.rs
+++ b/crates/tlsn/src/prover.rs
@@ -484,13 +484,22 @@ where
 
         // tls_client -> tls_conn
         // Always poll to register wakers, then check wants_read()
-        if let Poll::Ready(mut simplex) = state.client_io.as_mut().poll_lock_write(cx)
-            && let Poll::Ready(buf) = simplex.poll_mut(cx)?
-            && state.tls_client.wants_read()
-        {
-            let read = state.tls_client.read(buf)?;
-            if read > 0 {
-                simplex.advance_mut(read);
+        if let Poll::Ready(mut simplex) = state.client_io.as_mut().poll_lock_write(cx) {
+            match simplex.poll_mut(cx) {
+                Poll::Ready(Ok(buf)) if state.tls_client.wants_read() => {
+                    let read = state.tls_client.read(buf)?;
+                    if read > 0 {
+                        simplex.advance_mut(read);
+                    }
+                }
+                // do not attempt to write into closed sockets
+                Poll::Ready(Err(err))
+                    if matches!(
+                        err.kind(),
+                        std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
+                    ) => {}
+                Poll::Ready(Err(err)) => return Err(Error::from(err)),
+                _ => {}
             }
         }
 


### PR DESCRIPTION
Fixes #1170 

