### PR TITLE
fix(core,tlsn): let the verifier size the transcript it recorded

### DIFF
--- a/crates/core/src/transcript.rs
+++ b/crates/core/src/transcript.rs
@@ -247,6 +247,88 @@ impl From<CompressedPartialTranscript> for PartialTranscript {
     }
 }
 
+/// The data a prover reveals from a transcript.
+///
+/// Unlike [`PartialTranscript`], this does not carry the length of either
+/// direction. The receiver supplies the lengths it recorded when converting
+/// with [`TranscriptReveal::into_partial`], so a peer cannot influence the size
+/// of the allocation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(try_from = "validation::TranscriptRevealUnchecked")]
+pub struct TranscriptReveal {
+    /// Sent data which has been authenticated.
+    sent_authed: Vec<u8>,
+    /// Received data which has been authenticated.
+    received_authed: Vec<u8>,
+    /// Index of `sent_authed`.
+    sent_idx: RangeSet<usize>,
+    /// Index of `received_authed`.
+    recv_idx: RangeSet<usize>,
+}
+
+impl TranscriptReveal {
+    /// Returns the index of sent data which have been authenticated.
+    pub fn sent_authed(&self) -> &RangeSet<usize> {
+        &self.sent_idx
+    }
+
+    /// Returns the index of received data which have been authenticated.
+    pub fn received_authed(&self) -> &RangeSet<usize> {
+        &self.recv_idx
+    }
+
+    /// Converts into a partial transcript of the given lengths.
+    ///
+    /// The lengths are the receiver's own, so the transcript is sized by what
+    /// the receiver recorded rather than by anything the reveal declares.
+    ///
+    /// # Arguments
+    ///
+    /// * `sent_len` - The length of the sent data.
+    /// * `recv_len` - The length of the received data.
+    pub fn into_partial(
+        self,
+        sent_len: usize,
+        recv_len: usize,
+    ) -> Result<PartialTranscript, InvalidTranscriptReveal> {
+        if self.sent_idx.end().unwrap_or(0) > sent_len
+            || self.recv_idx.end().unwrap_or(0) > recv_len
+        {
+            return Err(InvalidTranscriptReveal(
+                "revealed ranges do not fit the transcript",
+            ));
+        }
+
+        Ok(CompressedPartialTranscript {
+            sent_authed: self.sent_authed,
+            received_authed: self.received_authed,
+            sent_idx: self.sent_idx,
+            recv_idx: self.recv_idx,
+            sent_total: sent_len,
+            recv_total: recv_len,
+        }
+        .into())
+    }
+}
+
+impl From<PartialTranscript> for TranscriptReveal {
+    fn from(uncompressed: PartialTranscript) -> Self {
+        let compressed = CompressedPartialTranscript::from(uncompressed);
+        Self {
+            sent_authed: compressed.sent_authed,
+            received_authed: compressed.received_authed,
+            sent_idx: compressed.sent_idx,
+            recv_idx: compressed.recv_idx,
+        }
+    }
+}
+
+/// Invalid transcript reveal error.
+#[derive(Debug, thiserror::Error)]
+#[error("invalid transcript reveal: {0}")]
+pub struct InvalidTranscriptReveal(&'static str);
+
 impl PartialTranscript {
     /// Creates a new partial transcript initalized to all 0s.
     ///
@@ -578,6 +660,38 @@ mod validation {
         }
     }
 
+    #[derive(Debug, Deserialize)]
+    #[cfg_attr(test, derive(Serialize))]
+    pub(super) struct TranscriptRevealUnchecked {
+        sent_authed: Vec<u8>,
+        received_authed: Vec<u8>,
+        sent_idx: RangeSet<usize>,
+        recv_idx: RangeSet<usize>,
+    }
+
+    impl TryFrom<TranscriptRevealUnchecked> for TranscriptReveal {
+        type Error = InvalidTranscriptReveal;
+
+        fn try_from(unchecked: TranscriptRevealUnchecked) -> Result<Self, Self::Error> {
+            // Whether the ranges fit the session is checked in `into_partial`,
+            // by the party that recorded it.
+            if unchecked.sent_authed.len() != unchecked.sent_idx.len()
+                || unchecked.received_authed.len() != unchecked.recv_idx.len()
+            {
+                return Err(InvalidTranscriptReveal(
+                    "lengths of index and data don't match",
+                ));
+            }
+
+            Ok(Self {
+                sent_authed: unchecked.sent_authed,
+                received_authed: unchecked.received_authed,
+                sent_idx: unchecked.sent_idx,
+                recv_idx: unchecked.recv_idx,
+            })
+        }
+    }
+
     #[cfg(test)]
     mod tests {
         use rstest::{fixture, rstest};
@@ -636,6 +750,37 @@ mod validation {
                 bincode::deserialize(&bytes);
             assert!(transcript.is_err());
         }
+
+        #[fixture]
+        fn transcript_reveal() -> TranscriptRevealUnchecked {
+            TranscriptRevealUnchecked {
+                received_authed: vec![1, 2, 3, 11, 12, 13],
+                sent_authed: vec![4, 5, 6, 14, 15, 16],
+                recv_idx: RangeSet::from([1..4, 11..14]),
+                sent_idx: RangeSet::from([4..7, 14..17]),
+            }
+        }
+
+        #[rstest]
+        fn test_transcript_reveal_valid(transcript_reveal: TranscriptRevealUnchecked) {
+            let bytes = bincode::serialize(&transcript_reveal).unwrap();
+            let reveal: Result<TranscriptReveal, Box<bincode::ErrorKind>> =
+                bincode::deserialize(&bytes);
+            assert!(reveal.is_ok());
+        }
+
+        #[rstest]
+        // Expect to fail since the index and data lengths do not match.
+        fn test_transcript_reveal_invalid_lengths(
+            mut transcript_reveal: TranscriptRevealUnchecked,
+        ) {
+            transcript_reveal.sent_authed.extend([1]);
+
+            let bytes = bincode::serialize(&transcript_reveal).unwrap();
+            let reveal: Result<TranscriptReveal, Box<bincode::ErrorKind>> =
+                bincode::deserialize(&bytes);
+            assert!(reveal.is_err());
+        }
     }
 }
 
