### PR TITLE
fix(MPC deadlock): give each RCOT consumer its own instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clmul"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2504,7 +2504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3373,7 +3373,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3593,7 +3593,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 [[package]]
 name = "matrix-transpose"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "mpz-circuits-core",
  "mpz-circuits-data",
@@ -3658,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "bincode",
  "itybity 0.3.2",
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "mpz-circuits-data"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "bincode",
  "mpz-circuits-core",
@@ -3683,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "mpz-cointoss"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "futures",
  "mpz-cointoss-core",
@@ -3696,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "mpz-cointoss-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "mpz-core",
  "opaque-debug",
@@ -3707,7 +3707,7 @@ dependencies = [
 [[package]]
 name = "mpz-common"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "async-task",
  "async-trait",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "mpz-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "aes 0.9.0",
  "bcs",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "mpz-fields"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-secp256r1",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "mpz-garble"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "async-trait",
  "derive_builder 0.11.2",
@@ -3802,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "mpz-garble-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "aes 0.9.0",
  "bitvec",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "mpz-hash"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "blake3",
  "itybity 0.3.2",
@@ -3846,7 +3846,7 @@ dependencies = [
 [[package]]
 name = "mpz-ideal-vm"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "async-trait",
  "futures",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "mpz-memory-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "blake3",
  "futures",
@@ -3878,7 +3878,7 @@ dependencies = [
 [[package]]
 name = "mpz-ole"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "async-trait",
  "futures",
@@ -3896,7 +3896,7 @@ dependencies = [
 [[package]]
 name = "mpz-ole-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "hybrid-array",
  "itybity 0.3.2",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "mpz-ot"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "mpz-ot-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "aes 0.9.0",
  "blake3",
@@ -3967,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "mpz-share-conversion"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "async-trait",
  "mpz-common",
@@ -3983,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "mpz-share-conversion-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "mpz-common",
  "mpz-core",
@@ -3997,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "mpz-vm-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "async-trait",
  "futures",
@@ -4010,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "mpz-zk"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "async-trait",
  "blake3",
@@ -4028,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "mpz-zk-core"
 version = "0.1.0-alpha.6"
-source = "git+https://github.com/privacy-ethereum/mpz?rev=v0.1.0-alpha.6#6ebfe619490c3155a589fc6a3be83b0976de19dc"
+source = "git+https://github.com/AdamDawidKrol/mpz?rev=c0379ef#c0379efa81cad70c21c922f65a6094da6f10c630"
 dependencies = [
  "blake3",
  "cfg-if",
@@ -4067,7 +4067,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4182,7 +4182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4996,7 +4996,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5749,7 +5749,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7138,7 +7138,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,3 +173,30 @@ webpki-roots = { version = "1.0" }
 webpki-root-certs = { version = "1.0" }
 ws_stream_wasm = { version = "0.7.5" }
 zeroize = { version = "1.8" }
+
+# Patch mpz to the fork carrying the per-instance KOS domain-separation change.
+[patch."https://github.com/privacy-ethereum/mpz"]
+clmul = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+matrix-transpose = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-circuits = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-circuits-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-circuits-data = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-cointoss = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-cointoss-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-common = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-fields = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-garble = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-garble-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-hash = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-ideal-vm = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-memory-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-ole = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-ole-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-ot = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-ot-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-share-conversion = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-share-conversion-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-vm-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-zk = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }
+mpz-zk-core = { git = "https://github.com/AdamDawidKrol/mpz", rev = "c0379ef" }

--- a/crates/tlsn/src/deps/prover.rs
+++ b/crates/tlsn/src/deps/prover.rs
@@ -54,36 +54,41 @@ impl ProverMpcDeps {
         let mut rng = rand::rng();
         let delta = Delta::new(Block::random(&mut rng));
 
-        let base_ot_send = co::Sender::default();
-        let base_ot_recv = co::Receiver::default();
-        let rcot_send = kos::Sender::new(
-            kos::SenderConfig::default(),
-            delta.into_inner(),
-            base_ot_recv,
-        );
-        let rcot_recv = kos::Receiver::new(kos::ReceiverConfig::default(), base_ot_send);
-        let rcot_recv = ferret::Receiver::new(
-            ferret::FerretConfig::builder()
-                .lpn_type(ferret::LpnType::Regular)
-                .build()
-                .expect("ferret config is valid"),
-            Block::random(&mut rng),
-            rcot_recv,
-        );
-
-        let rcot_send = SharedRCOTSender::new(rcot_send);
-        let rcot_recv = SharedRCOTReceiver::new(rcot_recv);
+        // Each RCOT consumer gets its own instance instead of sharing one. A shared
+        // RCOT only flushes once all its clones reach the flush barrier, but the
+        // preprocess branches (ke / record_layer / vm) don't all flush together, so a
+        // shared instance deadlocks. All senders use the same global delta.
+        let new_send = || {
+            SharedRCOTSender::new(kos::Sender::new(
+                kos::SenderConfig::default(),
+                delta.into_inner(),
+                co::Receiver::default(),
+            ))
+        };
+        let new_recv = |rng: &mut rand::rngs::ThreadRng| {
+            let rcot_recv =
+                kos::Receiver::new(kos::ReceiverConfig::default(), co::Sender::default());
+            let rcot_recv = ferret::Receiver::new(
+                ferret::FerretConfig::builder()
+                    .lpn_type(ferret::LpnType::Regular)
+                    .build()
+                    .expect("ferret config is valid"),
+                Block::random(rng),
+                rcot_recv,
+            );
+            SharedRCOTReceiver::new(rcot_recv)
+        };
 
         let mpc = cfg_select! {
             tlsn_insecure => { mpz_ideal_vm::IdealVm::new() }
             _ => {
-                ProverMpc::new(DerandCOTSender::new(rcot_send.clone()), rng.random(), delta)
+                ProverMpc::new(DerandCOTSender::new(new_send()), rng.random(), delta)
             }
         };
 
         let zk = cfg_select! {
             tlsn_insecure => { mpz_ideal_vm::IdealVm::new() }
-            _ => { ProverZk::new(Default::default(), rcot_recv.clone()) }
+            _ => { ProverZk::new(Default::default(), new_recv(&mut rng)) }
         };
 
         let vm = Arc::new(Mutex::new(Deap::new(tlsn_deap::Role::Leader, mpc, zk)));
@@ -91,8 +96,8 @@ impl ProverMpcDeps {
             build_mpc_tls_config(config),
             ctx,
             vm.clone(),
-            (rcot_send.clone(), rcot_send.clone(), rcot_send),
-            rcot_recv,
+            (new_send(), new_send(), new_send()),
+            new_recv(&mut rng),
         );
 
         Self {

--- a/crates/tlsn/src/deps/prover.rs
+++ b/crates/tlsn/src/deps/prover.rs
@@ -58,16 +58,21 @@ impl ProverMpcDeps {
         // RCOT only flushes once all its clones reach the flush barrier, but the
         // preprocess branches (ke / record_layer / vm) don't all flush together, so a
         // shared instance deadlocks. All senders use the same global delta.
-        let new_send = || {
+        let id = |n: u128| Block::new(n.to_le_bytes());
+        let new_send = |instance_id: Block| {
             SharedRCOTSender::new(kos::Sender::new(
                 kos::SenderConfig::default(),
                 delta.into_inner(),
+                instance_id,
                 co::Receiver::default(),
             ))
         };
-        let new_recv = |rng: &mut rand::rngs::ThreadRng| {
-            let rcot_recv =
-                kos::Receiver::new(kos::ReceiverConfig::default(), co::Sender::default());
+        let new_recv = |rng: &mut rand::rngs::ThreadRng, instance_id: Block| {
+            let rcot_recv = kos::Receiver::new(
+                kos::ReceiverConfig::default(),
+                instance_id,
+                co::Sender::default(),
+            );
             let rcot_recv = ferret::Receiver::new(
                 ferret::FerretConfig::builder()
                     .lpn_type(ferret::LpnType::Regular)
@@ -82,13 +87,13 @@ impl ProverMpcDeps {
         let mpc = cfg_select! {
             tlsn_insecure => { mpz_ideal_vm::IdealVm::new() }
             _ => {
-                ProverMpc::new(DerandCOTSender::new(new_send()), rng.random(), delta)
+                ProverMpc::new(DerandCOTSender::new(new_send(id(0))), rng.random(), delta)
             }
         };
 
         let zk = cfg_select! {
             tlsn_insecure => { mpz_ideal_vm::IdealVm::new() }
-            _ => { ProverZk::new(Default::default(), new_recv(&mut rng)) }
+            _ => { ProverZk::new(Default::default(), new_recv(&mut rng, id(1))) }
         };
 
         let vm = Arc::new(Mutex::new(Deap::new(tlsn_deap::Role::Leader, mpc, zk)));
@@ -96,8 +101,8 @@ impl ProverMpcDeps {
             build_mpc_tls_config(config),
             ctx,
             vm.clone(),
-            (new_send(), new_send(), new_send()),
-            new_recv(&mut rng),
+            (new_send(id(2)), new_send(id(3)), new_send(id(4))),
+            new_recv(&mut rng, id(5)),
         );
 
         Self {
@@ -150,7 +155,11 @@ impl ProverProxyDeps {
                 let mut rng = rand::rng();
 
                 let base_ot_send = co::Sender::default();
-                let rcot_recv = kos::Receiver::new(kos::ReceiverConfig::default(), base_ot_send);
+                let rcot_recv = kos::Receiver::new(
+                    kos::ReceiverConfig::default(),
+                    Block::ZERO,
+                    base_ot_send,
+                );
                 let rcot_recv = ferret::Receiver::new(
                     ferret::FerretConfig::builder()
                         .lpn_type(ferret::LpnType::Regular)

--- a/crates/tlsn/src/deps/verifier.rs
+++ b/crates/tlsn/src/deps/verifier.rs
@@ -54,34 +54,42 @@ impl VerifierMpcDeps {
         let mut rng = rand::rng();
 
         let delta = Delta::random(&mut rng);
-        let base_ot_send = co::Sender::default();
-        let base_ot_recv = co::Receiver::default();
-        let rcot_send = kos::Sender::new(
-            kos::SenderConfig::default(),
-            delta.into_inner(),
-            base_ot_recv,
-        );
-        let rcot_send = ferret::Sender::new(
-            ferret::FerretConfig::builder()
-                .lpn_type(ferret::LpnType::Regular)
-                .build()
-                .expect("ferret config is valid"),
-            Block::random(&mut rng),
-            rcot_send,
-        );
-        let rcot_recv = kos::Receiver::new(kos::ReceiverConfig::default(), base_ot_send);
 
-        let rcot_send = SharedRCOTSender::new(rcot_send);
-        let rcot_recv = SharedRCOTReceiver::new(rcot_recv);
+        // Each RCOT consumer gets its own instance instead of sharing one. A shared
+        // RCOT only flushes once all its clones reach the flush barrier, but the
+        // preprocess branches don't all flush together, so it deadlocks. All senders
+        // use the same global delta.
+        let new_send = |rng: &mut rand::rngs::ThreadRng| {
+            let rcot_send = kos::Sender::new(
+                kos::SenderConfig::default(),
+                delta.into_inner(),
+                co::Receiver::default(),
+            );
+            let rcot_send = ferret::Sender::new(
+                ferret::FerretConfig::builder()
+                    .lpn_type(ferret::LpnType::Regular)
+                    .build()
+                    .expect("ferret config is valid"),
+                Block::random(rng),
+                rcot_send,
+            );
+            SharedRCOTSender::new(rcot_send)
+        };
+        let new_recv = || {
+            SharedRCOTReceiver::new(kos::Receiver::new(
+                kos::ReceiverConfig::default(),
+                co::Sender::default(),
+            ))
+        };
 
         let mpc = cfg_select! {
             tlsn_insecure => { mpz_ideal_vm::IdealVm::new() }
-            _ => { VerifierMpc::new(DerandCOTReceiver::new(rcot_recv.clone())) }
+            _ => { VerifierMpc::new(DerandCOTReceiver::new(new_recv())) }
         };
 
         let zk = cfg_select! {
             tlsn_insecure => { mpz_ideal_vm::IdealVm::new() }
-            _ => { VerifierZk::new(Default::default(), delta, rcot_send.clone()) }
+            _ => { VerifierZk::new(Default::default(), delta, new_send(&mut rng)) }
         };
 
         let vm = Arc::new(Mutex::new(Deap::new(tlsn_deap::Role::Follower, mpc, zk)));
@@ -89,8 +97,8 @@ impl VerifierMpcDeps {
             build_mpc_tls_config(config),
             ctx,
             vm.clone(),
-            rcot_send,
-            (rcot_recv.clone(), rcot_recv.clone(), rcot_recv),
+            new_send(&mut rng),
+            (new_recv(), new_recv(), new_recv()),
         );
 
         Self {

--- a/crates/tlsn/src/deps/verifier.rs
+++ b/crates/tlsn/src/deps/verifier.rs
@@ -59,10 +59,12 @@ impl VerifierMpcDeps {
         // RCOT only flushes once all its clones reach the flush barrier, but the
         // preprocess branches don't all flush together, so it deadlocks. All senders
         // use the same global delta.
-        let new_send = |rng: &mut rand::rngs::ThreadRng| {
+        let id = |n: u128| Block::new(n.to_le_bytes());
+        let new_send = |rng: &mut rand::rngs::ThreadRng, instance_id: Block| {
             let rcot_send = kos::Sender::new(
                 kos::SenderConfig::default(),
                 delta.into_inner(),
+                instance_id,
                 co::Receiver::default(),
             );
             let rcot_send = ferret::Sender::new(
@@ -75,21 +77,22 @@ impl VerifierMpcDeps {
             );
             SharedRCOTSender::new(rcot_send)
         };
-        let new_recv = || {
+        let new_recv = |instance_id: Block| {
             SharedRCOTReceiver::new(kos::Receiver::new(
                 kos::ReceiverConfig::default(),
+                instance_id,
                 co::Sender::default(),
             ))
         };
 
         let mpc = cfg_select! {
             tlsn_insecure => { mpz_ideal_vm::IdealVm::new() }
-            _ => { VerifierMpc::new(DerandCOTReceiver::new(new_recv())) }
+            _ => { VerifierMpc::new(DerandCOTReceiver::new(new_recv(id(0)))) }
         };
 
         let zk = cfg_select! {
             tlsn_insecure => { mpz_ideal_vm::IdealVm::new() }
-            _ => { VerifierZk::new(Default::default(), delta, new_send(&mut rng)) }
+            _ => { VerifierZk::new(Default::default(), delta, new_send(&mut rng, id(1))) }
         };
 
         let vm = Arc::new(Mutex::new(Deap::new(tlsn_deap::Role::Follower, mpc, zk)));
@@ -97,8 +100,8 @@ impl VerifierMpcDeps {
             build_mpc_tls_config(config),
             ctx,
             vm.clone(),
-            new_send(&mut rng),
-            (new_recv(), new_recv(), new_recv()),
+            new_send(&mut rng, id(5)),
+            (new_recv(id(2)), new_recv(id(3)), new_recv(id(4))),
         );
 
         Self {
@@ -155,6 +158,7 @@ impl VerifierProxyDeps {
                 let rcot_send = kos::Sender::new(
                     kos::SenderConfig::default(),
                     delta.into_inner(),
+                    Block::ZERO,
                     base_ot_recv,
                 );
                 let rcot_send = ferret::Sender::new(


### PR DESCRIPTION
MPC `preprocess` (`crates/tlsn/src/deps/{prover,verifier}.rs`) builds one `SharedRCOT` and hands clones to the concurrent `try_join3` branches (key-exchange / record-layer / vm). A `SharedRCOT` only performs its single batched flush once all live clones reach the flush barrier — but the branches don't all flush in the same round, so a clone whose `flush()` is parked behind a sibling branch never arrives. The barrier then waits forever (`alive=N, arrived=1`) → an intermittent deadlock during preprocessing.

**Fix:**
Give each RCOT consumer its own `SharedRCOT` instance instead of clones of a shared one, so every barrier rendezvous is independent and can't wait on a clone parked in another branch. All senders keep using the same global `delta`.