@@ -682,6 +827,39 @@ mod tests {
         let bytes = bincode::serialize(&partial_transcript).unwrap();
         let deserialized_transcript: PartialTranscript = bincode::deserialize(&bytes).unwrap();
         assert_eq!(partial_transcript, deserialized_transcript);
+    }
+
+    #[rstest]
+    // A reveal rebuilds the transcript it came from, given the recorded lengths.
+    fn test_transcript_reveal_round_trip(partial_transcript: PartialTranscript) {
+        let sent_len = partial_transcript.len_sent();
+        let recv_len = partial_transcript.len_received();
+        let reveal = TranscriptReveal::from(partial_transcript.clone());
+        let rebuilt = reveal.into_partial(sent_len, recv_len).unwrap();
+        assert_eq!(rebuilt, partial_transcript);
+    }
+
+    #[rstest]
+    // The reveal carries no length, so the same disclosure serializes
+    // identically regardless of how long the transcript was.
+    fn test_transcript_reveal_serialization_length_independent() {
+        let reveal_of = |len: usize| {
+            let mut sent = vec![0xffu8; len];
+            sent[1..4].copy_from_slice(&[1, 2, 3]);
+            let transcript = Transcript::new(sent, vec![0xeeu8; len]);
+            let partial = transcript.to_partial(RangeSet::from(1..4), RangeSet::default());
+            bincode::serialize(&TranscriptReveal::from(partial)).unwrap()
+        };
+        assert_eq!(reveal_of(16), reveal_of(4096));
+    }
+
+    #[rstest]
+    // Expect an error since the reveal does not fit the recorded length.
+    fn test_transcript_reveal_into_partial_out_of_bounds(partial_transcript: PartialTranscript) {
+        let recv_len = partial_transcript.len_received();
+        let reveal = TranscriptReveal::from(partial_transcript);
+        let short = reveal.sent_authed().end().unwrap() - 1;
+        assert!(reveal.into_partial(short, recv_len).is_err());
     }
 
     #[rstest]

--- a/crates/tlsn/src/msg.rs
+++ b/crates/tlsn/src/msg.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tlsn_core::{
     config::{prove::ProveRequest, tls_commit::TlsCommitConfig},
     connection::{HandshakeData, ServerName},
-    transcript::PartialTranscript,
+    transcript::TranscriptReveal,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -19,7 +19,7 @@ pub(crate) struct TlsCommitRequestMsg {
 pub(crate) struct ProveRequestMsg {
     pub(crate) request: ProveRequest,
     pub(crate) handshake: Option<(ServerName, HandshakeData)>,
-    pub(crate) transcript: Option<PartialTranscript>,
+    pub(crate) transcript: Option<TranscriptReveal>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/tlsn/src/prover.rs
+++ b/crates/tlsn/src/prover.rs
@@ -35,7 +35,7 @@ use tlsn_core::{
         prove::ProveConfig, prover::ProverConfig, tls::TlsClientConfig, tls_commit::TlsCommitConfig,
     },
     connection::{HandshakeData, ServerName},
-    transcript::{TlsTranscript, Transcript},
+    transcript::{TlsTranscript, Transcript, TranscriptReveal},
 };
 use tlsn_mux::{Handle, Stream};
 use tracing::{Span, debug, info_span, instrument};
@@ -555,14 +555,14 @@ impl Prover<state::Committed> {
             )
         });
 
-        let partial_transcript = config
-            .reveal()
-            .map(|(sent, recv)| transcript.to_partial(sent.clone(), recv.clone()));
+        let reveal = config.reveal().map(|(sent, recv)| {
+            TranscriptReveal::from(transcript.to_partial(sent.clone(), recv.clone()))
+        });
 
         let msg = ProveRequestMsg {
             request: config.to_request(),
             handshake,
-            transcript: partial_transcript,
+            transcript: reveal,
         };
 
         ctx.io_mut().send(msg).await.map_err(|e| {

--- a/crates/tlsn/src/verifier/state.rs
+++ b/crates/tlsn/src/verifier/state.rs
@@ -6,7 +6,7 @@ use mpc_tls::SessionKeys;
 use tlsn_core::{
     config::prove::ProveRequest,
     connection::{HandshakeData, ServerName},
-    transcript::{PartialTranscript, TlsTranscript},
+    transcript::{TlsTranscript, TranscriptReveal},
 };
 
 use tlsn_core::config::tls_commit::TlsCommitConfig;
@@ -62,7 +62,7 @@ pub struct Verify {
     pub(crate) tls_transcript: TlsTranscript,
     pub(crate) request: ProveRequest,
     pub(crate) handshake: Option<(ServerName, HandshakeData)>,
-    pub(crate) transcript: Option<PartialTranscript>,
+    pub(crate) transcript: Option<TranscriptReveal>,
 }
 
 opaque_debug::implement!(Verify);

--- a/crates/tlsn/src/verifier/verify.rs
+++ b/crates/tlsn/src/verifier/verify.rs
@@ -9,6 +9,7 @@ use tlsn_core::{
     connection::{HandshakeData, ServerName},
     transcript::{
         ContentType, Direction, PartialTranscript, Record, TlsTranscript, TranscriptCommitment,
+        TranscriptReveal,
     },
     webpki::ServerCertVerifier,
 };
@@ -27,37 +28,36 @@ pub(crate) async fn verify<T: Vm<Binary> + Send + Sync>(
     tls_transcript: &TlsTranscript,
     request: ProveRequest,
     handshake: Option<(ServerName, HandshakeData)>,
-    transcript: Option<PartialTranscript>,
+    transcript: Option<TranscriptReveal>,
 ) -> Result<VerifierOutput> {
     let ciphertext_sent = collect_ciphertext(tls_transcript.sent());
     let ciphertext_recv = collect_ciphertext(tls_transcript.recv());
 
     let transcript = if let Some((auth_sent, auth_recv)) = request.reveal() {
-        let Some(transcript) = transcript else {
+        let Some(reveal) = transcript else {
             return Err(Error::internal().with_msg(
                 "verification failed: prover requested to reveal data but did not send transcript",
             ));
         };
 
-        if transcript.len_sent() != ciphertext_sent.len()
-            || transcript.len_received() != ciphertext_recv.len()
-        {
-            return Err(
-                Error::internal().with_msg("verification failed: transcript length mismatch")
-            );
-        }
-
-        if transcript.sent_authed() != auth_sent {
+        if reveal.sent_authed() != auth_sent {
             return Err(Error::internal().with_msg("verification failed: sent auth data mismatch"));
         }
 
-        if transcript.received_authed() != auth_recv {
+        if reveal.received_authed() != auth_recv {
             return Err(
                 Error::internal().with_msg("verification failed: received auth data mismatch")
             );
         }
 
-        transcript
+        // Sized by the lengths this party recorded.
+        reveal
+            .into_partial(ciphertext_sent.len(), ciphertext_recv.len())
+            .map_err(|e| {
+                Error::internal()
+                    .with_msg("verification failed: transcript reveal does not fit the session")
+                    .with_source(e)
+            })?
     } else {
         PartialTranscript::new(ciphertext_sent.len(), ciphertext_recv.len())
     };


### PR DESCRIPTION
## Summary

A verifier allocates a buffer sized by a length the prover declares, before that
length is checked against the session. A prover can declare an enormous length
in a tiny message and abort the verifier process.

This removes the declared length from the wire: the verifier sizes the
transcript from what it recorded, which it already had to know.

## Detail

`ProveRequestMsg.transcript` is a `PartialTranscript`, whose compressed form
carries `sent_total` / `recv_total`. Converting it to the in-memory form runs:

```rust
let mut sent = vec![0; compressed.sent_total];
let mut received = vec![0; compressed.recv_total];
```

The `TryFrom` validation just above checks that the revealed index fits inside
the declared total, but an empty index fits inside any total, so a message with
no authenticated data may name any length. `verify::verify` does compare the
length against the recorded ciphertext:

```rust
if transcript.len_sent() != ciphertext_sent.len() { ... }
```

but it runs in `accept()`, one message after the allocation. And the allocation
does not fail gracefully: `vec![0; n]` for an `n` that cannot be satisfied
reaches `handle_alloc_error`, which aborts. A verifier serving other sessions
loses all of them; `catch_unwind` does not apply.

## Reproduction

Deserializing the `transcript` field a prover controls, with `sent_total = 2^62`
and everything else empty:

```
transcript field: 48 bytes on the wire, declares 2^62 sent
memory allocation of 4611686018427387904 bytes failed
process aborted (SIGABRT)
```

## Fix

The declared length is redundant — the verifier recorded the session and checks
the prover's number against its own. So the prover stops sending it.
`TranscriptReveal` carries only what the prover contributes, the authenticated
bytes and their ranges, and the verifier builds the transcript with
`into_partial`, passing the lengths it measured:

```rust
reveal.into_partial(ciphertext_sent.len(), ciphertext_recv.len())?
```

There is no field left in which to declare a length, so the
`transcript length mismatch` branch is removed as unreachable. The remaining
bounds check — that the revealed ranges fit the recorded length — runs in
`into_partial` and returns an error. `TranscriptReveal` is
`CompressedPartialTranscript` minus the two totals, so its conversions delegate
to the existing sibling impls.

After the fix, the same attack has no field to use; an oversized reveal *range*
is refused before any allocation; and an honest reveal round-trips.

## Compatibility

The prove message changes, so prover and verifier must upgrade together. The
existing version handshake already enforces this: a mismatched pair is rejected
on the first message, on exact crate-version equality, before the prove message
is sent. `ProveRequestMsg` is `pub(crate)` and `PartialTranscript`'s public
serialization is untouched, so there is no public API change.

## Verification

```
cargo +nightly fmt --check --all
cargo clippy --keep-going --all-features --all-targets --locked
cargo test -p tlsn-core
cargo test -p tlsn --test test -- --ignored   # test_mpc, test_proxy
```

`test_mpc` and `test_proxy` run a full MPC-TLS and ProxyMode session, so the
changed message is exercised end to end. Five unit tests cover the round trip,
the length-independence of the serialized reveal, the out-of-bounds refusal, and
the wire-level self-consistency check.

## Related, not included

The prover's commitment ranges are unbounded in the same way and can drive an
allocation or an out-of-bounds index on the verifier. That is a separate change;
this PR is scoped to the transcript length so it stays reviewable.
